### PR TITLE
[codex] Smooth homepage navbar border

### DIFF
--- a/app/routes/-home.tsx
+++ b/app/routes/-home.tsx
@@ -40,7 +40,7 @@ export default function Homepage() {
       style={{ ...lightModeVars, backgroundColor: 'var(--background)', color: 'var(--foreground)' }}
     >
       {/* Minimal nav */}
-      <nav className={`fixed w-full top-0 z-50 px-6 py-4 flex justify-between items-center transition-all duration-200 ${scrolled ? 'bg-[#f0f0e8] text-[#1a1a1a] border-b-2 border-[#1a1a1a]' : 'bg-transparent text-[#f0f0e8] drop-shadow-md'}`}>
+      <nav className={`fixed w-full top-0 z-50 px-6 py-4 flex justify-between items-center border-b-2 transition-all duration-200 ${scrolled ? 'bg-[#f0f0e8] text-[#1a1a1a] border-[#1a1a1a]' : 'bg-transparent text-[#f0f0e8] border-transparent drop-shadow-md'}`}>
         <div className="flex items-center gap-4">
           <span className={`text-xl font-black tracking-tighter transition-opacity duration-200 ${scrolled ? 'opacity-100' : 'opacity-0'}`}>lawn.</span>
         </div>

--- a/app/routes/-home.tsx
+++ b/app/routes/-home.tsx
@@ -40,7 +40,7 @@ export default function Homepage() {
       style={{ ...lightModeVars, backgroundColor: 'var(--background)', color: 'var(--foreground)' }}
     >
       {/* Minimal nav */}
-      <nav className={`fixed w-full top-0 z-50 px-6 py-4 flex justify-between items-center border-b-2 transition-all duration-200 ${scrolled ? 'bg-[#f0f0e8] text-[#1a1a1a] border-[#1a1a1a]' : 'bg-transparent text-[#f0f0e8] border-transparent drop-shadow-md'}`}>
+      <nav className={`fixed w-full top-0 z-50 px-6 py-4 flex justify-between items-center border-b-2 transition-all duration-200 ${scrolled ? 'bg-[#f0f0e8] text-[#1a1a1a] border-[#1a1a1a]' : 'bg-transparent text-[#f0f0e8] border-[#1a1a1a]/0 drop-shadow-md'}`}>
         <div className="flex items-center gap-4">
           <span className={`text-xl font-black tracking-tighter transition-opacity duration-200 ${scrolled ? 'opacity-100' : 'opacity-0'}`}>lawn.</span>
         </div>


### PR DESCRIPTION
## Root cause

The homepage navbar only added `border-b-2` after crossing the scroll threshold. The border color could transition, but the border width appeared immediately, causing a visible layout pop.

## Change

Keep the 2px bottom border present in both navbar states and transition its color from transparent to the visible dark border when scrolled.

## Checks

- `bun run typecheck`
- `bun run lint`
- `git diff --check`

Closes #4

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Smooth homepage navbar border transition on scroll
> The nav border in [app/routes/-home.tsx](https://github.com/pingdotgg/lawn/pull/38/files#diff-d9391e0e29463bcb952063c25b9cbc3cf873b24e12b370a58eb66c3fa988e7bc) is now always rendered at 2px width. When not scrolled, the border color is transparent (`border-[#1a1a1a]/0`); when scrolled, it transitions to `#1a1a1a`. This avoids a layout shift that occurred when the border was added or removed on scroll.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b4860b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the top navigation bar styling to provide clearer visual feedback during scrolling. The navigation now displays distinct border appearance based on scroll position, improving visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->