### PR TITLE
fix cors-config to only allow lawn.video origins

### DIFF
--- a/cors-config.json
+++ b/cors-config.json
@@ -1,10 +1,13 @@
 {
   "CORSRules": [
     {
-      "AllowedOrigins": ["*"],
-      "AllowedMethods": ["GET", "PUT", "POST", "DELETE", "HEAD"],
+      "AllowedOrigins": [
+        "https://lawn.video",
+        "https://www.lawn.video"
+      ],
+      "AllowedMethods": ["GET", "PUT", "HEAD"],
       "AllowedHeaders": ["*"],
-      "ExposeHeaders": ["ETag", "x-amz-request-id", "x-amz-id-2"],
+      "ExposeHeaders": ["ETag"],
       "MaxAgeSeconds": 3600
     }
   ]


### PR DESCRIPTION
hey — `cors-config.json` currently allows all origins (`*`) which kinda defeats the purpose of cors. locked it down to `lawn.video`

also dropped DELETE and POST from allowed methods since presigned uploads use PUT, and trimmed exposed headers to just ETag (the `x-amz-request-id` / `x-amz-id-2` are aws internals the browser doesnt need)

if theres staging/preview domains those should be added too

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restrict S3 CORS policy in `cors-config.json` to https://lawn.video and https://www.lawn.video to limit cross-origin access
> Update CORS to allow only `GET`, `PUT`, and `HEAD`, restrict origins to the two lawn.video hosts, and expose only `ETag` in [cors-config.json](https://github.com/pingdotgg/lawn/pull/3/files#diff-6def0ee1b7d5f8977bd9e41983d202eec1c3e8fe93f49614a26e9c75a1a83461).
>
> #### 📍Where to Start
> Start with the CORS rules in [cors-config.json](https://github.com/pingdotgg/lawn/pull/3/files#diff-6def0ee1b7d5f8977bd9e41983d202eec1c3e8fe93f49614a26e9c75a1a83461).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3aa504c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted service access to specific domains for improved security and stability.
  * Updated cross-origin resource sharing configuration to limit allowed communication methods and response headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->