### PR TITLE
[codex] Auto-link URLs in comments

### DIFF
--- a/app/routes/-share.tsx
+++ b/app/routes/-share.tsx
@@ -12,6 +12,7 @@ import { triggerDownload } from "@/lib/download";
 import { formatDuration, formatTimestamp, formatRelativeTime } from "@/lib/utils";
 import { useVideoPresence } from "@/lib/useVideoPresence";
 import { VideoWatchers } from "@/components/presence/VideoWatchers";
+import { CommentText } from "@/components/comments/CommentText";
 import { Lock, Video, AlertCircle, MessageSquare, Clock, Download } from "lucide-react";
 import { useShareData } from "./-share.data";
 
@@ -415,7 +416,9 @@ export default function SharePage() {
                       {formatTimestamp(comment.timestampSeconds)}
                     </button>
                   </div>
-                  <p className="text-sm text-[#1a1a1a] mt-1 whitespace-pre-wrap">{comment.text}</p>
+                  <p className="text-sm text-[#1a1a1a] mt-1 whitespace-pre-wrap break-words">
+                    <CommentText text={comment.text} />
+                  </p>
                   <p className="text-[11px] text-[#888] mt-1">{formatRelativeTime(comment._creationTime)}</p>
 
                   {comment.replies.length > 0 ? (
@@ -432,7 +435,9 @@ export default function SharePage() {
                               {formatTimestamp(reply.timestampSeconds)}
                             </button>
                           </div>
-                          <p className="text-[#1a1a1a] whitespace-pre-wrap">{reply.text}</p>
+                          <p className="text-[#1a1a1a] whitespace-pre-wrap break-words">
+                            <CommentText text={reply.text} />
+                          </p>
                         </div>
                       ))}
                     </div>

--- a/app/routes/-watch.tsx
+++ b/app/routes/-watch.tsx
@@ -7,6 +7,7 @@ import { VideoPlayer, type VideoPlayerHandle } from "@/components/video-player/V
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { CommentText } from "@/components/comments/CommentText";
 import { triggerDownload } from "@/lib/download";
 import { formatDuration, formatTimestamp, formatRelativeTime } from "@/lib/utils";
 import { AlertCircle, MessageSquare, Clock, Download, X } from "lucide-react";
@@ -281,7 +282,9 @@ export default function WatchPage() {
                         {formatTimestamp(comment.timestampSeconds)}
                       </button>
                     </div>
-                    <p className="text-sm text-[#1a1a1a] mt-1 whitespace-pre-wrap">{comment.text}</p>
+                    <p className="text-sm text-[#1a1a1a] mt-1 whitespace-pre-wrap break-words">
+                      <CommentText text={comment.text} />
+                    </p>
                     <p className="text-[11px] text-[#888] mt-1">{formatRelativeTime(comment._creationTime)}</p>
 
                     {comment.replies.length > 0 ? (
@@ -298,7 +301,9 @@ export default function WatchPage() {
                                 {formatTimestamp(reply.timestampSeconds)}
                               </button>
                             </div>
-                            <p className="text-[#1a1a1a] whitespace-pre-wrap">{reply.text}</p>
+                            <p className="text-[#1a1a1a] whitespace-pre-wrap break-words">
+                              <CommentText text={reply.text} />
+                            </p>
                           </div>
                         ))}
                       </div>
@@ -387,7 +392,9 @@ export default function WatchPage() {
                         {formatTimestamp(comment.timestampSeconds)}
                       </button>
                     </div>
-                    <p className="text-sm text-[#1a1a1a] mt-1 whitespace-pre-wrap">{comment.text}</p>
+                    <p className="text-sm text-[#1a1a1a] mt-1 whitespace-pre-wrap break-words">
+                      <CommentText text={comment.text} />
+                    </p>
                     <p className="text-[11px] text-[#888] mt-1">{formatRelativeTime(comment._creationTime)}</p>
 
                     {comment.replies.length > 0 ? (
@@ -407,7 +414,9 @@ export default function WatchPage() {
                                 {formatTimestamp(reply.timestampSeconds)}
                               </button>
                             </div>
-                            <p className="text-[#1a1a1a] whitespace-pre-wrap">{reply.text}</p>
+                            <p className="text-[#1a1a1a] whitespace-pre-wrap break-words">
+                              <CommentText text={reply.text} />
+                            </p>
                           </div>
                         ))}
                       </div>

--- a/src/components/comments/CommentItem.tsx
+++ b/src/components/comments/CommentItem.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useState } from "react";
 import { CommentInput } from "./CommentInput";
+import { CommentText } from "./CommentText";
 
 interface Comment {
   _id: Id<"comments">;
@@ -131,7 +132,7 @@ export function CommentItem({
             </DropdownMenu>
           </div>
           <p className="text-sm text-[#1a1a1a] mt-1 whitespace-pre-wrap break-words">
-            {comment.text}
+            <CommentText text={comment.text} />
           </p>
           <p className="text-[11px] text-[#888] mt-1">
             {formatRelativeTime(comment._creationTime)}

--- a/src/components/comments/CommentText.tsx
+++ b/src/components/comments/CommentText.tsx
@@ -12,7 +12,7 @@ export function CommentText({ text }: CommentTextProps) {
         href={part.href}
         target="_blank"
         rel="noopener noreferrer"
-        className="break-all text-[#2d5a2d] underline underline-offset-2 hover:text-[#1a1a1a]"
+        className="break-all text-[#2d5a2d] underline underline-offset-2 hover:text-[#3a6a3a]"
       >
         {part.value}
       </a>

--- a/src/components/comments/CommentText.tsx
+++ b/src/components/comments/CommentText.tsx
@@ -1,0 +1,23 @@
+import { parseCommentLinks } from "@/lib/commentLinks";
+
+interface CommentTextProps {
+  text: string;
+}
+
+export function CommentText({ text }: CommentTextProps) {
+  return parseCommentLinks(text).map((part, index) =>
+    part.type === "link" ? (
+      <a
+        key={index}
+        href={part.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="break-all text-[#2d5a2d] underline underline-offset-2 hover:text-[#1a1a1a]"
+      >
+        {part.value}
+      </a>
+    ) : (
+      part.value
+    ),
+  );
+}

--- a/src/lib/commentLinks.test.ts
+++ b/src/lib/commentLinks.test.ts
@@ -74,3 +74,32 @@ test("does not link unsupported or malformed URLs", () => {
 
   assert.deepEqual(parts, [{ type: "text", value: text }]);
 });
+
+test("never linkifies javascript, data, or vbscript URLs", () => {
+  for (const text of [
+    "javascript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "vbscript:msgbox(1)",
+  ]) {
+    const parts = parseCommentLinks(text);
+    assert.equal(
+      parts.some((part) => part.type === "link"),
+      false,
+    );
+  }
+});
+
+test("trims unbalanced trailing delimiters in linear time", () => {
+  const text = `http://example.com${")".repeat(50000)}`;
+  const start = Date.now();
+  const parts = parseCommentLinks(text);
+  const elapsed = Date.now() - start;
+
+  assert.deepEqual(parts, [
+    { type: "link", value: "http://example.com", href: "http://example.com" },
+    { type: "text", value: ")".repeat(50000) },
+  ]);
+  // Quadratic trimming would take seconds for this input; linear stays tiny.
+  assert.ok(elapsed < 1000, `parsing took ${elapsed}ms`);
+  assert.equal(reconstructComment(parts), text);
+});

--- a/src/lib/commentLinks.test.ts
+++ b/src/lib/commentLinks.test.ts
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseCommentLinks } from "@/lib/commentLinks";
+
+function reconstructComment(parts: ReturnType<typeof parseCommentLinks>) {
+  return parts.map((part) => part.value).join("");
+}
+
+test("links http and https URLs while preserving surrounding whitespace", () => {
+  const text =
+    "First: http://example.com/path\n\nSecond:\thttps://example.org?q=one#two";
+  const parts = parseCommentLinks(text);
+
+  assert.deepEqual(
+    parts.filter((part) => part.type === "link"),
+    [
+      {
+        type: "link",
+        value: "http://example.com/path",
+        href: "http://example.com/path",
+      },
+      {
+        type: "link",
+        value: "https://example.org?q=one#two",
+        href: "https://example.org?q=one#two",
+      },
+    ],
+  );
+  assert.equal(reconstructComment(parts), text);
+});
+
+test("leaves sentence punctuation and unmatched delimiters outside links", () => {
+  const text =
+    'See (https://example.com/docs), then "https://example.org/test".';
+  const parts = parseCommentLinks(text);
+
+  assert.deepEqual(
+    parts.filter((part) => part.type === "link"),
+    [
+      {
+        type: "link",
+        value: "https://example.com/docs",
+        href: "https://example.com/docs",
+      },
+      {
+        type: "link",
+        value: "https://example.org/test",
+        href: "https://example.org/test",
+      },
+    ],
+  );
+  assert.equal(reconstructComment(parts), text);
+});
+
+test("keeps balanced delimiters that are part of a URL", () => {
+  const text = "Reference https://example.com/functions/call(value).";
+  const parts = parseCommentLinks(text);
+
+  assert.deepEqual(parts, [
+    { type: "text", value: "Reference " },
+    {
+      type: "link",
+      value: "https://example.com/functions/call(value)",
+      href: "https://example.com/functions/call(value)",
+    },
+    { type: "text", value: "." },
+  ]);
+  assert.equal(reconstructComment(parts), text);
+});
+
+test("does not link unsupported or malformed URLs", () => {
+  const text = "ftp://example.com http:// and https://?missing-host";
+  const parts = parseCommentLinks(text);
+
+  assert.deepEqual(parts, [{ type: "text", value: text }]);
+});

--- a/src/lib/commentLinks.ts
+++ b/src/lib/commentLinks.ts
@@ -1,0 +1,105 @@
+export type CommentTextPart =
+  | { type: "text"; value: string }
+  | { type: "link"; value: string; href: string };
+
+const URL_PATTERN = /https?:\/\/[^\s<]+/giu;
+const TRAILING_PUNCTUATION = new Set([".", ",", "!", "?", ";", ":", "'", '"', ">"]);
+const CLOSING_DELIMITERS = {
+  ")": "(",
+  "]": "[",
+  "}": "{",
+} as const;
+
+function countCharacter(value: string, character: string) {
+  let count = 0;
+
+  for (const currentCharacter of value) {
+    if (currentCharacter === character) {
+      count += 1;
+    }
+  }
+
+  return count;
+}
+
+function splitTrailingPunctuation(candidate: string) {
+  let link = candidate;
+
+  while (link.length > 0) {
+    const lastCharacter = link.at(-1);
+    if (!lastCharacter) break;
+
+    if (TRAILING_PUNCTUATION.has(lastCharacter)) {
+      link = link.slice(0, -1);
+      continue;
+    }
+
+    if (lastCharacter in CLOSING_DELIMITERS) {
+      const openingDelimiter =
+        CLOSING_DELIMITERS[lastCharacter as keyof typeof CLOSING_DELIMITERS];
+      if (
+        countCharacter(link, lastCharacter) >
+        countCharacter(link, openingDelimiter)
+      ) {
+        link = link.slice(0, -1);
+        continue;
+      }
+    }
+
+    break;
+  }
+
+  return {
+    link,
+    trailingText: candidate.slice(link.length),
+  };
+}
+
+function isValidHttpUrl(value: string) {
+  try {
+    const url = new URL(value);
+    return (
+      (url.protocol === "http:" || url.protocol === "https:") &&
+      Boolean(url.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function appendText(parts: CommentTextPart[], value: string) {
+  if (!value) return;
+
+  const previousPart = parts.at(-1);
+  if (previousPart?.type === "text") {
+    previousPart.value += value;
+    return;
+  }
+
+  parts.push({ type: "text", value });
+}
+
+export function parseCommentLinks(text: string) {
+  const parts: CommentTextPart[] = [];
+  let cursor = 0;
+
+  for (const match of text.matchAll(URL_PATTERN)) {
+    const candidate = match[0];
+    const matchIndex = match.index;
+
+    appendText(parts, text.slice(cursor, matchIndex));
+
+    const { link, trailingText } = splitTrailingPunctuation(candidate);
+    if (link && isValidHttpUrl(link)) {
+      parts.push({ type: "link", value: link, href: link });
+      appendText(parts, trailingText);
+    } else {
+      appendText(parts, candidate);
+    }
+
+    cursor = matchIndex + candidate.length;
+  }
+
+  appendText(parts, text.slice(cursor));
+  return parts;
+}

--- a/src/lib/commentLinks.ts
+++ b/src/lib/commentLinks.ts
@@ -10,38 +10,45 @@ const CLOSING_DELIMITERS = {
   "}": "{",
 } as const;
 
-function countCharacter(value: string, character: string) {
-  let count = 0;
+function splitTrailingPunctuation(candidate: string) {
+  // Count how many of each opening/closing delimiter the whole candidate
+  // contains up front, so trimming runs in O(n) instead of re-scanning the
+  // remaining string on every iteration (which is O(n^2) and lets a comment
+  // with many unbalanced delimiters hang the renderer).
+  const closingCounts = new Map<string, number>();
+  const openingCounts = new Map<string, number>();
 
-  for (const currentCharacter of value) {
-    if (currentCharacter === character) {
-      count += 1;
+  for (const character of candidate) {
+    if (character in CLOSING_DELIMITERS) {
+      closingCounts.set(character, (closingCounts.get(character) ?? 0) + 1);
+    } else {
+      for (const closing of Object.keys(CLOSING_DELIMITERS)) {
+        if (
+          character ===
+          CLOSING_DELIMITERS[closing as keyof typeof CLOSING_DELIMITERS]
+        ) {
+          openingCounts.set(closing, (openingCounts.get(closing) ?? 0) + 1);
+        }
+      }
     }
   }
 
-  return count;
-}
+  let end = candidate.length;
 
-function splitTrailingPunctuation(candidate: string) {
-  let link = candidate;
-
-  while (link.length > 0) {
-    const lastCharacter = link.at(-1);
-    if (!lastCharacter) break;
+  while (end > 0) {
+    const lastCharacter = candidate[end - 1];
 
     if (TRAILING_PUNCTUATION.has(lastCharacter)) {
-      link = link.slice(0, -1);
+      end -= 1;
       continue;
     }
 
     if (lastCharacter in CLOSING_DELIMITERS) {
-      const openingDelimiter =
-        CLOSING_DELIMITERS[lastCharacter as keyof typeof CLOSING_DELIMITERS];
-      if (
-        countCharacter(link, lastCharacter) >
-        countCharacter(link, openingDelimiter)
-      ) {
-        link = link.slice(0, -1);
+      const closing = closingCounts.get(lastCharacter) ?? 0;
+      const opening = openingCounts.get(lastCharacter) ?? 0;
+      if (closing > opening) {
+        closingCounts.set(lastCharacter, closing - 1);
+        end -= 1;
         continue;
       }
     }
@@ -50,8 +57,8 @@ function splitTrailingPunctuation(candidate: string) {
   }
 
   return {
-    link,
-    trailingText: candidate.slice(link.length),
+    link: candidate.slice(0, end),
+    trailingText: candidate.slice(end),
   };
 }
 


### PR DESCRIPTION
## Why
URLs pasted into comments were rendered as plain text, forcing reviewers to copy and paste them manually.

## Changes
- add a reusable typed comment URL parser and renderer
- auto-link validated `http` and `https` URLs in dashboard, restricted share, and public watch comments and replies
- preserve original whitespace and surrounding punctuation without using `dangerouslySetInnerHTML`
- open external links in a new tab with `noopener noreferrer`
- add focused parser tests for multiple links, whitespace, punctuation, balanced delimiters, and invalid protocols

## Checks
- `bun test` (10 passed)
- `bun run typecheck`
- `bun run lint`
- `git diff --check`

Closes #10

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-link HTTP/HTTPS URLs in comments on watch and share pages
> - Adds [`CommentText`](https://github.com/pingdotgg/lawn/pull/40/files#diff-8a9cb9e75c8621ded5c82f18d83df3ad1b762717b0d8610d03f84eb0f83e2bca) component that renders comment text with clickable anchors for HTTP/HTTPS URLs, opening in a new tab with `rel="noopener noreferrer"`.
> - Adds [`parseCommentLinks`](https://github.com/pingdotgg/lawn/pull/40/files#diff-7a62ca902224b87fe3991de0145f59838639ac5c23794025275dca1bbc0b456e) utility that splits comment strings into `link` and `text` parts, trimming trailing punctuation and unbalanced delimiters, and rejecting unsafe schemes (`javascript:`, `data:`, `vbscript:`).
> - Replaces plain text rendering with `<CommentText>` in [`CommentItem`](https://github.com/pingdotgg/lawn/pull/40/files#diff-b5918b745d876a582a1d0fb65657690baf7bce17ab649e0037aedd03461579ed), the [watch page](https://github.com/pingdotgg/lawn/pull/40/files#diff-2b2efe3a498fab946d47a922e4452d5ad03e3d9694febd564713cb76bfe0d056), and the [share page](https://github.com/pingdotgg/lawn/pull/40/files#diff-4c7afce7c090b6a53b79b157fcd010668e7e4a70ed8d0bb343eabdc84db2c64d), including mobile comment lists.
> - Adds `break-words` CSS class to comment paragraphs to prevent long URLs from overflowing their containers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4e87d99.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comments now automatically detect and render HTTP/HTTPS URLs as clickable external links
  * Improved text wrapping and handling across all comment displays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->