### PR TITLE
[codex] Export video comments as CSV

### DIFF
--- a/app/routes/dashboard/-video.tsx
+++ b/app/routes/dashboard/-video.tsx
@@ -15,6 +15,11 @@ import {
   type VideoWorkflowStatus,
 } from "@/components/videos/VideoWorkflowStatusControl";
 import { formatDuration } from "@/lib/utils";
+import {
+  buildCommentsCsv,
+  buildCommentsCsvFilename,
+} from "@/lib/commentCsv";
+import { triggerTextDownload } from "@/lib/download";
 import { useVideoPresence } from "@/lib/useVideoPresence";
 import { VideoWatchers } from "@/components/presence/VideoWatchers";
 import { DashboardHeader } from "@/components/DashboardHeader";
@@ -25,6 +30,7 @@ import {
   Link as LinkIcon,
   MessageSquare,
   MoreVertical,
+  Download,
 } from "lucide-react";
 import {
   DropdownMenu,
@@ -241,6 +247,15 @@ export default function VideoPage() {
     },
     [playerRef, setHighlightedCommentId]
   );
+
+  const handleExportComments = useCallback(() => {
+    if (!video || !commentsThreaded?.length) return;
+
+    triggerTextDownload(
+      buildCommentsCsv(commentsThreaded),
+      buildCommentsCsvFilename(video.title),
+    );
+  }, [commentsThreaded, video]);
 
   const handleSaveTitle = async () => {
     if (!editedTitle.trim() || !video || !resolvedVideoId) return;
@@ -500,11 +515,23 @@ export default function VideoPage() {
             <h2 className="font-semibold text-sm tracking-tight flex items-center gap-2 text-[#1a1a1a] dark:text-[#f0f0e8]">
               Discussion
             </h2>
-            {comments && comments.length > 0 && (
-              <span className="text-[11px] font-medium text-[#888] bg-[#1a1a1a]/5 dark:bg-white/5 px-2 py-0.5 rounded-full">
-                {comments.length} {comments.length === 1 ? 'comment' : 'comments'}
-              </span>
-            )}
+            <div className="flex items-center gap-2">
+              {comments && comments.length > 0 && (
+                <span className="text-[11px] font-medium text-[#888] bg-[#1a1a1a]/5 dark:bg-white/5 px-2 py-0.5 rounded-full">
+                  {comments.length} {comments.length === 1 ? 'comment' : 'comments'}
+                </span>
+              )}
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-[10px]"
+                onClick={handleExportComments}
+                disabled={!commentsThreaded?.length}
+              >
+                <Download className="h-3.5 w-3.5" />
+                Export CSV
+              </Button>
+            </div>
           </div>
           <div className="flex-1 overflow-hidden">
             <CommentList
@@ -540,14 +567,26 @@ export default function VideoPage() {
                 </span>
               )}
             </h2>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8"
-              onClick={() => setMobileCommentsOpen(false)}
-            >
-              <X className="h-4 w-4" />
-            </Button>
+            <div className="flex items-center gap-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 px-2 text-[10px]"
+                onClick={handleExportComments}
+                disabled={!commentsThreaded?.length}
+              >
+                <Download className="h-3.5 w-3.5" />
+                Export CSV
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={() => setMobileCommentsOpen(false)}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
           </div>
           <div className="flex-1 overflow-hidden">
             <CommentList

--- a/src/lib/commentCsv.test.ts
+++ b/src/lib/commentCsv.test.ts
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildCommentsCsv,
+  buildCommentsCsvFilename,
+} from "@/lib/commentCsv";
+
+test("exports comments and replies in thread order", () => {
+  const csv = buildCommentsCsv([
+    {
+      text: "First comment",
+      timestampSeconds: 65,
+      replies: [
+        {
+          text: "First reply",
+          timestampSeconds: 65,
+        },
+        {
+          text: "Second reply",
+          timestampSeconds: 65,
+        },
+      ],
+    },
+    {
+      text: "Later comment",
+      timestampSeconds: 125,
+      replies: [],
+    },
+  ]);
+
+  assert.equal(
+    csv,
+    [
+      "Timestamp,Comment",
+      '"1:05","First comment"',
+      '"1:05","Reply: First reply"',
+      '"1:05","Reply: Second reply"',
+      '"2:05","Later comment"',
+    ].join("\r\n"),
+  );
+});
+
+test("escapes CSV content and neutralizes spreadsheet formulas", () => {
+  const csv = buildCommentsCsv([
+    {
+      text: 'Comma, quote "and"\nnewline',
+      timestampSeconds: 0,
+      replies: [
+        {
+          text: "Reply with a comma, too",
+          timestampSeconds: 0,
+        },
+      ],
+    },
+    {
+      text: "=HYPERLINK(\"https://example.com\")",
+      timestampSeconds: 1,
+      replies: [],
+    },
+  ]);
+
+  assert.equal(
+    csv,
+    [
+      "Timestamp,Comment",
+      '"0:00","Comma, quote ""and""\nnewline"',
+      '"0:00","Reply: Reply with a comma, too"',
+      '"0:01","\'=HYPERLINK(""https://example.com"")"',
+    ].join("\r\n"),
+  );
+});
+
+test("builds a stable filesystem-safe filename", () => {
+  assert.equal(
+    buildCommentsCsvFilename('  Launch / Review: "Final"  '),
+    "launch-review-final-comments.csv",
+  );
+  assert.equal(buildCommentsCsvFilename("你好"), "video-comments.csv");
+});

