### PR TITLE
[codex] Load bold Geist Mono weights

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -59,6 +59,22 @@
   font-display: block;
 }
 
+@font-face {
+  font-family: 'Geist Mono';
+  src: url('https://cdn.jsdelivr.net/npm/geist@1.2.0/dist/fonts/geist-mono/GeistMono-Bold.woff2') format('woff2');
+  font-weight: 700;
+  font-style: normal;
+  font-display: block;
+}
+
+@font-face {
+  font-family: 'Geist Mono';
+  src: url('https://cdn.jsdelivr.net/npm/geist@1.2.0/dist/fonts/geist-mono/GeistMono-Black.woff2') format('woff2');
+  font-weight: 900;
+  font-style: normal;
+  font-display: block;
+}
+
 :root {
   /* Core palette - warm cream and dark */
   --background: #f0f0e8;


### PR DESCRIPTION
## Why

Geist Mono is used at 700 and 900 throughout the UI, but only the 400 and 500 font files were loaded. Browsers therefore synthesized the heavier styles.

## Change

- Load the real Geist Mono Bold (700) and Black (900) WOFF2 assets from the existing pinned jsDelivr package.
- Preserve the established `@font-face` and `font-display` behavior.

## Checks

- `bun run typecheck`
- `bun run lint`
- `git diff --check`
- Verified both CDN URLs return HTTP 200 with `font/woff2` content and valid WOFF2 files.

Closes #18

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Load bold Geist Mono font weights (700 and 900) in Codex
> Adds `@font-face` declarations for Geist Mono at weights 700 and 900 in [app.css](https://github.com/pingdotgg/lawn/pull/37/files#diff-0c4ab16f2f7c1e3f4b5d0a6d4c1d939044081653e1e1e56c560170b0af384730), pointing to woff2 files on the CDN. Previously, these weights would fall back to synthesized bold rendering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7923a3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added Geist Mono font family with Bold and Black weight variants for improved typography options across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->