### PR TITLE
Don't auto-redirect into newly created folder

### DIFF
--- a/app/routes/dashboard/-project.tsx
+++ b/app/routes/dashboard/-project.tsx
@@ -259,14 +259,13 @@ export default function ProjectPage({
 
     setIsCreatingFolder(true);
     try {
-      const newId = await createFolder({
+      await createFolder({
         teamId,
         name: newFolderName.trim(),
         parentId: resolvedProjectId,
       });
       setCreateFolderOpen(false);
       setNewFolderName("");
-      navigate({ to: projectPath(resolvedTeamSlug, newId) });
     } catch (error) {
       console.error("Failed to create folder:", error);
       window.alert(error instanceof Error ? error.message : "Failed to create folder");


### PR DESCRIPTION
## What

When creating a new folder via the dashboard's **NEW FOLDER** modal, the app no longer auto-navigates into the freshly created (empty) folder. The user stays in the current project, and the new folder simply appears in the folder list in place.

## Why

Auto-redirecting into a brand-new empty folder is disorienting — you lose your spot in the current view. Creating a folder is an organizational action; you usually want to keep working where you are.

## How

In `app/routes/dashboard/-project.tsx`, `handleCreateFolder` dropped the post-create `navigate(...)` call. The folder list is driven by a reactive Convex query, so the new folder shows up immediately without any navigation. Since `newId` was only used for that redirect, the return value is no longer captured.

Typecheck, lint, and Prettier all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop auto-redirecting to a newly created folder in the project page
> After creating a folder, `ProjectPage.handleCreateFolder` in [dashboard/-project.tsx](https://github.com/pingdotgg/lawn/pull/42/files#diff-7f6b0aea5a8a88876c7a210132a9b2b8df403a506bc812b95dc6657459a44f8b) no longer captures the returned folder id or calls `navigate`. The user stays on the current page; the dialog closes and the input clears as before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f38ddc3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->