--- a/src/lib/commentCsv.ts
+++ b/src/lib/commentCsv.ts
@@ -1,0 +1,49 @@
+import { formatTimestamp } from "@/lib/utils";
+
+interface CsvComment {
+  text: string;
+  timestampSeconds: number;
+}
+
+interface CsvCommentThread extends CsvComment {
+  replies: CsvComment[];
+}
+
+function escapeCsvCell(value: string) {
+  const spreadsheetSafeValue = /^\s*[=+\-@]/.test(value)
+    ? `'${value}`
+    : value;
+  return `"${spreadsheetSafeValue.replaceAll('"', '""')}"`;
+}
+
+export function buildCommentsCsv(comments: CsvCommentThread[]) {
+  const rows = comments.flatMap((comment) => [
+    comment,
+    ...comment.replies.map((reply) => ({
+      ...reply,
+      text: `Reply: ${reply.text}`,
+    })),
+  ]);
+
+  return [
+    "Timestamp,Comment",
+    ...rows.map((comment) =>
+      [
+        escapeCsvCell(formatTimestamp(comment.timestampSeconds)),
+        escapeCsvCell(comment.text),
+      ].join(","),
+    ),
+  ].join("\r\n");
+}
+
+export function buildCommentsCsvFilename(videoTitle: string) {
+  const slug = videoTitle
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80)
+    .replace(/-+$/g, "");
+
+  return `${slug || "video"}-comments.csv`;
+}

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -18,3 +18,16 @@ export function triggerDownload(url: string, filename?: string) {
   anchor.remove();
 }
 
+export function triggerTextDownload(content: string, filename: string) {
+  const url = URL.createObjectURL(
+    new Blob(["\uFEFF", content], { type: "text/csv;charset=utf-8" }),
+  );
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 0);
+}


### PR DESCRIPTION
## Why

Authorized dashboard users need a quick way to move video feedback into other tools without exposing comments through a new public export endpoint.

## Changes

- add one-click CSV export controls to the desktop and mobile discussion headers
- generate the export locally from the existing authorized comments query
- export `Timestamp` and `Comment` columns, with replies immediately after their parent
- escape commas, quotes, and newlines, and neutralize spreadsheet formulas
- use a deterministic, filesystem-safe filename based on the video title

## Checks

- `bun run typecheck`
- `bun run lint`
- `bun test` (9 passing)
- `git diff --check`

Closes #25


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CSV export for video comments in the Codex video page
> - Adds an 'Export CSV' button to both the desktop sidebar and mobile comments header in the [VideoPage component](https://github.com/pingdotgg/lawn/pull/41/files#diff-833e2f5b1e2fafc1cc96eaad146f828e4462dfc59201a1f837cf780c7d11a442); button is disabled when no threaded comments exist.
> - Introduces [`buildCommentsCsv`](https://github.com/pingdotgg/lawn/pull/41/files#diff-baa35d63e0c51f9d0432b0fe535155739c10b323363cbc47173d893fd10db1fc) to flatten threaded comments into CRLF-delimited CSV rows with timestamp and escaped content, and [`buildCommentsCsvFilename`](https://github.com/pingdotgg/lawn/pull/41/files#diff-baa35d63e0c51f9d0432b0fe535155739c10b323363cbc47173d893fd10db1fc) to generate a filesystem-safe slug from the video title.
> - Adds [`triggerTextDownload`](https://github.com/pingdotgg/lawn/pull/41/files#diff-84ca4140c3903e1866373ed78383026f1f76edf8dd1b5fbc8fe1cbaa8fec4ded) to initiate a client-side download of a UTF-8 CSV file with a BOM via a temporary anchor element.
> - CSV cells are injection-safe: values starting with `=`, `+`, `-`, or `@` are prefixed with an apostrophe to neutralize spreadsheet formula execution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e6daea7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->