### PR TITLE
[codex] Add video version stacks

### DIFF
--- a/app/routes/dashboard/-layout.tsx
+++ b/app/routes/dashboard/-layout.tsx
@@ -1,10 +1,10 @@
 import { useAuth } from "@clerk/tanstack-react-start";
-import { useQuery } from "convex/react";
+import { useConvex, useQuery } from "convex/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
 
-import { Outlet, useLocation, useParams } from "@tanstack/react-router";
+import { Outlet, useLocation, useNavigate, useParams } from "@tanstack/react-router";
 import { cn } from "@/lib/utils";
 import {
   Dialog,
@@ -16,16 +16,13 @@ import {
 import { UploadProgress } from "@/components/upload/UploadProgress";
 import { useVideoUploadManager } from "./-useVideoUploadManager";
 import { DashboardUploadProvider } from "@/lib/dashboardUploadContext";
+import { videoPath } from "@/lib/routes";
+import { prewarmVideo } from "./-video.data";
 
 const VIDEO_FILE_EXTENSIONS = /\.(mp4|mov|m4v|webm|avi|mkv)$/i;
 
 function isVideoFile(file: File) {
   return file.type.startsWith("video/") || VIDEO_FILE_EXTENSIONS.test(file.name);
-}
-
-function getVideoFiles(files: FileList | null) {
-  if (!files) return [];
-  return Array.from(files).filter(isVideoFile);
 }
 
 function dragEventHasFiles(event: DragEvent) {
@@ -34,19 +31,27 @@ function dragEventHasFiles(event: DragEvent) {
 
 export default function DashboardLayout() {
   const { isLoaded, userId } = useAuth();
+  const convex = useConvex();
+  const navigate = useNavigate({});
   const location = useLocation();
   const { pathname, searchStr } = location;
   const params = useParams({ strict: false });
   const teamSlug = typeof params.teamSlug === "string" ? params.teamSlug : undefined;
   const routeProjectId =
     typeof params.projectId === "string" ? (params.projectId as Id<"projects">) : undefined;
-  const routeVideoId = typeof params.videoId === "string" ? params.videoId : undefined;
+  const routeVideoId =
+    typeof params.videoId === "string" ? (params.videoId as Id<"videos">) : undefined;
   const publicPlaybackId = useQuery(
     api.videos.getPublicIdByVideoId,
     routeVideoId ? { videoId: routeVideoId } : "skip",
   );
+  const detailVideo = useQuery(
+    api.videos.get,
+    routeVideoId && userId ? { videoId: routeVideoId } : "skip",
+  );
   const uploadTargets = useQuery(api.projects.listUploadTargets, teamSlug ? { teamSlug } : {});
-  const { uploads, uploadFilesToProject, cancelUpload, retryProcessing } = useVideoUploadManager();
+  const { uploads, uploadFilesToProject, uploadNewVersion, cancelUpload, retryProcessing } =
+    useVideoUploadManager();
   const [isGlobalDragActive, setIsGlobalDragActive] = useState(false);
   const [projectPickerOpen, setProjectPickerOpen] = useState(false);
   const [pendingFiles, setPendingFiles] = useState<File[] | null>(null);
@@ -97,6 +102,19 @@ export default function DashboardLayout() {
     [pendingFiles, uploadFilesToProject],
   );
 
+  const requestVersionUpload = useCallback(
+    (
+      sourceVideoId: Id<"videos">,
+      versionStackId: Id<"videos">,
+      projectId: Id<"projects">,
+      file: File,
+    ) => {
+      if (!isVideoFile(file)) return;
+      void uploadNewVersion(sourceVideoId, versionStackId, projectId, file);
+    },
+    [uploadNewVersion],
+  );
+
   const handleProjectPickerOpenChange = useCallback((open: boolean) => {
     setProjectPickerOpen(open);
     if (!open) {
@@ -133,7 +151,36 @@ export default function DashboardLayout() {
       dragDepthRef.current = 0;
       setIsGlobalDragActive(false);
 
-      const files = getVideoFiles(event.dataTransfer?.files ?? null);
+      const droppedFiles = Array.from(event.dataTransfer?.files ?? []);
+
+      if (routeVideoId) {
+        if (droppedFiles.length !== 1) {
+          window.alert("Drop one video at a time to upload a new version.");
+          return;
+        }
+        const file = droppedFiles[0];
+        if (!isVideoFile(file)) {
+          window.alert("Choose a single video file to upload as a new version.");
+          return;
+        }
+        if (!detailVideo) {
+          window.alert("Use the New version action when this video is ready for uploads.");
+          return;
+        }
+        if (detailVideo.role === "viewer") {
+          window.alert("You need member access to upload a new version.");
+          return;
+        }
+        requestVersionUpload(
+          detailVideo._id,
+          detailVideo.versionStackId ?? detailVideo._id,
+          detailVideo.projectId,
+          file,
+        );
+        return;
+      }
+
+      const files = droppedFiles.filter(isVideoFile);
       if (files.length === 0) return;
       requestUpload(files);
     };
@@ -149,16 +196,26 @@ export default function DashboardLayout() {
       window.removeEventListener("dragleave", handleDragLeave);
       window.removeEventListener("drop", handleDrop);
     };
-  }, [requestUpload]);
+  }, [detailVideo, requestUpload, requestVersionUpload, routeVideoId]);
+
+  const viewUploadedVersion = useCallback(
+    (projectId: Id<"projects">, videoId: Id<"videos">) => {
+      if (!teamSlug) return;
+      prewarmVideo(convex, { teamSlug, projectId, videoId });
+      navigate({ to: videoPath(teamSlug, projectId, videoId) });
+    },
+    [convex, navigate, teamSlug],
+  );
 
   const uploadContext = useMemo(
     () => ({
       requestUpload,
+      requestVersionUpload,
       uploads,
       cancelUpload,
       retryProcessing,
     }),
-    [requestUpload, uploads, cancelUpload, retryProcessing],
+    [requestUpload, requestVersionUpload, uploads, cancelUpload, retryProcessing],
   );
   const isResolvingPublicPlaybackExemption =
     Boolean(isLoaded && !userId && routeVideoId) && publicPlaybackId === undefined;
@@ -213,7 +270,11 @@ export default function DashboardLayout() {
           <div className="absolute inset-0 bg-[#1a1a1a]/20" />
           <div className="absolute inset-4 flex items-center justify-center border-4 border-dashed border-[#2d5a2d] bg-[#2d5a2d]/10">
             <p className="border-2 border-[#1a1a1a] bg-[#f0f0e8] px-4 py-2 text-sm font-bold text-[#1a1a1a]">
-              Drop videos to upload
+              {routeVideoId
+                ? detailVideo?.role === "viewer"
+                  ? "New version uploads require member access"
+                  : "Drop one video to upload it as a new version"
+                : "Drop videos to upload"}
             </p>
           </div>
         </div>
@@ -221,23 +282,36 @@ export default function DashboardLayout() {
 
       {uploads.length > 0 && (
         <div className="fixed top-16 right-4 left-4 z-50 space-y-2 sm:top-auto sm:right-auto sm:bottom-4 sm:w-full sm:max-w-sm">
-          {uploads.map((upload) => (
-            <UploadProgress
-              key={upload.id}
-              fileName={upload.file.name}
-              fileSize={upload.file.size}
-              progress={upload.progress}
-              status={upload.status}
-              error={upload.error}
-              bytesPerSecond={upload.bytesPerSecond}
-              estimatedSecondsRemaining={upload.estimatedSecondsRemaining}
-              resuming={upload.resuming}
-              onCancel={() => cancelUpload(upload.id)}
-              onRetryProcessing={
-                upload.canRetryProcessing ? () => retryProcessing(upload.id) : undefined
-              }
-            />
-          ))}
+          {uploads.map((upload) => {
+            const completedVersionId =
+              upload.status === "complete" && upload.creationIntent.kind === "version"
+                ? upload.videoId
+                : undefined;
+
+            return (
+              <UploadProgress
+                key={upload.id}
+                fileName={upload.file.name}
+                fileSize={upload.file.size}
+                progress={upload.progress}
+                status={upload.status}
+                error={upload.error}
+                bytesPerSecond={upload.bytesPerSecond}
+                estimatedSecondsRemaining={upload.estimatedSecondsRemaining}
+                resuming={upload.resuming}
+                intentLabel={upload.creationIntent.kind === "version" ? "New version" : undefined}
+                onCancel={() => cancelUpload(upload.id)}
+                onRetryProcessing={
+                  upload.canRetryProcessing ? () => retryProcessing(upload.id) : undefined
+                }
+                onView={
+                  completedVersionId && teamSlug
+                    ? () => viewUploadedVersion(upload.projectId, completedVersionId)
+                    : undefined
+                }
+              />
+            );
+          })}
         </div>
       )}
 

--- a/app/routes/dashboard/-project.tsx
+++ b/app/routes/dashboard/-project.tsx
@@ -34,6 +34,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Id } from "@convex/_generated/dataModel";
 import { cn } from "@/lib/utils";
@@ -136,6 +137,16 @@ function VideoIntentTarget({
       ref={dragRef}
       className={cn(className, isDragging && "opacity-50")}
       onClick={onOpen}
+      onKeyDown={(event) => {
+        if (event.currentTarget !== event.target) return;
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onOpen();
+        }
+      }}
+      role="link"
+      tabIndex={0}
+      aria-label={dragPayload.kind === "video" ? `Open video ${dragPayload.title}` : "Open video"}
       {...prewarmIntentHandlers}
     >
       {children}
@@ -191,6 +202,7 @@ export default function ProjectPage({
     _id: Id<"videos">;
     title: string;
     projectId: Id<"projects">;
+    versionNumber: number;
   } | null>(null);
   const [dndError, setDndError] = useState<string | null>(null);
 
@@ -244,8 +256,13 @@ export default function ProjectPage({
     [requestUpload, resolvedProjectId],
   );
 
-  const handleDeleteVideo = async (videoId: Id<"videos">) => {
-    if (!confirm("Are you sure you want to delete this video?")) return;
+  const handleDeleteVideo = async (videoId: Id<"videos">, versionNumber: number) => {
+    if (
+      !confirm(
+        `Delete the latest version (v${versionNumber})? Its comments and share links will be deleted. The previous version will become latest.`,
+      )
+    )
+      return;
     try {
       await deleteVideo({ videoId });
     } catch (error) {
@@ -369,6 +386,7 @@ export default function ProjectPage({
   }
 
   const canUpload = project?.role !== "viewer";
+  const canDeleteVideo = project?.role === "owner" || project?.role === "admin";
   const hasChildFolders = (childFolders?.length ?? 0) > 0;
   const hasVideos = (videos?.length ?? 0) > 0;
   const showEmptyDropzone = !isLoadingData && !hasVideos && !hasChildFolders;
@@ -431,6 +449,9 @@ export default function ProjectPage({
           {/* View toggle */}
           <div className="flex items-center border-2 border-[#1a1a1a] p-0.5">
             <button
+              type="button"
+              aria-label="Show grid view"
+              aria-pressed={viewMode === "grid"}
               onClick={() => setViewMode("grid")}
               className={cn(
                 "p-1.5 transition-colors",
@@ -442,6 +463,9 @@ export default function ProjectPage({
               <Grid3X3 className="h-4 w-4" />
             </button>
             <button
+              type="button"
+              aria-label="Show list view"
+              aria-pressed={viewMode === "list"}
               onClick={() => setViewMode("list")}
               className={cn(
                 "p-1.5 transition-colors",
@@ -518,6 +542,7 @@ export default function ProjectPage({
                 const canDownload =
                   Boolean(video.s3Key) && video.status !== "failed" && video.status !== "uploading";
                 const watchingCount = projectPresenceCounts?.counts?.[video._id] ?? 0;
+                const isVersionStack = video.versionNumber > 1;
 
                 return (
                   <VideoIntentTarget
@@ -541,7 +566,14 @@ export default function ProjectPage({
                       })
                     }
                   >
-                    <div className="relative aspect-video overflow-hidden border-2 border-[#1a1a1a] bg-[#e8e8e0] shadow-[4px_4px_0px_0px_var(--shadow-color)] transition-all group-hover:translate-x-[2px] group-hover:translate-y-[2px] group-hover:shadow-[2px_2px_0px_0px_var(--shadow-color)]">
+                    <div
+                      className={cn(
+                        "relative aspect-video overflow-hidden border-2 border-[#1a1a1a] bg-[#e8e8e0] transition-all group-hover:translate-x-[2px] group-hover:translate-y-[2px]",
+                        isVersionStack
+                          ? "shadow-[3px_3px_0px_0px_#c8c8c0,6px_6px_0px_0px_var(--shadow-color)] group-hover:shadow-[2px_2px_0px_0px_#c8c8c0,4px_4px_0px_0px_var(--shadow-color)]"
+                          : "shadow-[4px_4px_0px_0px_var(--shadow-color)] group-hover:shadow-[2px_2px_0px_0px_var(--shadow-color)]",
+                      )}
+                    >
                       {thumbnailSrc ? (
                         <img
                           src={thumbnailSrc}
@@ -559,6 +591,14 @@ export default function ProjectPage({
                           {formatDuration(video.duration)}
                         </div>
                       )}
+                      {isVersionStack && (
+                        <Badge
+                          variant="default"
+                          className="absolute top-2 left-2 z-10 px-1.5 py-0 text-[10px] text-[#f0f0e8]"
+                        >
+                          Version {video.versionNumber}
+                        </Badge>
+                      )}
                       {video.status !== "ready" && (
                         <div className="absolute inset-0 flex items-center justify-center bg-black/60">
                           <span className="text-xs font-bold tracking-wider text-white uppercase">
@@ -569,14 +609,15 @@ export default function ProjectPage({
                         </div>
                       )}
                       {/* Hover menu */}
-                      <div className="absolute top-2 right-2 opacity-0 transition-opacity group-hover:opacity-100">
+                      <div className="absolute top-2 right-2 opacity-100 transition-opacity md:opacity-0 md:group-focus-within:opacity-100 md:group-hover:opacity-100">
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
                             <button
                               type="button"
                               className="inline-flex h-8 w-8 cursor-pointer items-center justify-center bg-black/60 text-white hover:bg-black/80"
+                              aria-label={`Open actions for ${video.title}`}
                             >
-                              <MoreVertical className="h-4 w-4" />
+                              <MoreVertical className="h-4 w-4" aria-hidden="true" />
                             </button>
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="end">
@@ -608,23 +649,24 @@ export default function ProjectPage({
                                     _id: video._id,
                                     title: video.title,
                                     projectId: project._id,
+                                    versionNumber: video.versionNumber,
                                   });
                                 }}
                               >
                                 <FolderInput className="mr-2 h-4 w-4" />
-                                Move
+                                Move all versions
                               </DropdownMenuItem>
                             )}
-                            {canUpload && (
+                            {canDeleteVideo && (
                               <DropdownMenuItem
                                 className="text-[#dc2626] focus:text-[#dc2626]"
                                 onClick={(e) => {
                                   e.stopPropagation();
-                                  handleDeleteVideo(video._id);
+                                  handleDeleteVideo(video._id, video.versionNumber);
                                 }}
                               >
                                 <Trash2 className="mr-2 h-4 w-4" />
-                                Delete
+                                Delete latest version (v{video.versionNumber})
                               </DropdownMenuItem>
                             )}
                           </DropdownMenuContent>
@@ -681,6 +723,7 @@ export default function ProjectPage({
               const canDownload =
                 Boolean(video.s3Key) && video.status !== "failed" && video.status !== "uploading";
               const watchingCount = projectPresenceCounts?.counts?.[video._id] ?? 0;
+              const isVersionStack = video.versionNumber > 1;
 
               return (
                 <VideoIntentTarget
@@ -705,7 +748,14 @@ export default function ProjectPage({
                   }
                 >
                   {/* Thumbnail */}
-                  <div className="relative aspect-video w-44 shrink-0 overflow-hidden border-2 border-[#1a1a1a] bg-[#e8e8e0] shadow-[4px_4px_0px_0px_var(--shadow-color)] transition-all group-hover:translate-x-[2px] group-hover:translate-y-[2px] group-hover:shadow-[2px_2px_0px_0px_var(--shadow-color)]">
+                  <div
+                    className={cn(
+                      "relative aspect-video w-44 shrink-0 overflow-hidden border-2 border-[#1a1a1a] bg-[#e8e8e0] transition-all group-hover:translate-x-[2px] group-hover:translate-y-[2px]",
+                      isVersionStack
+                        ? "shadow-[3px_3px_0px_0px_#c8c8c0,6px_6px_0px_0px_var(--shadow-color)] group-hover:shadow-[2px_2px_0px_0px_#c8c8c0,4px_4px_0px_0px_var(--shadow-color)]"
+                        : "shadow-[4px_4px_0px_0px_var(--shadow-color)] group-hover:shadow-[2px_2px_0px_0px_var(--shadow-color)]",
+                    )}
+                  >
                     {thumbnailSrc ? (
                       <img
                         src={thumbnailSrc}
@@ -731,6 +781,14 @@ export default function ProjectPage({
                       <div className="absolute right-1 bottom-1 bg-black/70 px-1 py-0.5 font-mono text-[10px] text-white">
                         {formatDuration(video.duration)}
                       </div>
+                    )}
+                    {isVersionStack && (
+                      <Badge
+                        variant="default"
+                        className="absolute top-1 left-1 z-10 px-1 py-0 text-[9px] text-[#f0f0e8]"
+                      >
+                        Version {video.versionNumber}
+                      </Badge>
                     )}
                   </div>
 
@@ -768,14 +826,15 @@ export default function ProjectPage({
                   </div>
 
                   {/* Actions */}
-                  <div className="opacity-0 transition-opacity group-hover:opacity-100">
+                  <div className="opacity-100 transition-opacity md:opacity-0 md:group-focus-within:opacity-100 md:group-hover:opacity-100">
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
                         <button
                           type="button"
                           className="inline-flex h-8 w-8 cursor-pointer items-center justify-center text-[#888] hover:text-[#1a1a1a]"
+                          aria-label={`Open actions for ${video.title}`}
                         >
-                          <MoreVertical className="h-4 w-4" />
+                          <MoreVertical className="h-4 w-4" aria-hidden="true" />
                         </button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">
@@ -807,23 +866,24 @@ export default function ProjectPage({
                                 _id: video._id,
                                 title: video.title,
                                 projectId: project._id,
+                                versionNumber: video.versionNumber,
                               });
                             }}
                           >
                             <FolderInput className="mr-2 h-4 w-4" />
-                            Move
+                            Move all versions
                           </DropdownMenuItem>
                         )}
-                        {canUpload && (
+                        {canDeleteVideo && (
                           <DropdownMenuItem
                             className="text-[#dc2626] focus:text-[#dc2626]"
                             onClick={(e) => {
                               e.stopPropagation();
-                              handleDeleteVideo(video._id);
+                              handleDeleteVideo(video._id, video.versionNumber);
                             }}
                           >
                             <Trash2 className="mr-2 h-4 w-4" />
-                            Delete
+                            Delete latest version (v{video.versionNumber})
                           </DropdownMenuItem>
                         )}
                       </DropdownMenuContent>

--- a/app/routes/dashboard/-routeDataContracts.test.ts
+++ b/app/routes/dashboard/-routeDataContracts.test.ts
@@ -35,6 +35,7 @@ test("dashboard route data contracts expose expected essential queries", () => {
     "comments:getThreaded",
     "comments:list",
     "videos:get",
+    "videos:listVersions",
     "workspace:resolveContext",
   ]);
 });

--- a/app/routes/dashboard/-useVideoUploadManager.ts
+++ b/app/routes/dashboard/-useVideoUploadManager.ts
@@ -8,12 +8,15 @@ import {
   deleteUploadResumeSession,
   findUploadResumeSessionByFingerprint,
   loadUploadResumeSession,
+  type UploadCreationIntent,
+  uploadCreationIntentsMatch,
 } from "@/lib/uploadResumeDb";
 import { isProcessingRetryError, isResumableUploadError, uploadVideoFile } from "@/lib/videoUpload";
 
 export interface ManagedUploadItem {
   id: string;
   projectId: Id<"projects">;
+  creationIntent: UploadCreationIntent;
   file: File;
   videoId?: Id<"videos">;
   progress: number;
@@ -33,8 +36,13 @@ function createUploadId() {
   return Math.random().toString(36).slice(2);
 }
 
+function isMissingVideoError(error: unknown) {
+  return error instanceof Error && error.message.includes("Video not found");
+}
+
 export function useVideoUploadManager() {
   const createVideo = useMutation(api.videos.create);
+  const createVersion = useMutation(api.videos.createVersion);
   const initiateVideoUpload = useAction(api.videoActions.initiateVideoUpload);
   const signUploadParts = useAction(api.videoActions.signUploadParts);
   const completeMultipartUpload = useAction(api.videoActions.completeMultipartUpload);
@@ -43,179 +51,259 @@ export function useVideoUploadManager() {
   const abortVideoUpload = useAction(api.videoActions.abortVideoUpload);
   const [uploads, setUploads] = useState<ManagedUploadItem[]>([]);
 
-  const uploadActions = {
-    initiateVideoUpload,
-    signUploadParts,
-    completeMultipartUpload,
-    markUploadComplete,
-  };
+  const uploadFile = useCallback(
+    async (projectId: Id<"projects">, file: File, creationIntent: UploadCreationIntent) => {
+      const uploadId = createUploadId();
+      const abortController = new AbortController();
 
-  const uploadFilesToProject = useCallback(
-    async (projectId: Id<"projects">, files: File[]) => {
-      for (const file of files) {
-        const uploadId = createUploadId();
-        const title = file.name.replace(/\.[^/.]+$/, "");
-        const abortController = new AbortController();
-
-        if (isFileTooLarge(file.size)) {
-          setUploads((prev) => [
-            ...prev,
-            {
-              id: uploadId,
-              projectId,
-              file,
-              progress: 0,
-              status: "error",
-              error: `Video file is too large. Maximum size is ${formatMaxUploadSize()}.`,
-              abortController,
-            },
-          ]);
-          continue;
-        }
-
-        const fingerprint = await buildFileFingerprint(file);
-        const existingResume = await findUploadResumeSessionByFingerprint(fingerprint, projectId);
-
+      if (isFileTooLarge(file.size)) {
         setUploads((prev) => [
           ...prev,
           {
             id: uploadId,
             projectId,
+            creationIntent,
             file,
             progress: 0,
-            status: "pending",
+            status: "error",
+            error: `Video file is too large. Maximum size is ${formatMaxUploadSize()}.`,
             abortController,
-            resuming: Boolean(existingResume),
           },
         ]);
+        return;
+      }
 
-        let createdVideoId: Id<"videos"> | undefined = existingResume?.videoId;
+      const fingerprint = await buildFileFingerprint(file);
+      const existingResume = await findUploadResumeSessionByFingerprint(
+        fingerprint,
+        creationIntent,
+      );
 
-        try {
-          if (!createdVideoId) {
-            createdVideoId = await createVideo({
-              projectId,
-              title,
-              fileSize: file.size,
-              contentType: file.type || "video/mp4",
-            });
-          }
+      setUploads((prev) => [
+        ...prev,
+        {
+          id: uploadId,
+          projectId,
+          creationIntent,
+          file,
+          progress: 0,
+          status: "pending",
+          abortController,
+          resuming: Boolean(existingResume),
+        },
+      ]);
 
-          let resumeSession = (await loadUploadResumeSession(createdVideoId)) ?? existingResume;
+      const createVideoForIntent = async () => {
+        if (creationIntent.kind === "version") {
+          const created = await createVersion({
+            sourceVideoId: creationIntent.sourceVideoId,
+            fileSize: file.size,
+            contentType: file.type || "video/mp4",
+          });
+          return created.videoId;
+        }
 
-          const runUpload = async () => {
-            setUploads((prev) =>
-              prev.map((upload) =>
-                upload.id === uploadId
-                  ? {
-                      ...upload,
-                      videoId: createdVideoId,
-                      status: "uploading",
-                      resuming: Boolean(resumeSession),
-                    }
-                  : upload,
-              ),
-            );
+        return await createVideo({
+          projectId: creationIntent.projectId,
+          title: file.name.replace(/\.[^/.]+$/, ""),
+          fileSize: file.size,
+          contentType: file.type || "video/mp4",
+        });
+      };
 
-            await uploadVideoFile({
-              file,
-              projectId,
-              videoId: createdVideoId!,
-              actions: uploadActions,
-              signal: abortController.signal,
-              resumeSession,
-              fileFingerprint: fingerprint,
-              onResumingChange: (resuming) => {
-                setUploads((prev) =>
-                  prev.map((upload) => (upload.id === uploadId ? { ...upload, resuming } : upload)),
-                );
-              },
-              onProgress: (update) => {
-                setUploads((prev) =>
-                  prev.map((upload) =>
-                    upload.id === uploadId
-                      ? {
-                          ...upload,
-                          progress: update.progress,
-                          bytesPerSecond: update.bytesPerSecond,
-                          estimatedSecondsRemaining: update.estimatedSecondsRemaining,
-                        }
-                      : upload,
-                  ),
-                );
-              },
-            });
-          };
+      let createdVideoId: Id<"videos"> | undefined = existingResume?.videoId;
 
-          try {
-            await runUpload();
-          } catch (error) {
-            const staleResumeVideo =
-              Boolean(existingResume) &&
-              error instanceof Error &&
-              error.message.includes("Video not found");
-            if (!staleResumeVideo) {
-              throw error;
-            }
+      try {
+        if (!createdVideoId) {
+          createdVideoId = await createVideoForIntent();
+        }
 
-            await deleteUploadResumeSession(createdVideoId);
-            createdVideoId = await createVideo({
-              projectId,
-              title,
-              fileSize: file.size,
-              contentType: file.type || "video/mp4",
-            });
-            resumeSession = undefined;
-            await runUpload();
-          }
+        const loadedResume = await loadUploadResumeSession(createdVideoId);
+        let resumeSession =
+          loadedResume && uploadCreationIntentsMatch(loadedResume, creationIntent)
+            ? loadedResume
+            : existingResume;
+        if (loadedResume && !uploadCreationIntentsMatch(loadedResume, creationIntent)) {
+          await deleteUploadResumeSession(loadedResume.videoId);
+        }
 
-          setUploads((prev) =>
-            prev.map((upload) =>
-              upload.id === uploadId
-                ? { ...upload, status: "complete", progress: 100, resuming: false }
-                : upload,
-            ),
-          );
-
-          setTimeout(() => {
-            setUploads((prev) => prev.filter((upload) => upload.id !== uploadId));
-          }, 3000);
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : "Upload failed";
-          const cancelled = abortController.signal.aborted;
-          const resumable = isResumableUploadError(error);
-          const canRetryProcessing = isProcessingRetryError(error);
-
+        const runUpload = async (videoId: Id<"videos">, currentResume: typeof resumeSession) => {
           setUploads((prev) =>
             prev.map((upload) =>
               upload.id === uploadId
                 ? {
                     ...upload,
-                    status: cancelled ? "pending" : "error",
-                    error: cancelled ? undefined : errorMessage,
-                    canRetryProcessing,
+                    videoId,
+                    status: "uploading",
+                    resuming: Boolean(currentResume),
                   }
                 : upload,
             ),
           );
 
-          if (cancelled) {
+          await uploadVideoFile({
+            file,
+            creationIntent,
+            videoId,
+            actions: {
+              initiateVideoUpload,
+              signUploadParts,
+              completeMultipartUpload,
+              markUploadComplete,
+            },
+            signal: abortController.signal,
+            resumeSession: currentResume,
+            fileFingerprint: fingerprint,
+            onResumingChange: (resuming) => {
+              setUploads((prev) =>
+                prev.map((upload) => (upload.id === uploadId ? { ...upload, resuming } : upload)),
+              );
+            },
+            onProgress: (update) => {
+              setUploads((prev) =>
+                prev.map((upload) =>
+                  upload.id === uploadId
+                    ? {
+                        ...upload,
+                        progress: update.progress,
+                        bytesPerSecond: update.bytesPerSecond,
+                        estimatedSecondsRemaining: update.estimatedSecondsRemaining,
+                      }
+                    : upload,
+                ),
+              );
+            },
+            onProcessing: () => {
+              setUploads((prev) =>
+                prev.map((upload) =>
+                  upload.id === uploadId
+                    ? {
+                        ...upload,
+                        status: "processing",
+                        progress: 100,
+                        bytesPerSecond: 0,
+                        estimatedSecondsRemaining: 0,
+                      }
+                    : upload,
+                ),
+              );
+            },
+          });
+        };
+
+        try {
+          await runUpload(createdVideoId, resumeSession);
+        } catch (error) {
+          const staleResumeVideo =
+            Boolean(existingResume) &&
+            error instanceof Error &&
+            error.message.includes("Video not found");
+          if (!staleResumeVideo) {
+            throw error;
+          }
+
+          await deleteUploadResumeSession(createdVideoId);
+          createdVideoId = await createVideoForIntent();
+          resumeSession = undefined;
+          await runUpload(createdVideoId, resumeSession);
+        }
+
+        setUploads((prev) =>
+          prev.map((upload) =>
+            upload.id === uploadId
+              ? { ...upload, status: "complete", progress: 100, resuming: false }
+              : upload,
+          ),
+        );
+
+        setTimeout(
+          () => {
             setUploads((prev) => prev.filter((upload) => upload.id !== uploadId));
-          } else if (createdVideoId && !resumable && !canRetryProcessing) {
-            deleteUploadResumeSession(createdVideoId).catch(console.error);
-            markUploadFailed({ videoId: createdVideoId }).catch(console.error);
+          },
+          creationIntent.kind === "version" ? 10_000 : 3000,
+        );
+
+        return createdVideoId;
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : "Upload failed";
+        const cancelled = abortController.signal.aborted;
+        const resumable = isResumableUploadError(error);
+        const canRetryProcessing = isProcessingRetryError(error);
+
+        setUploads((prev) =>
+          prev.map((upload) =>
+            upload.id === uploadId
+              ? {
+                  ...upload,
+                  status: cancelled ? "pending" : "error",
+                  error: cancelled ? undefined : errorMessage,
+                  canRetryProcessing,
+                }
+              : upload,
+          ),
+        );
+
+        if (cancelled) {
+          if (createdVideoId) {
+            await deleteUploadResumeSession(createdVideoId);
+            try {
+              await abortVideoUpload({ videoId: createdVideoId });
+            } catch (cleanupError) {
+              if (!isMissingVideoError(cleanupError)) {
+                console.error(cleanupError);
+              }
+            }
+          }
+          setUploads((prev) => prev.filter((upload) => upload.id !== uploadId));
+        } else if (createdVideoId && !resumable && !canRetryProcessing) {
+          await deleteUploadResumeSession(createdVideoId);
+          try {
+            await markUploadFailed({ videoId: createdVideoId });
+          } catch (cleanupError) {
+            if (!isMissingVideoError(cleanupError)) {
+              console.error(cleanupError);
+            }
           }
         }
+
+        return undefined;
       }
     },
     [
       createVideo,
+      createVersion,
       initiateVideoUpload,
       signUploadParts,
       completeMultipartUpload,
       markUploadComplete,
       markUploadFailed,
+      abortVideoUpload,
     ],
+  );
+
+  const uploadFilesToProject = useCallback(
+    async (projectId: Id<"projects">, files: File[]) => {
+      for (const file of files) {
+        await uploadFile(projectId, file, { kind: "standalone", projectId });
+      }
+    },
+    [uploadFile],
+  );
+
+  const uploadNewVersion = useCallback(
+    async (
+      sourceVideoId: Id<"videos">,
+      versionStackId: Id<"videos">,
+      projectId: Id<"projects">,
+      file: File,
+    ) => {
+      return await uploadFile(projectId, file, {
+        kind: "version",
+        sourceVideoId,
+        versionStackId,
+      });
+    },
+    [uploadFile],
   );
 
   const cancelUpload = useCallback(
@@ -225,7 +313,11 @@ export function useVideoUploadManager() {
         upload.abortController.abort();
       }
       if (upload?.videoId) {
-        abortVideoUpload({ videoId: upload.videoId }).catch(console.error);
+        abortVideoUpload({ videoId: upload.videoId }).catch((error) => {
+          if (!isMissingVideoError(error)) {
+            console.error(error);
+          }
+        });
         deleteUploadResumeSession(upload.videoId).catch(console.error);
       }
       setUploads((prev) => prev.filter((item) => item.id !== uploadId));
@@ -261,9 +353,12 @@ export function useVideoUploadManager() {
               : item,
           ),
         );
-        setTimeout(() => {
-          setUploads((prev) => prev.filter((item) => item.id !== uploadId));
-        }, 3000);
+        setTimeout(
+          () => {
+            setUploads((prev) => prev.filter((item) => item.id !== uploadId));
+          },
+          upload.creationIntent.kind === "version" ? 10_000 : 3000,
+        );
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Processing failed";
         const canRetryProcessing = isProcessingRetryError(error);
@@ -290,6 +385,7 @@ export function useVideoUploadManager() {
   return {
     uploads,
     uploadFilesToProject,
+    uploadNewVersion,
     cancelUpload,
     retryProcessing,
   };

--- a/app/routes/dashboard/-video.data.ts
+++ b/app/routes/dashboard/-video.data.ts
@@ -17,6 +17,9 @@ export function getVideoEssentialSpecs(params: {
     makeRouteQuerySpec(api.videos.get, {
       videoId: params.videoId,
     }),
+    makeRouteQuerySpec(api.videos.listVersions, {
+      videoId: params.videoId,
+    }),
     makeRouteQuerySpec(api.comments.list, {
       videoId: params.videoId,
     }),
@@ -41,6 +44,10 @@ export function useVideoData(params: {
   const resolvedVideoId = context?.video?._id;
 
   const video = useQuery(api.videos.get, resolvedVideoId ? { videoId: resolvedVideoId } : "skip");
+  const versions = useQuery(
+    api.videos.listVersions,
+    resolvedVideoId ? { videoId: resolvedVideoId } : "skip",
+  );
   const comments = useQuery(
     api.comments.list,
     resolvedVideoId ? { videoId: resolvedVideoId } : "skip",
@@ -56,6 +63,7 @@ export function useVideoData(params: {
     resolvedProjectId,
     resolvedVideoId,
     video,
+    versions,
     comments,
     commentsThreaded,
   };

--- a/app/routes/dashboard/-video.tsx
+++ b/app/routes/dashboard/-video.tsx
@@ -200,6 +200,7 @@ export default function VideoPage() {
   const updateVideoWorkflowStatus = useMutation(api.videos.updateWorkflowStatus);
   const deleteVideo = useMutation(api.videos.remove);
   const checkMuxAssetStatus = useAction(api.videoActions.checkMuxAssetStatus);
+  const retryFailedProcessing = useAction(api.videoActions.markUploadComplete);
   const getPlaybackSession = useAction(api.videoActions.getPlaybackSession);
   const getOriginalPlaybackUrl = useAction(api.videoActions.getOriginalPlaybackUrl);
   const getDownloadUrl = useAction(api.videoActions.getDownloadUrl);
@@ -218,6 +219,8 @@ export default function VideoPage() {
   const [isLoadingPlayback, setIsLoadingPlayback] = useState(false);
   const [originalPlaybackUrl, setOriginalPlaybackUrl] = useState<string | null>(null);
   const [isLoadingOriginalPlayback, setIsLoadingOriginalPlayback] = useState(false);
+  const [isRetryingFailedProcessing, setIsRetryingFailedProcessing] = useState(false);
+  const [retryFailedProcessingError, setRetryFailedProcessingError] = useState<string | null>(null);
   const [preferredSource, setPreferredSource] = useState<"mux720" | "original">("original");
   const playerRef = useRef<VideoPlayerHandle | null>(null);
   const isPlayable = video?.status === "ready" && Boolean(video?.muxPlaybackId);
@@ -450,6 +453,22 @@ export default function VideoPage() {
     }
   }, [deleteVideo, navigate, resolvedProjectId, resolvedTeamSlug, resolvedVideoId, video]);
 
+  const handleRetryFailedProcessing = useCallback(async () => {
+    if (!resolvedVideoId) return;
+
+    setIsRetryingFailedProcessing(true);
+    setRetryFailedProcessingError(null);
+    try {
+      await retryFailedProcessing({ videoId: resolvedVideoId });
+    } catch (error) {
+      setRetryFailedProcessingError(
+        error instanceof Error ? error.message : "Failed to retry video processing.",
+      );
+    } finally {
+      setIsRetryingFailedProcessing(false);
+    }
+  }, [resolvedVideoId, retryFailedProcessing]);
+
   const startEditingTitle = () => {
     if (video) {
       setEditedTitle(video.title);
@@ -476,6 +495,7 @@ export default function VideoPage() {
   const canEdit = video.role !== "viewer";
   const canDelete = video.role === "owner" || video.role === "admin";
   const canComment = true;
+  const showVersionSelector = (versions?.length ?? 0) > 1;
 
   return (
     <div className="flex h-full flex-col">
@@ -554,13 +574,15 @@ export default function VideoPage() {
           <VideoWatchers watchers={watchers} />
         </div>
         <div className="ml-1 hidden flex-shrink-0 items-center gap-3 border-l-2 border-[#1a1a1a]/20 pl-3 lg:flex">
-          <VersionSelector
-            versions={versions}
-            currentVideoId={resolvedVideoId}
-            currentVersionNumber={video.versionNumber}
-            teamSlug={resolvedTeamSlug}
-            onSelect={handleVersionSelected}
-          />
+          {showVersionSelector && (
+            <VersionSelector
+              versions={versions}
+              currentVideoId={resolvedVideoId}
+              currentVersionNumber={video.versionNumber}
+              teamSlug={resolvedTeamSlug}
+              onSelect={handleVersionSelected}
+            />
+          )}
           {canEdit && (
             <UploadButton
               multiple={false}
@@ -609,14 +631,16 @@ export default function VideoPage() {
 
         {/* Compact: workflow status + consolidated menu until large screens */}
         <div className="flex items-center gap-2 lg:hidden">
-          <VersionSelector
-            versions={versions}
-            currentVideoId={resolvedVideoId}
-            currentVersionNumber={video.versionNumber}
-            teamSlug={resolvedTeamSlug}
-            onSelect={handleVersionSelected}
-            compact
-          />
+          {showVersionSelector && (
+            <VersionSelector
+              versions={versions}
+              currentVideoId={resolvedVideoId}
+              currentVersionNumber={video.versionNumber}
+              teamSlug={resolvedTeamSlug}
+              onSelect={handleVersionSelected}
+              compact
+            />
+          )}
           <VideoWorkflowStatusControl
             status={video.workflowStatus}
             size="lg"
@@ -733,7 +757,34 @@ export default function VideoPage() {
                         : "Processing video..."}
                     </p>
                   )}
-                  {video.status === "failed" && <p className="text-[#dc2626]">Processing failed</p>}
+                  {video.status === "failed" && (
+                    <div className="flex max-w-md flex-col items-center gap-3 px-6">
+                      <p className="font-bold text-[#f87171]">Processing failed</p>
+                      {video.uploadError && (
+                        <p className="text-sm text-white/60">{video.uploadError}</p>
+                      )}
+                      {video.isLatestVersion && showVersionSelector && (
+                        <p className="text-sm text-white/60">
+                          Previous versions are still available from the version menu.
+                        </p>
+                      )}
+                      {canEdit && video.s3Key && (
+                        <Button
+                          variant="outline"
+                          onClick={() => void handleRetryFailedProcessing()}
+                          disabled={isRetryingFailedProcessing}
+                        >
+                          {isRetryingFailedProcessing && (
+                            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                          )}
+                          Retry processing
+                        </Button>
+                      )}
+                      {retryFailedProcessingError && (
+                        <p className="text-sm text-[#f87171]">{retryFailedProcessingError}</p>
+                      )}
+                    </div>
+                  )}
                 </div>
               )}
             </div>

--- a/app/routes/dashboard/-video.tsx
+++ b/app/routes/dashboard/-video.tsx
@@ -19,6 +19,8 @@ import { triggerTextDownload } from "@/lib/download";
 import { useVideoPresence } from "@/lib/useVideoPresence";
 import { VideoWatchers } from "@/components/presence/VideoWatchers";
 import { DashboardHeader } from "@/components/DashboardHeader";
+import { UploadButton } from "@/components/upload/UploadButton";
+import { useDashboardUploadContext } from "@/lib/dashboardUploadContext";
 import {
   Edit2,
   Check,
@@ -27,19 +29,149 @@ import {
   MessageSquare,
   MoreVertical,
   Download,
+  Layers3,
+  Upload,
+  Trash2,
+  Loader2,
 } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Id } from "@convex/_generated/dataModel";
-import { projectPath, teamHomePath } from "@/lib/routes";
+import { projectPath, teamHomePath, videoPath } from "@/lib/routes";
 import { useRoutePrewarmIntent } from "@/lib/useRoutePrewarmIntent";
 import { prewarmProject } from "./-project.data";
 import { prewarmTeam } from "./-team.data";
-import { useVideoData } from "./-video.data";
+import { prewarmVideo, useVideoData } from "./-video.data";
+
+function versionStatusLabel(status: string) {
+  switch (status) {
+    case "uploading":
+      return "Uploading";
+    case "processing":
+      return "Processing";
+    case "failed":
+      return "Failed";
+    default:
+      return "Ready";
+  }
+}
+
+function VersionSelectorOption({
+  version,
+  teamSlug,
+  currentVideoId,
+  onSelect,
+}: {
+  version: {
+    _id: Id<"videos">;
+    projectId: Id<"projects">;
+    versionNumber: number;
+    status: string;
+    isLatestVersion: boolean;
+  };
+  teamSlug: string;
+  currentVideoId: Id<"videos">;
+  onSelect: (videoId: Id<"videos">) => void;
+}) {
+  const convex = useConvex();
+  const prewarmIntentHandlers = useRoutePrewarmIntent(() =>
+    prewarmVideo(convex, {
+      teamSlug,
+      projectId: version.projectId,
+      videoId: version._id,
+    }),
+  );
+
+  return (
+    <DropdownMenuRadioItem
+      value={version._id}
+      onSelect={() => onSelect(version._id)}
+      {...prewarmIntentHandlers}
+    >
+      <span className="font-bold">v{version.versionNumber}</span>
+      <span className="ml-2 text-xs text-[#888]">
+        {version._id === currentVideoId
+          ? `${version.isLatestVersion ? "Viewing latest" : "Viewing"} · ${versionStatusLabel(version.status)}`
+          : version.isLatestVersion
+            ? `Latest · ${versionStatusLabel(version.status)}`
+            : versionStatusLabel(version.status)}
+      </span>
+    </DropdownMenuRadioItem>
+  );
+}
+
+function VersionSelector({
+  versions,
+  currentVideoId,
+  currentVersionNumber,
+  teamSlug,
+  onSelect,
+  compact = false,
+}: {
+  versions:
+    | Array<{
+        _id: Id<"videos">;
+        projectId: Id<"projects">;
+        versionNumber: number;
+        status: string;
+        isLatestVersion: boolean;
+      }>
+    | undefined;
+  currentVideoId: Id<"videos">;
+  currentVersionNumber: number;
+  teamSlug: string;
+  onSelect: (videoId: Id<"videos">) => void;
+  compact?: boolean;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size={compact ? "icon" : "default"}
+          className={compact ? "h-8 w-8" : undefined}
+          aria-label={`Select video version, currently v${currentVersionNumber}`}
+        >
+          {versions === undefined ? (
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <Layers3 className="h-4 w-4" aria-hidden="true" />
+          )}
+          {!compact && <span>v{currentVersionNumber}</span>}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-52">
+        <DropdownMenuLabel>Video versions</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {versions === undefined ? (
+          <DropdownMenuItem disabled>Loading versions…</DropdownMenuItem>
+        ) : versions.length === 0 ? (
+          <DropdownMenuItem disabled>No versions available</DropdownMenuItem>
+        ) : (
+          <DropdownMenuRadioGroup value={currentVideoId}>
+            {versions.map((version) => (
+              <VersionSelectorOption
+                key={version._id}
+                version={version}
+                teamSlug={teamSlug}
+                currentVideoId={currentVideoId}
+                onSelect={onSelect}
+              />
+            ))}
+          </DropdownMenuRadioGroup>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
 
 export default function VideoPage() {
   const params = useParams({ strict: false });
@@ -56,6 +188,7 @@ export default function VideoPage() {
     resolvedProjectId,
     resolvedVideoId,
     video,
+    versions,
     comments,
     commentsThreaded,
   } = useVideoData({
@@ -65,10 +198,12 @@ export default function VideoPage() {
   });
   const updateVideo = useMutation(api.videos.update);
   const updateVideoWorkflowStatus = useMutation(api.videos.updateWorkflowStatus);
+  const deleteVideo = useMutation(api.videos.remove);
   const checkMuxAssetStatus = useAction(api.videoActions.checkMuxAssetStatus);
   const getPlaybackSession = useAction(api.videoActions.getPlaybackSession);
   const getOriginalPlaybackUrl = useAction(api.videoActions.getOriginalPlaybackUrl);
   const getDownloadUrl = useAction(api.videoActions.getDownloadUrl);
+  const { requestVersionUpload } = useDashboardUploadContext();
 
   const [currentTime, setCurrentTime] = useState(0);
   const [isEditingTitle, setIsEditingTitle] = useState(false);
@@ -263,6 +398,58 @@ export default function VideoPage() {
     [resolvedVideoId, updateVideoWorkflowStatus],
   );
 
+  const handleVersionSelected = useCallback(
+    (selectedVideoId: Id<"videos">) => {
+      if (!resolvedProjectId || selectedVideoId === resolvedVideoId) return;
+      navigate({
+        to: videoPath(resolvedTeamSlug, resolvedProjectId, selectedVideoId),
+      });
+    },
+    [navigate, resolvedProjectId, resolvedTeamSlug, resolvedVideoId],
+  );
+
+  const handleNewVersionSelected = useCallback(
+    (files: File[]) => {
+      const file = files[0];
+      if (!file || !resolvedVideoId || !resolvedProjectId) return;
+      requestVersionUpload(
+        resolvedVideoId,
+        video?.versionStackId ?? resolvedVideoId,
+        resolvedProjectId,
+        file,
+      );
+    },
+    [requestVersionUpload, resolvedProjectId, resolvedVideoId, video?.versionStackId],
+  );
+
+  const handleDeleteVersion = useCallback(async () => {
+    if (!video || !resolvedVideoId || !resolvedProjectId) return;
+    if (
+      !window.confirm(
+        `Delete ${video.isLatestVersion ? "the latest" : "the current"} version (v${video.versionNumber})? Its comments and share links will be deleted.${video.isLatestVersion ? " The previous version will become latest." : ""}`,
+      )
+    ) {
+      return;
+    }
+
+    try {
+      const result = await deleteVideo({ videoId: resolvedVideoId });
+      if (result.replacementVideoId) {
+        navigate({
+          to: videoPath(resolvedTeamSlug, resolvedProjectId, result.replacementVideoId),
+          replace: true,
+        });
+      } else {
+        navigate({
+          to: projectPath(resolvedTeamSlug, resolvedProjectId),
+          replace: true,
+        });
+      }
+    } catch (error) {
+      console.error("Failed to delete video version:", error);
+    }
+  }, [deleteVideo, navigate, resolvedProjectId, resolvedTeamSlug, resolvedVideoId, video]);
+
   const startEditingTitle = () => {
     if (video) {
       setEditedTitle(video.title);
@@ -287,6 +474,7 @@ export default function VideoPage() {
   }
 
   const canEdit = video.role !== "viewer";
+  const canDelete = video.role === "owner" || video.role === "admin";
   const canComment = true;
 
   return (
@@ -355,7 +543,7 @@ export default function VideoPage() {
         ]}
       >
         {/* Desktop: inline actions */}
-        <div className="hidden items-center gap-3 text-xs text-[#888] sm:flex">
+        <div className="hidden items-center gap-3 text-xs text-[#888] 2xl:flex">
           <span className="max-w-[100px] truncate">{video.uploaderName}</span>
           {video.duration && (
             <>
@@ -365,33 +553,24 @@ export default function VideoPage() {
           )}
           <VideoWatchers watchers={watchers} />
         </div>
-        <div className="ml-1 hidden flex-shrink-0 items-center gap-3 border-l-2 border-[#1a1a1a]/20 pl-3 sm:flex">
-          <VideoWorkflowStatusControl
-            status={video.workflowStatus}
-            size="lg"
-            disabled={!canEdit}
-            onChange={(workflowStatus) => {
-              void handleUpdateWorkflowStatus(workflowStatus);
-            }}
+        <div className="ml-1 hidden flex-shrink-0 items-center gap-3 border-l-2 border-[#1a1a1a]/20 pl-3 lg:flex">
+          <VersionSelector
+            versions={versions}
+            currentVideoId={resolvedVideoId}
+            currentVersionNumber={video.versionNumber}
+            teamSlug={resolvedTeamSlug}
+            onSelect={handleVersionSelected}
           />
-          <Button variant="outline" onClick={() => setShareDialogOpen(true)}>
-            <LinkIcon className="mr-1.5 h-4 w-4" />
-            Share
-          </Button>
-          <Button
-            variant="outline"
-            className="lg:hidden"
-            onClick={() => setMobileCommentsOpen(true)}
-          >
-            <MessageSquare className="h-4 w-4" />
-            {comments && comments.length > 0 && (
-              <span className="ml-1 text-xs">{comments.length}</span>
-            )}
-          </Button>
-        </div>
-
-        {/* Mobile: workflow status + menu button */}
-        <div className="flex items-center gap-2 sm:hidden">
+          {canEdit && (
+            <UploadButton
+              multiple={false}
+              variant="outline"
+              onFilesSelected={handleNewVersionSelected}
+            >
+              <Upload className="h-4 w-4" />
+              New version
+            </UploadButton>
+          )}
           <VideoWorkflowStatusControl
             status={video.workflowStatus}
             size="lg"
@@ -402,8 +581,71 @@ export default function VideoPage() {
           />
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="icon" className="h-8 w-8">
-                <MoreVertical className="h-4 w-4" />
+              <Button variant="outline" size="icon" aria-label="More video actions">
+                <MoreVertical className="h-4 w-4" aria-hidden="true" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onSelect={() => setShareDialogOpen(true)}>
+                <LinkIcon className="mr-2 h-4 w-4" />
+                Share
+              </DropdownMenuItem>
+              <DropdownMenuItem className="xl:hidden" onSelect={() => setMobileCommentsOpen(true)}>
+                <MessageSquare className="mr-2 h-4 w-4" />
+                Comments{comments && comments.length > 0 ? ` (${comments.length})` : ""}
+              </DropdownMenuItem>
+              {canDelete && (
+                <DropdownMenuItem
+                  className="text-[#dc2626] focus:text-[#dc2626]"
+                  onSelect={() => void handleDeleteVersion()}
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  {`Delete ${video.isLatestVersion ? "latest" : "current"} version (v${video.versionNumber})`}
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+
+        {/* Compact: workflow status + consolidated menu until large screens */}
+        <div className="flex items-center gap-2 lg:hidden">
+          <VersionSelector
+            versions={versions}
+            currentVideoId={resolvedVideoId}
+            currentVersionNumber={video.versionNumber}
+            teamSlug={resolvedTeamSlug}
+            onSelect={handleVersionSelected}
+            compact
+          />
+          <VideoWorkflowStatusControl
+            status={video.workflowStatus}
+            size="lg"
+            disabled={!canEdit}
+            onChange={(workflowStatus) => {
+              void handleUpdateWorkflowStatus(workflowStatus);
+            }}
+          />
+          {canEdit && (
+            <UploadButton
+              multiple={false}
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              onFilesSelected={handleNewVersionSelected}
+            >
+              <Upload className="h-4 w-4" />
+              <span className="sr-only">Upload new version</span>
+            </UploadButton>
+          )}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-8 w-8"
+                aria-label="More video actions"
+              >
+                <MoreVertical className="h-4 w-4" aria-hidden="true" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
@@ -415,6 +657,15 @@ export default function VideoPage() {
                 <MessageSquare className="mr-2 h-4 w-4" />
                 Comments{comments && comments.length > 0 ? ` (${comments.length})` : ""}
               </DropdownMenuItem>
+              {canDelete && (
+                <DropdownMenuItem
+                  className="text-[#dc2626] focus:text-[#dc2626]"
+                  onSelect={() => void handleDeleteVersion()}
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  {`Delete ${video.isLatestVersion ? "latest" : "current"} version (v${video.versionNumber})`}
+                </DropdownMenuItem>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         </div>

--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,7 @@
         "video.js": "^8.23.4",
       },
       "devDependencies": {
+        "@edge-runtime/vm": "^5.0.0",
         "@eslint/js": "^9.34.0",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
@@ -49,6 +50,7 @@
         "@types/video.js": "^7.3.58",
         "@vitejs/plugin-react": "^5.1.0",
         "concurrently": "^9.2.1",
+        "convex-test": "^0.0.53",
         "eslint": "^9",
         "prettier": "^3.8.4",
         "prettier-plugin-tailwindcss": "^0.8.0",
@@ -59,6 +61,7 @@
         "typescript-eslint": "^8.41.0",
         "vite": "^7.1.7",
         "vite-tsconfig-paths": "^5.1.4",
+        "vitest": "^4.1.9",
       },
     },
   },
@@ -212,6 +215,10 @@
     "@convex-dev/rate-limiter": ["@convex-dev/rate-limiter@0.3.2", "", { "peerDependencies": { "convex": "^1.24.8", "react": "^18.2.0 || ^19.0.0" }, "optionalPeers": ["react"] }, "sha512-+oBPsBfFbzdxiF/9XaaTQmVnvDlvEfg/c69/v8LxTbw4VLuiflIKlfnPQL8OS0azXQQ11hcPWHmU8ytFmHKDXA=="],
 
     "@convex-dev/stripe": ["@convex-dev/stripe@0.1.4", "", { "dependencies": { "stripe": "^20.0.0" }, "peerDependencies": { "convex": "^1.29.3", "react": "^18.3.1 || ^19.0.0" } }, "sha512-HnINm3K2QHGvP0X4YV7KruCjQ1Ni0HE1qpJ5rZYjfdUbMcqJsX4ZYTmOo7tL83qtokS3EahKVkhXLCH/9Ms/og=="],
+
+    "@edge-runtime/primitives": ["@edge-runtime/primitives@6.0.0", "", {}, "sha512-FqoxaBT+prPBHBwE1WXS1ocnu/VLTQyZ6NMUBAdbP7N2hsFTTxMC/jMu2D/8GAlMQfxeuppcPuCUk/HO3fpIvA=="],
+
+    "@edge-runtime/vm": ["@edge-runtime/vm@5.0.0", "", { "dependencies": { "@edge-runtime/primitives": "6.0.0" } }, "sha512-NKBGBSIKUG584qrS1tyxVpX/AKJKQw5HgjYEnPLC0QsTw79JrGn+qUr8CXFb955Iy7GUdiiUv1rJ6JBGvaKb6w=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
@@ -601,6 +608,8 @@
 
     "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@stripe/stripe-js": ["@stripe/stripe-js@8.7.0", "", {}, "sha512-tNUerSstwNC1KuHgX4CASGO0Md3CB26IJzSXmVlSuFvhsBP4ZaEPpY4jxWOn9tfdDscuVT4Kqb8cZ2o9nLCgRQ=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.1.18", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "enhanced-resolve": "^5.18.3", "jiti": "^2.6.1", "lightningcss": "1.30.2", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.1.18" } }, "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ=="],
@@ -679,6 +688,10 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
@@ -723,6 +736,20 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.1.4", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA=="],
 
+    "@vitest/expect": ["@vitest/expect@4.1.9", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.9", "", { "dependencies": { "@vitest/spy": "4.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.9", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.9", "", { "dependencies": { "@vitest/utils": "4.1.9", "pathe": "^2.0.3" } }, "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "@vitest/utils": "4.1.9", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.9", "", {}, "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA=="],
+
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.11", "", {}, "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
@@ -748,6 +775,8 @@
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
@@ -783,6 +812,8 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001766", "", {}, "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA=="],
 
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "cheerio": ["cheerio@1.2.0", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.1", "htmlparser2": "^10.1.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.19.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg=="],
@@ -810,6 +841,8 @@
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "convex": ["convex@1.41.0", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.20.1" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-euxVf6yfpB7/VGKOobkLgjpbJidsUgW+b0ezonEyCUPqlpHFwR4/yIiI1hjjErzraiw91GxrtxpXQClMLNqU+w=="],
+
+    "convex-test": ["convex-test@0.0.53", "", { "peerDependencies": { "convex": "^1.32.0" } }, "sha512-bouZQTnTvZi8IHljHL++yClj1vcV+/9ZxEcd8JZz7RDxOfPkRKrkMgkk/xlX4M1EAiwcEJPNiQE7VJFvDM3lCQ=="],
 
     "cookie-es": ["cookie-es@2.0.0", "", {}, "sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg=="],
 
@@ -873,6 +906,8 @@
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
+    "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
+
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
@@ -901,9 +936,13 @@
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
 
@@ -1103,6 +1142,8 @@
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
+    "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
+
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
@@ -1197,15 +1238,19 @@
 
     "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "srvx": ["srvx@0.11.5", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-MbQgu/gbLcXjg1bhUhPXXOpeMfmDMTGSKPWeht5acXnlQNldD925eS4+bIH/qESecSkP71dU3Fmvunlai1+yzw=="],
 
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
     "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
 
-    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -1235,7 +1280,13 @@
 
     "tiny-warning": ["tiny-warning@1.0.3", "", {}, "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -1291,6 +1342,8 @@
 
     "vitefu": ["vitefu@1.1.1", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ=="],
 
+    "vitest": ["vitest@4.1.9", "", { "dependencies": { "@vitest/expect": "4.1.9", "@vitest/mocker": "4.1.9", "@vitest/pretty-format": "4.1.9", "@vitest/runner": "4.1.9", "@vitest/snapshot": "4.1.9", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.9", "@vitest/browser-preview": "4.1.9", "@vitest/browser-webdriverio": "4.1.9", "@vitest/coverage-istanbul": "4.1.9", "@vitest/coverage-v8": "4.1.9", "@vitest/ui": "4.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ=="],
+
     "web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
@@ -1304,6 +1357,8 @@
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
@@ -1358,6 +1413,8 @@
     "@babel/template/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
 
     "@clerk/shared/csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
+    "@clerk/shared/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -128,7 +128,9 @@ async function folderCounts(
 ): Promise<{ videoCount: number; subfolderCount: number }> {
   const videos = await ctx.db
     .query("videos")
-    .withIndex("by_project", (q) => q.eq("projectId", project._id))
+    .withIndex("by_project_and_superseded_by_video_id", (q) =>
+      q.eq("projectId", project._id).eq("supersededByVideoId", undefined),
+    )
     .collect();
   const subfolders = await ctx.db
     .query("projects")

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -92,8 +92,16 @@ export default defineSchema({
       v.literal("failed"),
     ),
     workflowStatus: v.union(v.literal("review"), v.literal("rework"), v.literal("done")),
+    // Existing rows are implicit v1 videos. These fields are materialized when
+    // the first additional version is created, so no backfill is required.
+    versionStackId: v.optional(v.id("videos")),
+    versionNumber: v.optional(v.number()),
+    supersededByVideoId: v.optional(v.id("videos")),
   })
     .index("by_project", ["projectId"])
+    .index("by_project_and_superseded_by_video_id", ["projectId", "supersededByVideoId"])
+    .index("by_version_stack_id_and_version_number", ["versionStackId", "versionNumber"])
+    .index("by_superseded_by_video_id", ["supersededByVideoId"])
     .index("by_public_id", ["publicId"])
     .index("by_mux_upload_id", ["muxUploadId"])
     .index("by_mux_asset_id", ["muxAssetId"])

--- a/convex/teams.ts
+++ b/convex/teams.ts
@@ -131,7 +131,9 @@ export const listWithProjects = query({
           projects.map(async (project) => {
             const videos = await ctx.db
               .query("videos")
-              .withIndex("by_project", (q) => q.eq("projectId", project._id))
+              .withIndex("by_project_and_superseded_by_video_id", (q) =>
+                q.eq("projectId", project._id).eq("supersededByVideoId", undefined),
+              )
               .collect();
             const subfolders = await ctx.db
               .query("projects")

--- a/convex/videoActions.ts
+++ b/convex/videoActions.ts
@@ -658,7 +658,7 @@ export const completeMultipartUpload = action({
       });
     } catch (error) {
       try {
-        if (completed && shouldDeleteUploadedObjectOnFailure(error)) {
+        if (completed) {
           await deleteUploadedObject(video.s3Key);
         } else if (!completed) {
           await abortMultipartUploadSession({
@@ -670,12 +670,9 @@ export const completeMultipartUpload = action({
         // Preserve the original completion, validation, or reconciliation failure.
       }
 
-      await ctx.runMutation(internal.videos.markAsFailed, {
+      await ctx.runMutation(internal.videos.finalizeAbandonedUpload, {
         videoId: args.videoId,
         uploadError: error instanceof Error ? error.message : "Upload failed after completion.",
-      });
-      await ctx.runMutation(internal.videos.clearMultipartUploadId, {
-        videoId: args.videoId,
       });
       throw error;
     }
@@ -695,19 +692,20 @@ export const abortVideoUpload = action({
     await requireVideoMemberAccess(ctx, args.videoId);
     const video = await getVideoForUpload(ctx, args.videoId);
 
-    if (video.s3Key && video.s3MultipartUploadId) {
-      await abortMultipartUploadSession({
-        key: video.s3Key,
-        uploadId: video.s3MultipartUploadId,
-      });
-    } else if (video.s3Key) {
-      await deleteUploadedObject(video.s3Key);
+    try {
+      if (video.s3Key && video.s3MultipartUploadId) {
+        await abortMultipartUploadSession({
+          key: video.s3Key,
+          uploadId: video.s3MultipartUploadId,
+        });
+      } else if (video.s3Key) {
+        await deleteUploadedObject(video.s3Key);
+      }
+    } catch (error) {
+      console.error("Failed to clean up cancelled upload storage", args.videoId, error);
     }
 
-    await ctx.runMutation(internal.videos.clearUploadStorageInfo, {
-      videoId: args.videoId,
-    });
-    await ctx.runMutation(internal.videos.markAsFailed, {
+    await ctx.runMutation(internal.videos.finalizeAbandonedUpload, {
       videoId: args.videoId,
       uploadError: "Upload cancelled.",
     });
@@ -843,13 +841,17 @@ export const markUploadComplete = action({
         shouldDeleteObject && error instanceof Error
           ? error.message
           : "Mux ingest failed after upload.";
+      if (shouldDeleteObject) {
+        await ctx.runMutation(internal.videos.finalizeAbandonedUpload, {
+          videoId: args.videoId,
+          uploadError,
+        });
+        throw error;
+      }
       await ctx.runMutation(internal.videos.markAsFailed, {
         videoId: args.videoId,
         uploadError,
       });
-      if (shouldDeleteObject) {
-        throw error;
-      }
       throw new Error("Mux ingest failed after upload. Retry processing without re-uploading.");
     }
 
@@ -868,19 +870,20 @@ export const markUploadFailed = action({
     await requireVideoMemberAccess(ctx, args.videoId);
     const video = await getVideoForUpload(ctx, args.videoId);
 
-    if (video.s3Key && video.s3MultipartUploadId) {
-      await abortMultipartUploadSession({
-        key: video.s3Key,
-        uploadId: video.s3MultipartUploadId,
-      });
-    } else if (video.s3Key) {
-      await deleteUploadedObject(video.s3Key);
+    try {
+      if (video.s3Key && video.s3MultipartUploadId) {
+        await abortMultipartUploadSession({
+          key: video.s3Key,
+          uploadId: video.s3MultipartUploadId,
+        });
+      } else if (video.s3Key) {
+        await deleteUploadedObject(video.s3Key);
+      }
+    } catch (error) {
+      console.error("Failed to clean up permanently failed upload storage", args.videoId, error);
     }
-    await ctx.runMutation(internal.videos.clearUploadStorageInfo, {
-      videoId: args.videoId,
-    });
 
-    await ctx.runMutation(internal.videos.markAsFailed, {
+    await ctx.runMutation(internal.videos.finalizeAbandonedUpload, {
       videoId: args.videoId,
       uploadError: "Upload failed before Mux could process the asset.",
     });
@@ -910,14 +913,15 @@ export const sweepStaleUploads = internalAction({
       if (!claimed) continue;
 
       try {
-        await abortMultipartUploadSession({
-          key: claimed.key,
-          uploadId: claimed.uploadId,
-        });
+        if (claimed.storage.kind === "multipart") {
+          await abortMultipartUploadSession({
+            key: claimed.storage.key,
+            uploadId: claimed.storage.uploadId,
+          });
+        } else if (claimed.storage.kind === "object") {
+          await deleteUploadedObject(claimed.storage.key);
+        }
 
-        await ctx.runMutation(internal.videos.clearUploadStorageInfo, {
-          videoId: candidate.videoId,
-        });
         reclaimed += 1;
       } catch (error) {
         console.error("Failed to reclaim stale upload", candidate.videoId, error);

--- a/convex/videoPresence.ts
+++ b/convex/videoPresence.ts
@@ -205,7 +205,9 @@ export const listProjectOnlineCounts = query({
 
     const videos = await ctx.db
       .query("videos")
-      .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
+      .withIndex("by_project_and_superseded_by_video_id", (q) =>
+        q.eq("projectId", args.projectId).eq("supersededByVideoId", undefined),
+      )
       .collect();
 
     const counts: Record<string, number> = {};

--- a/convex/videoVersions.vitest.ts
+++ b/convex/videoVersions.vitest.ts
@@ -3,6 +3,7 @@
 import { convexTest } from "convex-test";
 import { expect, test } from "vitest";
 import { api, internal } from "./_generated/api";
+import { getTeamStorageUsedBytes } from "./billingHelpers";
 import { createVersionRecord, MAX_VIDEO_STACK_SIZE } from "./videos";
 import schema from "./schema";
 
@@ -104,6 +105,121 @@ test("materializes v1 and appends after the actual latest version", async () => 
   expect(visible.map((video) => [video._id, video.versionNumber])).toEqual([[v3, 3]]);
 });
 
+test("selects the stack head independently of version number ordering", async () => {
+  const t = convexTest(schema, modules);
+  const seeded = await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "owner",
+      plan: "basic",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Campaign",
+    });
+    const v1 = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      title: "Cut",
+      visibility: "public",
+      publicId: "head-v1",
+      status: "ready",
+      workflowStatus: "review",
+    });
+    return { v1 };
+  });
+
+  const { videoId: v2 } = await t.run((ctx) =>
+    createVersionRecord(ctx, {
+      sourceVideoId: seeded.v1,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      publicId: "head-v2",
+    }),
+  );
+  const { videoId: v3 } = await t.run((ctx) =>
+    createVersionRecord(ctx, {
+      sourceVideoId: seeded.v1,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      publicId: "head-v3",
+    }),
+  );
+  await t.run((ctx) => ctx.db.patch(v2, { versionNumber: 99 }));
+
+  const { videoId: v4 } = await t.run((ctx) =>
+    createVersionRecord(ctx, {
+      sourceVideoId: v2,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      publicId: "head-v4",
+    }),
+  );
+
+  const state = await t.run(async (ctx) => ({
+    v2: await ctx.db.get(v2),
+    v3: await ctx.db.get(v3),
+    v4: await ctx.db.get(v4),
+  }));
+  expect(state.v2?.supersededByVideoId).toBe(v3);
+  expect(state.v3?.supersededByVideoId).toBe(v4);
+  expect(state.v4?.versionNumber).toBe(4);
+});
+
+test("rejects a stack with more than one head", async () => {
+  const t = convexTest(schema, modules);
+  const seeded = await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "owner",
+      plan: "basic",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Campaign",
+    });
+    const v1 = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      title: "Cut",
+      visibility: "public",
+      publicId: "multi-head-v1",
+      status: "ready",
+      workflowStatus: "review",
+      versionNumber: 1,
+    });
+    await ctx.db.patch(v1, { versionStackId: v1 });
+    const v2 = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      title: "Cut",
+      visibility: "public",
+      publicId: "multi-head-v2",
+      status: "ready",
+      workflowStatus: "review",
+      versionStackId: v1,
+      versionNumber: 2,
+    });
+    return { v1, v2 };
+  });
+
+  await expect(
+    t.run((ctx) =>
+      createVersionRecord(ctx, {
+        sourceVideoId: seeded.v1,
+        uploadedByClerkId: "owner",
+        uploaderName: "Owner",
+        publicId: "multi-head-v3",
+      }),
+    ),
+  ).rejects.toThrow("exactly one latest version");
+});
+
 test("moves the whole stack and rewires middle and latest deletions", async () => {
   const t = convexTest(schema, modules);
   const seeded = await t.run(async (ctx) => {
@@ -195,6 +311,64 @@ test("moves the whole stack and rewires middle and latest deletions", async () =
   expect(visible.map((video) => [video._id, video.versionNumber])).toEqual([[seeded.v1, 1]]);
 });
 
+test("refuses to move a stack whose versions do not share the source project", async () => {
+  const t = convexTest(schema, modules);
+  const seeded = await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "owner",
+      plan: "basic",
+    });
+    await ctx.db.insert("teamMembers", {
+      teamId,
+      userClerkId: "owner",
+      userEmail: "owner@example.com",
+      userName: "Owner",
+      role: "owner",
+    });
+    const sourceProjectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Source",
+    });
+    const mismatchedProjectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Mismatched",
+    });
+    const destinationProjectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Destination",
+    });
+    const v1 = await ctx.db.insert("videos", {
+      projectId: sourceProjectId,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      title: "Cut",
+      visibility: "public",
+      publicId: "mismatch-v1",
+      status: "ready",
+      workflowStatus: "review",
+    });
+    return { sourceProjectId, mismatchedProjectId, destinationProjectId, v1 };
+  });
+  const { videoId: v2 } = await t.run((ctx) =>
+    createVersionRecord(ctx, {
+      sourceVideoId: seeded.v1,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      publicId: "mismatch-v2",
+    }),
+  );
+  await t.run((ctx) => ctx.db.patch(seeded.v1, { projectId: seeded.mismatchedProjectId }));
+
+  await expect(
+    t.withIdentity({ subject: "owner" }).mutation(api.videos.move, {
+      videoId: v2,
+      projectId: seeded.destinationProjectId,
+    }),
+  ).rejects.toThrow("must belong to the same project");
+});
+
 test("deleting the first version preserves the remaining stack", async () => {
   const t = convexTest(schema, modules);
   const seeded = await t.run(async (ctx) => {
@@ -257,6 +431,95 @@ test("deleting the first version preserves the remaining stack", async () => {
 
   const visible = await authed.query(api.videos.list, { projectId: seeded.projectId });
   expect(visible.map((video) => video._id)).toEqual([v3]);
+});
+
+test("deletes an unstacked legacy video with no replacement", async () => {
+  const t = convexTest(schema, modules);
+  const videoId = await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "owner",
+      plan: "basic",
+    });
+    await ctx.db.insert("teamMembers", {
+      teamId,
+      userClerkId: "owner",
+      userEmail: "owner@example.com",
+      userName: "Owner",
+      role: "owner",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Campaign",
+    });
+    return await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      title: "Legacy cut",
+      visibility: "public",
+      publicId: "legacy-only",
+      status: "ready",
+      workflowStatus: "review",
+    });
+  });
+
+  const result = await t
+    .withIdentity({ subject: "owner" })
+    .mutation(api.videos.remove, { videoId });
+  expect(result.replacementVideoId).toBeNull();
+  await expect(t.run((ctx) => ctx.db.get(videoId))).resolves.toBeNull();
+});
+
+test("storage counts every stored version while project lists only the head", async () => {
+  const t = convexTest(schema, modules);
+  const seeded = await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "owner",
+      plan: "basic",
+    });
+    await ctx.db.insert("teamMembers", {
+      teamId,
+      userClerkId: "owner",
+      userEmail: "owner@example.com",
+      userName: "Owner",
+      role: "owner",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Campaign",
+    });
+    const v1 = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      title: "Cut",
+      visibility: "public",
+      publicId: "storage-v1",
+      fileSize: 100,
+      status: "ready",
+      workflowStatus: "review",
+    });
+    return { teamId, projectId, v1 };
+  });
+  const { videoId: v2 } = await t.run((ctx) =>
+    createVersionRecord(ctx, {
+      sourceVideoId: seeded.v1,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      publicId: "storage-v2",
+      fileSize: 200,
+    }),
+  );
+
+  await expect(t.run((ctx) => getTeamStorageUsedBytes(ctx, seeded.teamId))).resolves.toBe(300);
+  const listed = await t
+    .withIdentity({ subject: "owner" })
+    .query(api.videos.list, { projectId: seeded.projectId });
+  expect(listed.map((video) => video._id)).toEqual([v2]);
 });
 
 test("public version paths enforce authentication and member authorization", async () => {
@@ -374,6 +637,184 @@ test("abandoned version uploads atomically restore the previous head", async () 
     .withIdentity({ subject: "owner" })
     .query(api.videos.list, { projectId: seeded.projectId });
   expect(visible.map((video) => video._id)).toEqual([seeded.v1]);
+});
+
+test("hard failure after promotion rolls back a version before a Mux asset exists", async () => {
+  const t = convexTest(schema, modules);
+  const seeded = await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "owner",
+      plan: "basic",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Campaign",
+    });
+    const v1 = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      title: "Cut",
+      visibility: "public",
+      publicId: "promoted-v1",
+      status: "ready",
+      workflowStatus: "review",
+    });
+    return { v1 };
+  });
+  const { videoId: v2 } = await t.run((ctx) =>
+    createVersionRecord(ctx, {
+      sourceVideoId: seeded.v1,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      publicId: "promoted-v2",
+    }),
+  );
+  await t.mutation(internal.videos.markAsProcessing, { videoId: v2 });
+
+  const result = await t.mutation(internal.videos.finalizeAbandonedUpload, {
+    videoId: v2,
+    uploadError: "Uploaded object failed validation.",
+  });
+  expect(result.removedVersion).toBe(true);
+
+  const state = await t.run(async (ctx) => ({
+    v1: await ctx.db.get(seeded.v1),
+    v2: await ctx.db.get(v2),
+  }));
+  expect(state.v2).toBeNull();
+  expect(state.v1?.supersededByVideoId).toBeUndefined();
+});
+
+test("failure after Mux promotion stays retryable as the latest version", async () => {
+  const t = convexTest(schema, modules);
+  const seeded = await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "owner",
+      plan: "basic",
+    });
+    await ctx.db.insert("teamMembers", {
+      teamId,
+      userClerkId: "owner",
+      userEmail: "owner@example.com",
+      userName: "Owner",
+      role: "owner",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Campaign",
+    });
+    const v1 = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      title: "Cut",
+      visibility: "public",
+      publicId: "retryable-v1",
+      status: "ready",
+      workflowStatus: "review",
+    });
+    return { projectId, v1 };
+  });
+  const { videoId: v2 } = await t.run((ctx) =>
+    createVersionRecord(ctx, {
+      sourceVideoId: seeded.v1,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      publicId: "retryable-v2",
+    }),
+  );
+  await t.run((ctx) =>
+    ctx.db.patch(v2, {
+      s3Key: "videos/retryable-v2/cut.mp4",
+      status: "processing",
+      muxAssetId: "mux-asset-v2",
+    }),
+  );
+
+  const updated = await t.mutation(internal.videos.markMuxAssetAsFailed, {
+    videoId: v2,
+    muxAssetId: "mux-asset-v2",
+    uploadError: "Mux could not encode this asset.",
+  });
+  expect(updated).toBe(true);
+
+  const state = await t.run(async (ctx) => ({
+    v1: await ctx.db.get(seeded.v1),
+    v2: await ctx.db.get(v2),
+  }));
+  expect(state.v1?.supersededByVideoId).toBe(v2);
+  expect(state.v2).toMatchObject({
+    status: "failed",
+    s3Key: "videos/retryable-v2/cut.mp4",
+  });
+
+  const listed = await t
+    .withIdentity({ subject: "owner" })
+    .query(api.videos.list, { projectId: seeded.projectId });
+  expect(listed.map((video) => video._id)).toEqual([v2]);
+});
+
+test("abandoned upload with a Mux asset exercises the kept-as-failed branch", async () => {
+  const t = convexTest(schema, modules);
+  const videoId = await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "owner",
+      plan: "basic",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Campaign",
+    });
+    const v1 = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      title: "Cut",
+      visibility: "public",
+      publicId: "kept-v1",
+      status: "ready",
+      workflowStatus: "review",
+      versionNumber: 1,
+    });
+    await ctx.db.patch(v1, { versionStackId: v1 });
+    const v2 = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      title: "Cut",
+      visibility: "public",
+      publicId: "kept-v2",
+      status: "processing",
+      workflowStatus: "review",
+      versionStackId: v1,
+      versionNumber: 2,
+      muxAssetId: "mux-asset",
+      s3Key: "videos/kept-v2/cut.mp4",
+    });
+    await ctx.db.patch(v1, { supersededByVideoId: v2 });
+    return v2;
+  });
+
+  const result = await t.mutation(internal.videos.finalizeAbandonedUpload, {
+    videoId,
+    uploadError: "Permanent processing failure.",
+  });
+  expect(result.removedVersion).toBe(false);
+
+  const failed = await t.run((ctx) => ctx.db.get(videoId));
+  expect(failed).toMatchObject({
+    status: "failed",
+    muxAssetStatus: "errored",
+    uploadError: "Permanent processing failure.",
+  });
+  expect(failed?.s3Key).toBeUndefined();
 });
 
 test("stale provisional versions roll back even before storage is initiated", async () => {

--- a/convex/videoVersions.vitest.ts
+++ b/convex/videoVersions.vitest.ts
@@ -1,0 +1,600 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { expect, test } from "vitest";
+import { api, internal } from "./_generated/api";
+import { createVersionRecord, MAX_VIDEO_STACK_SIZE } from "./videos";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+test("materializes v1 and appends after the actual latest version", async () => {
+  const t = convexTest(schema, modules);
+  const seeded = await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "user_1",
+      plan: "basic",
+    });
+    await ctx.db.insert("teamMembers", {
+      teamId,
+      userClerkId: "user_1",
+      userEmail: "owner@example.com",
+      userName: "Owner",
+      role: "admin",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Campaign",
+    });
+    const videoId = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "user_1",
+      uploaderName: "Owner",
+      title: "First cut",
+      description: "Original notes",
+      visibility: "public",
+      publicId: "public-v1",
+      status: "ready",
+      workflowStatus: "done",
+    });
+    return { projectId, videoId };
+  });
+
+  const { videoId: v2 } = await t.run((ctx) =>
+    createVersionRecord(ctx, {
+      sourceVideoId: seeded.videoId,
+      uploadedByClerkId: "user_1",
+      uploaderName: "Owner",
+      publicId: "public-v2",
+      fileSize: 200,
+      contentType: "video/mp4",
+    }),
+  );
+  await t.run(async (ctx) => {
+    await ctx.db.patch(v2, {
+      title: "Second cut",
+      description: "Latest notes",
+      visibility: "private",
+      workflowStatus: "done",
+    });
+  });
+
+  const { videoId: v3 } = await t.run((ctx) =>
+    createVersionRecord(ctx, {
+      sourceVideoId: seeded.videoId,
+      uploadedByClerkId: "user_1",
+      uploaderName: "Owner",
+      publicId: "public-v3",
+      fileSize: 300,
+      contentType: "video/quicktime",
+    }),
+  );
+
+  const documents = await t.run(async (ctx) => ({
+    v1: await ctx.db.get(seeded.videoId),
+    v2: await ctx.db.get(v2),
+    v3: await ctx.db.get(v3),
+  }));
+
+  expect(documents.v1).toMatchObject({
+    versionStackId: seeded.videoId,
+    versionNumber: 1,
+    supersededByVideoId: v2,
+  });
+  expect(documents.v2).toMatchObject({
+    versionStackId: seeded.videoId,
+    versionNumber: 2,
+    supersededByVideoId: v3,
+  });
+  expect(documents.v3).toMatchObject({
+    versionStackId: seeded.videoId,
+    versionNumber: 3,
+    title: "Second cut",
+    description: "Latest notes",
+    visibility: "private",
+    workflowStatus: "review",
+    projectId: seeded.projectId,
+  });
+
+  const visible = await t.withIdentity({ subject: "user_1" }).query(api.videos.list, {
+    projectId: seeded.projectId,
+  });
+  expect(visible.map((video) => [video._id, video.versionNumber])).toEqual([[v3, 3]]);
+});
+
+test("moves the whole stack and rewires middle and latest deletions", async () => {
+  const t = convexTest(schema, modules);
+  const seeded = await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "user_1",
+      plan: "basic",
+    });
+    await ctx.db.insert("teamMembers", {
+      teamId,
+      userClerkId: "user_1",
+      userEmail: "owner@example.com",
+      userName: "Owner",
+      role: "admin",
+    });
+    const sourceProjectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Source",
+    });
+    const destinationProjectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Destination",
+    });
+    const v1 = await ctx.db.insert("videos", {
+      projectId: sourceProjectId,
+      uploadedByClerkId: "user_1",
+      uploaderName: "Owner",
+      title: "Cut",
+      visibility: "public",
+      publicId: "move-v1",
+      status: "ready",
+      workflowStatus: "review",
+    });
+    return { sourceProjectId, destinationProjectId, v1 };
+  });
+
+  const { videoId: v2 } = await t.run((ctx) =>
+    createVersionRecord(ctx, {
+      sourceVideoId: seeded.v1,
+      uploadedByClerkId: "user_1",
+      uploaderName: "Owner",
+      publicId: "move-v2",
+    }),
+  );
+  const { videoId: v3 } = await t.run((ctx) =>
+    createVersionRecord(ctx, {
+      sourceVideoId: seeded.v1,
+      uploadedByClerkId: "user_1",
+      uploaderName: "Owner",
+      publicId: "move-v3",
+    }),
+  );
+
+  const authed = t.withIdentity({ subject: "user_1" });
+  await authed.mutation(api.videos.move, {
+    videoId: v2,
+    projectId: seeded.destinationProjectId,
+  });
+
+  const movedProjects = await t.run(async (ctx) =>
+    Promise.all([seeded.v1, v2, v3].map(async (videoId) => (await ctx.db.get(videoId))?.projectId)),
+  );
+  expect(movedProjects).toEqual([
+    seeded.destinationProjectId,
+    seeded.destinationProjectId,
+    seeded.destinationProjectId,
+  ]);
+
+  await authed.mutation(api.videos.remove, { videoId: v2 });
+  const afterMiddleDelete = await t.run(async (ctx) => ({
+    v1: await ctx.db.get(seeded.v1),
+    v2: await ctx.db.get(v2),
+    v3: await ctx.db.get(v3),
+  }));
+  expect(afterMiddleDelete.v2).toBeNull();
+  expect(afterMiddleDelete.v1?.supersededByVideoId).toBe(v3);
+  expect(afterMiddleDelete.v3?.supersededByVideoId).toBeUndefined();
+
+  const latestDelete = await authed.mutation(api.videos.remove, { videoId: v3 });
+  expect(latestDelete.replacementVideoId).toBe(seeded.v1);
+
+  const promoted = await t.run((ctx) => ctx.db.get(seeded.v1));
+  expect(promoted?.supersededByVideoId).toBeUndefined();
+
+  const visible = await authed.query(api.videos.list, {
+    projectId: seeded.destinationProjectId,
+  });
+  expect(visible.map((video) => [video._id, video.versionNumber])).toEqual([[seeded.v1, 1]]);
+});
+
+test("deleting the first version preserves the remaining stack", async () => {
+  const t = convexTest(schema, modules);
+  const seeded = await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "user_1",
+      plan: "basic",
+    });
+    await ctx.db.insert("teamMembers", {
+      teamId,
+      userClerkId: "user_1",
+      userEmail: "owner@example.com",
+      userName: "Owner",
+      role: "admin",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Campaign",
+    });
+    const v1 = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "user_1",
+      uploaderName: "Owner",
+      title: "Cut",
+      visibility: "public",
+      publicId: "first-v1",
+      status: "ready",
+      workflowStatus: "review",
+    });
+    return { projectId, v1 };
+  });
+
+  const { videoId: v2 } = await t.run((ctx) =>
+    createVersionRecord(ctx, {
+      sourceVideoId: seeded.v1,
+      uploadedByClerkId: "user_1",
+      uploaderName: "Owner",
+      publicId: "first-v2",
+    }),
+  );
+  const { videoId: v3 } = await t.run((ctx) =>
+    createVersionRecord(ctx, {
+      sourceVideoId: v2,
+      uploadedByClerkId: "user_1",
+      uploaderName: "Owner",
+      publicId: "first-v3",
+    }),
+  );
+
+  const authed = t.withIdentity({ subject: "user_1" });
+  const result = await authed.mutation(api.videos.remove, { videoId: seeded.v1 });
+  expect(result.replacementVideoId).toBe(v2);
+
+  const versions = await authed.query(api.videos.listVersions, { videoId: v2 });
+  expect(versions.map((version) => [version._id, version.versionNumber])).toEqual([
+    [v3, 3],
+    [v2, 2],
+  ]);
+
+  const visible = await authed.query(api.videos.list, { projectId: seeded.projectId });
+  expect(visible.map((video) => video._id)).toEqual([v3]);
+});
+
+test("public version paths enforce authentication and member authorization", async () => {
+  const t = convexTest(schema, modules);
+  const seeded = await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "owner",
+      plan: "basic",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Campaign",
+    });
+    const videoId = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      title: "Cut",
+      visibility: "public",
+      publicId: "auth-v1",
+      status: "ready",
+      workflowStatus: "review",
+    });
+    await ctx.db.insert("teamMembers", {
+      teamId,
+      userClerkId: "viewer",
+      userEmail: "viewer@example.com",
+      userName: "Viewer",
+      role: "viewer",
+    });
+    await ctx.db.insert("teamMembers", {
+      teamId,
+      userClerkId: "member",
+      userEmail: "member@example.com",
+      userName: "Member",
+      role: "member",
+    });
+    return { videoId };
+  });
+
+  await expect(t.query(api.videos.listVersions, { videoId: seeded.videoId })).rejects.toThrow(
+    "Not authenticated",
+  );
+  await expect(
+    t.withIdentity({ subject: "viewer" }).mutation(api.videos.createVersion, {
+      sourceVideoId: seeded.videoId,
+      fileSize: 1,
+      contentType: "video/mp4",
+    }),
+  ).rejects.toThrow("Requires member role or higher");
+
+  const versions = await t
+    .withIdentity({ subject: "member" })
+    .query(api.videos.listVersions, { videoId: seeded.videoId });
+  expect(versions).toHaveLength(1);
+});
+
+test("abandoned version uploads atomically restore the previous head", async () => {
+  const t = convexTest(schema, modules);
+  const seeded = await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "owner",
+      plan: "basic",
+    });
+    await ctx.db.insert("teamMembers", {
+      teamId,
+      userClerkId: "owner",
+      userEmail: "owner@example.com",
+      userName: "Owner",
+      role: "owner",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Campaign",
+    });
+    const v1 = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      title: "Cut",
+      visibility: "public",
+      publicId: "rollback-v1",
+      status: "ready",
+      workflowStatus: "done",
+    });
+    return { projectId, v1 };
+  });
+  const { videoId: v2 } = await t.run((ctx) =>
+    createVersionRecord(ctx, {
+      sourceVideoId: seeded.v1,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      publicId: "rollback-v2",
+    }),
+  );
+
+  const result = await t.mutation(internal.videos.finalizeAbandonedUpload, {
+    videoId: v2,
+    uploadError: "Upload cancelled.",
+  });
+  expect(result.removedVersion).toBe(true);
+
+  const state = await t.run(async (ctx) => ({
+    v1: await ctx.db.get(seeded.v1),
+    v2: await ctx.db.get(v2),
+  }));
+  expect(state.v2).toBeNull();
+  expect(state.v1?.supersededByVideoId).toBeUndefined();
+
+  const visible = await t
+    .withIdentity({ subject: "owner" })
+    .query(api.videos.list, { projectId: seeded.projectId });
+  expect(visible.map((video) => video._id)).toEqual([seeded.v1]);
+});
+
+test("stale provisional versions roll back even before storage is initiated", async () => {
+  const t = convexTest(schema, modules);
+  const seeded = await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "owner",
+      plan: "basic",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Campaign",
+    });
+    const v1 = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      title: "Cut",
+      visibility: "public",
+      publicId: "stale-v1",
+      status: "ready",
+      workflowStatus: "review",
+    });
+    return { v1 };
+  });
+  const { videoId: v2 } = await t.run((ctx) =>
+    createVersionRecord(ctx, {
+      sourceVideoId: seeded.v1,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      publicId: "stale-v2",
+    }),
+  );
+
+  const claimed = await t.mutation(internal.videos.claimStaleUpload, {
+    videoId: v2,
+    cutoff: Date.now() + 1000,
+  });
+  expect(claimed).toMatchObject({
+    storage: { kind: "none" },
+    removedVersion: true,
+  });
+
+  const state = await t.run(async (ctx) => ({
+    v1: await ctx.db.get(seeded.v1),
+    v2: await ctx.db.get(v2),
+  }));
+  expect(state.v2).toBeNull();
+  expect(state.v1?.supersededByVideoId).toBeUndefined();
+});
+
+test("concurrent version creation serializes into one ordered chain", async () => {
+  const t = convexTest(schema, modules);
+  const seeded = await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "owner",
+      plan: "basic",
+    });
+    await ctx.db.insert("teamMembers", {
+      teamId,
+      userClerkId: "owner",
+      userEmail: "owner@example.com",
+      userName: "Owner",
+      role: "owner",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Campaign",
+    });
+    const v1 = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      title: "Cut",
+      visibility: "public",
+      publicId: "concurrent-v1",
+      status: "ready",
+      workflowStatus: "review",
+    });
+    return { v1 };
+  });
+
+  await Promise.all([
+    t.run((ctx) =>
+      createVersionRecord(ctx, {
+        sourceVideoId: seeded.v1,
+        uploadedByClerkId: "owner",
+        uploaderName: "Owner",
+        publicId: "concurrent-a",
+      }),
+    ),
+    t.run((ctx) =>
+      createVersionRecord(ctx, {
+        sourceVideoId: seeded.v1,
+        uploadedByClerkId: "owner",
+        uploaderName: "Owner",
+        publicId: "concurrent-b",
+      }),
+    ),
+  ]);
+
+  const versions = await t
+    .withIdentity({ subject: "owner" })
+    .query(api.videos.listVersions, { videoId: seeded.v1 });
+  expect(versions.map((version) => version.versionNumber)).toEqual([3, 2, 1]);
+
+  const chain = await t.run(async (ctx) => {
+    const rows = await ctx.db
+      .query("videos")
+      .withIndex("by_version_stack_id_and_version_number", (q) => q.eq("versionStackId", seeded.v1))
+      .order("asc")
+      .take(4);
+    return rows.map((row) => [row.versionNumber, row.supersededByVideoId ?? null]);
+  });
+  expect(chain[0]?.[1]).toBeTruthy();
+  expect(chain[1]?.[1]).toBeTruthy();
+  expect(chain[2]?.[1]).toBeNull();
+});
+
+test("version stack operations enforce the explicit stack limit", async () => {
+  const t = convexTest(schema, modules);
+  const seeded = await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "owner",
+      plan: "basic",
+    });
+    await ctx.db.insert("teamMembers", {
+      teamId,
+      userClerkId: "owner",
+      userEmail: "owner@example.com",
+      userName: "Owner",
+      role: "owner",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Campaign",
+    });
+    const v1 = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      title: "Cut",
+      visibility: "public",
+      publicId: "limit-v1",
+      status: "ready",
+      workflowStatus: "review",
+      versionNumber: 1,
+    });
+    await ctx.db.patch(v1, { versionStackId: v1 });
+
+    let previousId = v1;
+    for (let versionNumber = 2; versionNumber <= MAX_VIDEO_STACK_SIZE; versionNumber += 1) {
+      const videoId = await ctx.db.insert("videos", {
+        projectId,
+        uploadedByClerkId: "owner",
+        uploaderName: "Owner",
+        title: "Cut",
+        visibility: "public",
+        publicId: `limit-v${versionNumber}`,
+        status: "ready",
+        workflowStatus: "review",
+        versionStackId: v1,
+        versionNumber,
+      });
+      await ctx.db.patch(previousId, { supersededByVideoId: videoId });
+      previousId = videoId;
+    }
+
+    return { projectId, v1, latestId: previousId };
+  });
+
+  const versions = await t
+    .withIdentity({ subject: "owner" })
+    .query(api.videos.listVersions, { videoId: seeded.v1 });
+  expect(versions).toHaveLength(MAX_VIDEO_STACK_SIZE);
+
+  await expect(
+    t.run((ctx) =>
+      createVersionRecord(ctx, {
+        sourceVideoId: seeded.v1,
+        uploadedByClerkId: "owner",
+        uploaderName: "Owner",
+        publicId: "limit-overflow",
+      }),
+    ),
+  ).rejects.toThrow(`at most ${MAX_VIDEO_STACK_SIZE} versions`);
+
+  const overflowId = await t.run(async (ctx) => {
+    const videoId = await ctx.db.insert("videos", {
+      projectId: seeded.projectId,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      title: "Cut",
+      visibility: "public",
+      publicId: "limit-corrupt",
+      status: "ready",
+      workflowStatus: "review",
+      versionStackId: seeded.v1,
+      versionNumber: MAX_VIDEO_STACK_SIZE + 1,
+    });
+    await ctx.db.patch(seeded.latestId, { supersededByVideoId: videoId });
+    return videoId;
+  });
+
+  const authed = t.withIdentity({ subject: "owner" });
+  await expect(authed.query(api.videos.listVersions, { videoId: overflowId })).rejects.toThrow(
+    `at most ${MAX_VIDEO_STACK_SIZE} versions`,
+  );
+  await expect(
+    authed.mutation(api.videos.move, {
+      videoId: overflowId,
+      projectId: seeded.projectId,
+    }),
+  ).rejects.toThrow(`at most ${MAX_VIDEO_STACK_SIZE} versions`);
+  await expect(authed.mutation(api.videos.remove, { videoId: overflowId })).rejects.toThrow(
+    `at most ${MAX_VIDEO_STACK_SIZE} versions`,
+  );
+});

--- a/convex/videos.ts
+++ b/convex/videos.ts
@@ -26,6 +26,7 @@ const visibilityValidator = v.union(v.literal("public"), v.literal("private"));
 const VIDEO_DELETE_BATCH_DOCS = 500;
 export const MAX_VIDEO_STACK_SIZE = 100;
 const VIDEO_STACK_LIMIT_ERROR = `A video can have at most ${MAX_VIDEO_STACK_SIZE} versions.`;
+const VIDEO_STACK_HEAD_ERROR = "A video version stack must have exactly one latest version.";
 
 type WorkflowStatus = "review" | "rework" | "done";
 type StackReadCtx = Pick<QueryCtx, "db">;
@@ -40,7 +41,10 @@ function normalizeVersionNumber(video: Doc<"videos">) {
 
 async function getStackVersions(ctx: StackReadCtx, video: Doc<"videos">) {
   if (!video.versionStackId) {
-    return [video];
+    return {
+      versions: [video],
+      latest: video,
+    };
   }
 
   const versions = await ctx.db
@@ -55,7 +59,20 @@ async function getStackVersions(ctx: StackReadCtx, video: Doc<"videos">) {
     throw new Error(VIDEO_STACK_LIMIT_ERROR);
   }
 
-  return versions;
+  const latestVersions = versions.filter(
+    (stackVersion) => stackVersion.supersededByVideoId === undefined,
+  );
+  if (latestVersions.length !== 1) {
+    throw new Error(VIDEO_STACK_HEAD_ERROR);
+  }
+
+  return {
+    versions: [...versions].sort(
+      (a, b) =>
+        normalizeVersionNumber(b) - normalizeVersionNumber(a) || b._creationTime - a._creationTime,
+    ),
+    latest: latestVersions[0],
+  };
 }
 
 async function getPredecessor(ctx: MutationCtx, videoId: Id<"videos">) {
@@ -80,7 +97,6 @@ async function failOrRollbackUpload(ctx: MutationCtx, video: Doc<"videos">, uplo
   if (
     video.versionStackId &&
     video.versionNumber !== undefined &&
-    video.status !== "processing" &&
     video.status !== "ready" &&
     !video.muxAssetId
   ) {
@@ -296,9 +312,9 @@ export async function createVersionRecord(
     throw new Error("Video not found");
   }
 
-  const versions = await getStackVersions(ctx, sourceVideo);
+  const { versions, latest } = await getStackVersions(ctx, sourceVideo);
   return await insertVersionRecord(ctx, {
-    latest: versions[0] ?? sourceVideo,
+    latest,
     stackSize: versions.length,
     uploadedByClerkId: args.uploadedByClerkId,
     uploaderName: args.uploaderName,
@@ -354,8 +370,7 @@ export const createVersion = mutation({
       args.sourceVideoId,
       "member",
     );
-    const versions = await getStackVersions(ctx, sourceVideo);
-    const latest = versions[0] ?? sourceVideo;
+    const { versions, latest } = await getStackVersions(ctx, sourceVideo);
     const { project } = await requireProjectAccess(ctx, latest.projectId, "member");
 
     assertVideoFileSizeAllowed(args.fileSize ?? 0);
@@ -425,7 +440,7 @@ export const listVersions = query({
   handler: async (ctx, args) => {
     const { video } = await requireVideoAccess(ctx, args.videoId);
 
-    const versions = await getStackVersions(ctx, video);
+    const { versions } = await getStackVersions(ctx, video);
 
     return versions.map((version) => ({
       _id: version._id,
@@ -593,7 +608,11 @@ export const move = mutation({
     // Validate access to the SOURCE: `requireVideoAccess` loads the video and its
     // current (source) project, and requires `member` on the source folder's team.
     const { project: sourceProject, video } = await requireVideoAccess(ctx, args.videoId, "member");
-    const versions = await getStackVersions(ctx, video);
+    const { versions } = await getStackVersions(ctx, video);
+
+    if (!versions.every((version) => version.projectId === sourceProject._id)) {
+      throw new Error("All versions of a video must belong to the same project");
+    }
 
     if (sourceProject._id === args.projectId) {
       return; // no-op: dropped back into the same folder

--- a/convex/videos.ts
+++ b/convex/videos.ts
@@ -1,8 +1,15 @@
 import { v } from "convex/values";
-import { internalMutation, internalQuery, mutation, query, MutationCtx } from "./_generated/server";
+import {
+  internalMutation,
+  internalQuery,
+  mutation,
+  query,
+  MutationCtx,
+  QueryCtx,
+} from "./_generated/server";
 import { internal } from "./_generated/api";
 import { identityName, requireProjectAccess, requireVideoAccess } from "./auth";
-import { Id } from "./_generated/dataModel";
+import { Doc, Id } from "./_generated/dataModel";
 import { generateUniqueToken } from "./security";
 import { resolveActiveShareGrant } from "./shareAccess";
 import { assertTeamCanStoreBytes, assertTeamHasActiveSubscription } from "./billingHelpers";
@@ -17,11 +24,83 @@ const workflowStatusValidator = v.union(
 const visibilityValidator = v.union(v.literal("public"), v.literal("private"));
 
 const VIDEO_DELETE_BATCH_DOCS = 500;
+export const MAX_VIDEO_STACK_SIZE = 100;
+const VIDEO_STACK_LIMIT_ERROR = `A video can have at most ${MAX_VIDEO_STACK_SIZE} versions.`;
 
 type WorkflowStatus = "review" | "rework" | "done";
+type StackReadCtx = Pick<QueryCtx, "db">;
 
 function normalizeWorkflowStatus(status: WorkflowStatus | undefined): WorkflowStatus {
   return status ?? "review";
+}
+
+function normalizeVersionNumber(video: Doc<"videos">) {
+  return video.versionNumber ?? 1;
+}
+
+async function getStackVersions(ctx: StackReadCtx, video: Doc<"videos">) {
+  if (!video.versionStackId) {
+    return [video];
+  }
+
+  const versions = await ctx.db
+    .query("videos")
+    .withIndex("by_version_stack_id_and_version_number", (q) =>
+      q.eq("versionStackId", video.versionStackId),
+    )
+    .order("desc")
+    .take(MAX_VIDEO_STACK_SIZE + 1);
+
+  if (versions.length > MAX_VIDEO_STACK_SIZE) {
+    throw new Error(VIDEO_STACK_LIMIT_ERROR);
+  }
+
+  return versions;
+}
+
+async function getPredecessor(ctx: MutationCtx, videoId: Id<"videos">) {
+  return await ctx.db
+    .query("videos")
+    .withIndex("by_superseded_by_video_id", (q) => q.eq("supersededByVideoId", videoId))
+    .unique();
+}
+
+async function rewireStackBeforeDelete(ctx: MutationCtx, video: Doc<"videos">) {
+  if (!video.versionStackId) return;
+
+  const predecessor = await getPredecessor(ctx, video._id);
+  if (predecessor) {
+    await ctx.db.patch(predecessor._id, {
+      supersededByVideoId: video.supersededByVideoId,
+    });
+  }
+}
+
+async function failOrRollbackUpload(ctx: MutationCtx, video: Doc<"videos">, uploadError: string) {
+  if (
+    video.versionStackId &&
+    video.versionNumber !== undefined &&
+    video.status !== "processing" &&
+    video.status !== "ready" &&
+    !video.muxAssetId
+  ) {
+    await deleteVideoAndDependents(ctx, video._id);
+    return true;
+  }
+
+  await ctx.db.patch(video._id, {
+    muxAssetStatus: "errored",
+    uploadError,
+    status: "failed",
+    s3Key: undefined,
+    s3MultipartUploadId: undefined,
+    s3MultipartPartSizeBytes: undefined,
+    s3MultipartPartCount: undefined,
+    fileSize: undefined,
+    contentType: undefined,
+    uploadUpdatedAt: Date.now(),
+  });
+  return false;
 }
 
 async function generatePublicId(ctx: MutationCtx) {
@@ -62,6 +141,9 @@ export async function deleteVideoAndDependents(
   ctx: MutationCtx,
   videoId: Id<"videos">,
 ): Promise<number> {
+  const video = await ctx.db.get(videoId);
+  if (!video) return 0;
+
   let deleted = 0;
 
   const comments = await ctx.db
@@ -83,6 +165,7 @@ export async function deleteVideoAndDependents(
     deleted++;
   }
 
+  await rewireStackBeforeDelete(ctx, video);
   await ctx.db.delete(videoId);
   deleted++;
 
@@ -141,8 +224,88 @@ export async function deleteVideoAndDependentsBatch(
 
   if (remaining === 0) return { deleted, done: false };
 
+  await rewireStackBeforeDelete(ctx, video);
   await ctx.db.delete(videoId);
   return { deleted: deleted + 1, done: true };
+}
+
+async function insertVersionRecord(
+  ctx: MutationCtx,
+  args: {
+    latest: Doc<"videos">;
+    stackSize: number;
+    uploadedByClerkId: string;
+    uploaderName: string;
+    publicId: string;
+    fileSize?: number;
+    contentType?: string;
+  },
+) {
+  if (args.stackSize >= MAX_VIDEO_STACK_SIZE) {
+    throw new Error(VIDEO_STACK_LIMIT_ERROR);
+  }
+
+  const latest = args.latest;
+  const versionStackId = latest.versionStackId ?? latest._id;
+  const versionNumber = normalizeVersionNumber(latest) + 1;
+
+  const videoId = await ctx.db.insert("videos", {
+    projectId: latest.projectId,
+    uploadedByClerkId: args.uploadedByClerkId,
+    uploaderName: args.uploaderName,
+    title: latest.title,
+    description: latest.description,
+    visibility: latest.visibility,
+    publicId: args.publicId,
+    fileSize: args.fileSize,
+    contentType: args.contentType,
+    status: "uploading",
+    muxAssetStatus: "preparing",
+    workflowStatus: "review",
+    uploadUpdatedAt: Date.now(),
+    versionStackId,
+    versionNumber,
+  });
+
+  await ctx.db.patch(latest._id, {
+    versionStackId,
+    versionNumber: normalizeVersionNumber(latest),
+    supersededByVideoId: videoId,
+  });
+
+  return {
+    videoId,
+    versionStackId,
+    versionNumber,
+  };
+}
+
+export async function createVersionRecord(
+  ctx: MutationCtx,
+  args: {
+    sourceVideoId: Id<"videos">;
+    uploadedByClerkId: string;
+    uploaderName: string;
+    publicId: string;
+    fileSize?: number;
+    contentType?: string;
+  },
+) {
+  const sourceVideo = await ctx.db.get(args.sourceVideoId);
+  if (!sourceVideo) {
+    throw new Error("Video not found");
+  }
+
+  const versions = await getStackVersions(ctx, sourceVideo);
+  return await insertVersionRecord(ctx, {
+    latest: versions[0] ?? sourceVideo,
+    stackSize: versions.length,
+    uploadedByClerkId: args.uploadedByClerkId,
+    uploaderName: args.uploaderName,
+    publicId: args.publicId,
+    fileSize: args.fileSize,
+    contentType: args.contentType,
+  });
 }
 
 export const create = mutation({
@@ -179,6 +342,37 @@ export const create = mutation({
   },
 });
 
+export const createVersion = mutation({
+  args: {
+    sourceVideoId: v.id("videos"),
+    fileSize: v.optional(v.number()),
+    contentType: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const { user, video: sourceVideo } = await requireVideoAccess(
+      ctx,
+      args.sourceVideoId,
+      "member",
+    );
+    const versions = await getStackVersions(ctx, sourceVideo);
+    const latest = versions[0] ?? sourceVideo;
+    const { project } = await requireProjectAccess(ctx, latest.projectId, "member");
+
+    assertVideoFileSizeAllowed(args.fileSize ?? 0);
+    await assertTeamCanStoreBytes(ctx, project.teamId, args.fileSize ?? 0);
+
+    return await insertVersionRecord(ctx, {
+      latest,
+      stackSize: versions.length,
+      uploadedByClerkId: user.subject,
+      uploaderName: identityName(user),
+      publicId: await generatePublicId(ctx),
+      fileSize: args.fileSize,
+      contentType: args.contentType,
+    });
+  },
+});
+
 export const list = query({
   args: { projectId: v.id("projects") },
   handler: async (ctx, args) => {
@@ -186,7 +380,9 @@ export const list = query({
 
     const videos = await ctx.db
       .query("videos")
-      .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
+      .withIndex("by_project_and_superseded_by_video_id", (q) =>
+        q.eq("projectId", args.projectId).eq("supersededByVideoId", undefined),
+      )
       .order("desc")
       .collect();
 
@@ -201,6 +397,7 @@ export const list = query({
           ...video,
           uploaderName: video.uploaderName ?? "Unknown",
           workflowStatus: normalizeWorkflowStatus(video.workflowStatus),
+          versionNumber: normalizeVersionNumber(video),
           commentCount: comments.length,
         };
       }),
@@ -216,8 +413,30 @@ export const get = query({
       ...video,
       uploaderName: video.uploaderName ?? "Unknown",
       workflowStatus: normalizeWorkflowStatus(video.workflowStatus),
+      versionNumber: normalizeVersionNumber(video),
+      isLatestVersion: video.supersededByVideoId === undefined,
       role: membership.role,
     };
+  },
+});
+
+export const listVersions = query({
+  args: { videoId: v.id("videos") },
+  handler: async (ctx, args) => {
+    const { video } = await requireVideoAccess(ctx, args.videoId);
+
+    const versions = await getStackVersions(ctx, video);
+
+    return versions.map((version) => ({
+      _id: version._id,
+      projectId: version.projectId,
+      title: version.title,
+      status: version.status,
+      thumbnailUrl: version.thumbnailUrl,
+      versionNumber: normalizeVersionNumber(version),
+      isLatestVersion: version.supersededByVideoId === undefined,
+      createdAt: version._creationTime,
+    }));
   },
 });
 
@@ -373,7 +592,8 @@ export const move = mutation({
   handler: async (ctx, args) => {
     // Validate access to the SOURCE: `requireVideoAccess` loads the video and its
     // current (source) project, and requires `member` on the source folder's team.
-    const { project: sourceProject } = await requireVideoAccess(ctx, args.videoId, "member");
+    const { project: sourceProject, video } = await requireVideoAccess(ctx, args.videoId, "member");
+    const versions = await getStackVersions(ctx, video);
 
     if (sourceProject._id === args.projectId) {
       return; // no-op: dropped back into the same folder
@@ -386,7 +606,9 @@ export const move = mutation({
       throw new Error("Can't move a video to a different team");
     }
 
-    await ctx.db.patch(args.videoId, { projectId: args.projectId });
+    for (const version of versions) {
+      await ctx.db.patch(version._id, { projectId: args.projectId });
+    }
   },
 });
 
@@ -420,14 +642,21 @@ export const updateWorkflowStatus = mutation({
 
 export const remove = mutation({
   args: { videoId: v.id("videos") },
+  returns: v.object({
+    replacementVideoId: v.union(v.id("videos"), v.null()),
+  }),
   handler: async (ctx, args) => {
-    await requireVideoAccess(ctx, args.videoId, "admin");
+    const { video } = await requireVideoAccess(ctx, args.videoId, "admin");
+    await getStackVersions(ctx, video);
+    const predecessor = await getPredecessor(ctx, args.videoId);
+    const replacementVideoId = video.supersededByVideoId ?? predecessor?._id ?? null;
     const result = await deleteVideoAndDependentsBatch(ctx, args.videoId, VIDEO_DELETE_BATCH_DOCS);
     if (!result.done) {
       await ctx.scheduler.runAfter(0, internal.videos.continueVideoDelete, {
         videoId: args.videoId,
       });
     }
+    return { replacementVideoId };
   },
 });
 
@@ -635,6 +864,26 @@ export const markAsFailed = internalMutation({
   },
 });
 
+export const finalizeAbandonedUpload = internalMutation({
+  args: {
+    videoId: v.id("videos"),
+    uploadError: v.string(),
+  },
+  returns: v.object({
+    removedVersion: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    const video = await ctx.db.get(args.videoId);
+    if (!video) {
+      return { removedVersion: true };
+    }
+
+    return {
+      removedVersion: await failOrRollbackUpload(ctx, video, args.uploadError),
+    };
+  },
+});
+
 export const clearMultipartUploadId = internalMutation({
   args: {
     videoId: v.id("videos"),
@@ -677,7 +926,6 @@ export const listStaleUploadCandidates = internalQuery({
         .withIndex("by_status_and_upload_updated_at", (q) => q.eq("status", "uploading"))
         .take(args.limit)
     )
-      .filter((video) => video.s3Key && video.s3MultipartUploadId)
       .filter((video) => (video.uploadUpdatedAt ?? video._creationTime) < args.cutoff)
       .sort(
         (a, b) => (a.uploadUpdatedAt ?? a._creationTime) - (b.uploadUpdatedAt ?? b._creationTime),
@@ -698,23 +946,35 @@ export const claimStaleUpload = internalMutation({
     if (
       !video ||
       video.status !== "uploading" ||
-      (video.uploadUpdatedAt ?? video._creationTime) >= args.cutoff ||
-      !video.s3Key ||
-      !video.s3MultipartUploadId
+      (video.uploadUpdatedAt ?? video._creationTime) >= args.cutoff
     ) {
       return null;
     }
 
-    await ctx.db.patch(args.videoId, {
-      status: "failed",
-      muxAssetStatus: "errored",
-      uploadError: "Upload expired after a period of inactivity.",
-      uploadUpdatedAt: Date.now(),
-    });
+    const storage =
+      video.s3Key && video.s3MultipartUploadId
+        ? {
+            kind: "multipart" as const,
+            key: video.s3Key,
+            uploadId: video.s3MultipartUploadId,
+          }
+        : video.s3Key
+          ? {
+              kind: "object" as const,
+              key: video.s3Key,
+            }
+          : {
+              kind: "none" as const,
+            };
+    const removedVersion = await failOrRollbackUpload(
+      ctx,
+      video,
+      "Upload expired after a period of inactivity.",
+    );
 
     return {
-      key: video.s3Key,
-      uploadId: video.s3MultipartUploadId,
+      storage,
+      removedVersion,
     };
   },
 });

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint app src convex --ignore-pattern 'convex/_generated/**'",
+    "test": "bun run test:unit && bun run test:convex",
+    "test:unit": "bun test",
+    "test:convex": "vitest run",
+    "check": "bun run format:check && bun run typecheck && bun run typecheck:convex && bun run lint && bun run test",
     "typecheck": "tsc --noEmit",
     "typecheck:convex": "bunx convex typecheck",
     "generate:og": "bun run scripts/generate-og.tsx"
@@ -52,6 +56,7 @@
     "video.js": "^8.23.4"
   },
   "devDependencies": {
+    "@edge-runtime/vm": "^5.0.0",
     "@eslint/js": "^9.34.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
@@ -61,6 +66,7 @@
     "@types/video.js": "^7.3.58",
     "@vitejs/plugin-react": "^5.1.0",
     "concurrently": "^9.2.1",
+    "convex-test": "^0.0.53",
     "eslint": "^9",
     "prettier": "^3.8.4",
     "prettier-plugin-tailwindcss": "^0.8.0",
@@ -70,7 +76,8 @@
     "typescript": "^5",
     "typescript-eslint": "^8.41.0",
     "vite": "^7.1.7",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^4.1.9"
   },
   "type": "module"
 }

--- a/src/components/upload/UploadButton.tsx
+++ b/src/components/upload/UploadButton.tsx
@@ -1,16 +1,28 @@
 "use client";
 
 import { useRef } from "react";
-import { Button } from "@/components/ui/button";
+import { Button, type ButtonProps } from "@/components/ui/button";
 import { Plus } from "lucide-react";
 
 interface UploadButtonProps {
   onFilesSelected: (files: File[]) => void;
   disabled?: boolean;
+  multiple?: boolean;
+  variant?: ButtonProps["variant"];
+  size?: ButtonProps["size"];
+  className?: string;
   children?: React.ReactNode;
 }
 
-export function UploadButton({ onFilesSelected, disabled, children }: UploadButtonProps) {
+export function UploadButton({
+  onFilesSelected,
+  disabled,
+  multiple = true,
+  variant,
+  size,
+  className,
+  children,
+}: UploadButtonProps) {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleClick = () => {
@@ -31,11 +43,18 @@ export function UploadButton({ onFilesSelected, disabled, children }: UploadButt
         ref={inputRef}
         type="file"
         accept="video/*"
-        multiple
+        multiple={multiple}
         onChange={handleChange}
         className="hidden"
       />
-      <Button onClick={handleClick} disabled={disabled}>
+      <Button
+        type="button"
+        variant={variant}
+        size={size}
+        className={className}
+        onClick={handleClick}
+        disabled={disabled}
+      >
         {children || (
           <>
             <Plus className="mr-1.5 h-4 w-4" />

--- a/src/components/upload/UploadProgress.tsx
+++ b/src/components/upload/UploadProgress.tsx
@@ -28,8 +28,10 @@ interface UploadProgressProps {
   bytesPerSecond?: number;
   estimatedSecondsRemaining?: number | null;
   resuming?: boolean;
+  intentLabel?: string;
   onCancel?: () => void;
   onRetryProcessing?: () => void;
+  onView?: () => void;
 }
 
 export function UploadProgress({
@@ -41,13 +43,25 @@ export function UploadProgress({
   bytesPerSecond = 0,
   estimatedSecondsRemaining = null,
   resuming = false,
+  intentLabel,
   onCancel,
   onRetryProcessing,
+  onView,
 }: UploadProgressProps) {
   return (
-    <div className="border-2 border-[#1a1a1a] bg-[#f0f0e8] p-4">
+    <div
+      className="border-2 border-[#1a1a1a] bg-[#f0f0e8] p-4"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0 flex-1">
+          {intentLabel && (
+            <p className="mb-1 text-[10px] font-black tracking-wider text-[#2d5a2d] uppercase">
+              {intentLabel}
+            </p>
+          )}
           <p className="truncate text-sm font-bold text-[#1a1a1a]">{fileName}</p>
           <p className="mt-0.5 text-xs text-[#888]">
             {formatBytes(fileSize)}
@@ -64,8 +78,11 @@ export function UploadProgress({
               size="icon"
               onClick={onCancel}
               className="h-7 w-7 text-[#888] hover:text-[#1a1a1a]"
+              aria-label={
+                status === "error" ? `Dismiss ${fileName}` : `Cancel upload of ${fileName}`
+              }
             >
-              <X className="h-4 w-4" />
+              <X className="h-4 w-4" aria-hidden="true" />
             </Button>
           )}
         </div>
@@ -90,6 +107,19 @@ export function UploadProgress({
       )}
 
       {status === "processing" && <p className="mt-2 text-xs text-[#888]">Processing video...</p>}
+
+      {status === "complete" && (
+        <div className="mt-2 flex items-center justify-between gap-3">
+          <p className="text-xs font-bold text-[#2d5a2d]">
+            {intentLabel ? "New version uploaded." : "Upload complete."}
+          </p>
+          {onView && (
+            <Button variant="outline" size="sm" onClick={onView}>
+              View version
+            </Button>
+          )}
+        </div>
+      )}
 
       {status === "error" && error && (
         <div className="mt-2 space-y-2">

--- a/src/components/videos/MoveVideoDialog.tsx
+++ b/src/components/videos/MoveVideoDialog.tsx
@@ -14,7 +14,12 @@ import { useMoveActions } from "@/lib/dnd/useMoveActions";
 type MoveVideoDialogProps = {
   teamId: Id<"teams">;
   /** The video being moved, plus its current folder so we can exclude it. */
-  video: { _id: Id<"videos">; title: string; projectId: Id<"projects"> } | null;
+  video: {
+    _id: Id<"videos">;
+    title: string;
+    projectId: Id<"projects">;
+    versionNumber: number;
+  } | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 };
@@ -53,8 +58,14 @@ export function MoveVideoDialog({ teamId, video, open, onOpenChange }: MoveVideo
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Move {video ? `"${video.title}"` : "video"}</DialogTitle>
-          <DialogDescription>Choose which folder this video should live in.</DialogDescription>
+          <DialogTitle>
+            {video ? `Move all versions of "${video.title}"` : "Move video"}
+          </DialogTitle>
+          <DialogDescription>
+            {video
+              ? `Choose a folder for every version of this video, including the latest version (v${video.versionNumber}).`
+              : "Choose which folder this video should live in."}
+          </DialogDescription>
         </DialogHeader>
 
         {error && (

--- a/src/lib/dashboardUploadContext.tsx
+++ b/src/lib/dashboardUploadContext.tsx
@@ -4,10 +4,27 @@ import type { UploadStatus } from "@/components/upload/UploadProgress";
 
 export type DashboardUploadContextValue = {
   requestUpload: (files: File[], preferredProjectId?: Id<"projects">) => void;
+  requestVersionUpload: (
+    sourceVideoId: Id<"videos">,
+    versionStackId: Id<"videos">,
+    projectId: Id<"projects">,
+    file: File,
+  ) => void;
   uploads: {
     id: string;
     projectId: Id<"projects">;
+    creationIntent:
+      | {
+          kind: "standalone";
+          projectId: Id<"projects">;
+        }
+      | {
+          kind: "version";
+          sourceVideoId: Id<"videos">;
+          versionStackId: Id<"videos">;
+        };
     file: File;
+    videoId?: Id<"videos">;
     progress: number;
     status: UploadStatus;
     error?: string;

--- a/src/lib/uploadResumeDb.test.ts
+++ b/src/lib/uploadResumeDb.test.ts
@@ -1,0 +1,118 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { Id } from "@convex/_generated/dataModel";
+import {
+  uploadCreationIntentsMatch,
+  type MultipartUploadResumeSession,
+} from "@/lib/uploadResumeDb";
+
+function session(overrides: Partial<MultipartUploadResumeSession>): MultipartUploadResumeSession {
+  return {
+    videoId: "video_1" as Id<"videos">,
+    fileName: "cut.mp4",
+    fileSize: 100,
+    fileLastModified: 123,
+    fileFingerprint: "fingerprint",
+    strategy: "multipart",
+    uploadId: "upload",
+    s3Key: "key",
+    partSizeBytes: 50,
+    partCount: 2,
+    completedParts: [],
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+test("standalone and version upload intents cannot cross-resume", () => {
+  const projectId = "project_1" as Id<"projects">;
+  const sourceVideoId = "video_source" as Id<"videos">;
+  const versionStackId = "video_stack" as Id<"videos">;
+  const standalone = session({
+    creationIntent: { kind: "standalone", projectId },
+  });
+  const version = session({
+    creationIntent: { kind: "version", versionStackId },
+  });
+
+  assert.equal(uploadCreationIntentsMatch(standalone, { kind: "standalone", projectId }), true);
+  assert.equal(
+    uploadCreationIntentsMatch(standalone, {
+      kind: "version",
+      sourceVideoId,
+      versionStackId,
+    }),
+    false,
+  );
+  assert.equal(uploadCreationIntentsMatch(version, { kind: "standalone", projectId }), false);
+  assert.equal(
+    uploadCreationIntentsMatch(version, {
+      kind: "version",
+      sourceVideoId,
+      versionStackId,
+    }),
+    true,
+  );
+  assert.equal(
+    uploadCreationIntentsMatch(version, {
+      kind: "version",
+      sourceVideoId: "video_other" as Id<"videos">,
+      versionStackId,
+    }),
+    true,
+  );
+  assert.equal(
+    uploadCreationIntentsMatch(version, {
+      kind: "version",
+      sourceVideoId,
+      versionStackId: "video_other_stack" as Id<"videos">,
+    }),
+    false,
+  );
+});
+
+test("legacy version sessions fall back to their exact source video", () => {
+  const sourceVideoId = "video_source" as Id<"videos">;
+  const legacyVersion = session({
+    creationIntent: { kind: "version", sourceVideoId },
+  });
+
+  assert.equal(
+    uploadCreationIntentsMatch(legacyVersion, {
+      kind: "version",
+      sourceVideoId,
+      versionStackId: "video_stack" as Id<"videos">,
+    }),
+    true,
+  );
+  assert.equal(
+    uploadCreationIntentsMatch(legacyVersion, {
+      kind: "version",
+      sourceVideoId: "video_other" as Id<"videos">,
+      versionStackId: "video_stack" as Id<"videos">,
+    }),
+    false,
+  );
+});
+
+test("legacy resume sessions remain standalone and project-scoped", () => {
+  const projectId = "project_1" as Id<"projects">;
+  const legacy = session({ projectId });
+
+  assert.equal(uploadCreationIntentsMatch(legacy, { kind: "standalone", projectId }), true);
+  assert.equal(
+    uploadCreationIntentsMatch(legacy, {
+      kind: "standalone",
+      projectId: "project_2" as Id<"projects">,
+    }),
+    false,
+  );
+  assert.equal(
+    uploadCreationIntentsMatch(legacy, {
+      kind: "version",
+      sourceVideoId: "video_source" as Id<"videos">,
+      versionStackId: "video_stack" as Id<"videos">,
+    }),
+    false,
+  );
+});

--- a/src/lib/uploadResumeDb.ts
+++ b/src/lib/uploadResumeDb.ts
@@ -5,8 +5,32 @@ const DB_VERSION = 1;
 const STORE_NAME = "sessions";
 const RESUME_SESSION_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
 
+export type UploadCreationIntent =
+  | {
+      kind: "standalone";
+      projectId: Id<"projects">;
+    }
+  | {
+      kind: "version";
+      sourceVideoId: Id<"videos">;
+      versionStackId: Id<"videos">;
+    };
+
+type UploadResumeIntent =
+  | {
+      kind: "standalone";
+      projectId: Id<"projects">;
+    }
+  | {
+      kind: "version";
+      versionStackId?: Id<"videos">;
+      sourceVideoId?: Id<"videos">;
+    };
+
 export type MultipartUploadResumeSession = {
   videoId: Id<"videos">;
+  creationIntent?: UploadResumeIntent;
+  // Legacy sessions predate explicit creation intents and are standalone.
   projectId?: Id<"projects">;
   fileName: string;
   fileSize: number;
@@ -20,6 +44,48 @@ export type MultipartUploadResumeSession = {
   completedParts: Array<{ partNumber: number; etag: string }>;
   updatedAt: number;
 };
+
+function getSessionCreationIntent(
+  session: MultipartUploadResumeSession,
+): UploadResumeIntent | undefined {
+  if (session.creationIntent) {
+    return session.creationIntent;
+  }
+  if (session.projectId) {
+    return { kind: "standalone", projectId: session.projectId };
+  }
+  return undefined;
+}
+
+export function uploadCreationIntentsMatch(
+  session: MultipartUploadResumeSession,
+  intent: UploadCreationIntent,
+) {
+  const sessionIntent = getSessionCreationIntent(session);
+  if (!sessionIntent || sessionIntent.kind !== intent.kind) {
+    return false;
+  }
+  if (intent.kind === "standalone") {
+    return sessionIntent.kind === "standalone" && sessionIntent.projectId === intent.projectId;
+  }
+  if (sessionIntent.kind !== "version") {
+    return false;
+  }
+  if (sessionIntent.versionStackId) {
+    return sessionIntent.versionStackId === intent.versionStackId;
+  }
+  return sessionIntent.sourceVideoId === intent.sourceVideoId;
+}
+
+export function getUploadResumeIntent(intent: UploadCreationIntent): UploadResumeIntent {
+  if (intent.kind === "standalone") {
+    return intent;
+  }
+  return {
+    kind: "version",
+    versionStackId: intent.versionStackId,
+  };
+}
 
 function openDb(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
@@ -111,7 +177,7 @@ export async function deleteUploadResumeSession(videoId: Id<"videos">) {
 
 export async function findUploadResumeSessionByFingerprint(
   fingerprint: string,
-  projectId: Id<"projects">,
+  intent: UploadCreationIntent,
 ) {
   try {
     const allSessions = await runTransaction<MultipartUploadResumeSession[]>("readonly", (store) =>
@@ -128,7 +194,7 @@ export async function findUploadResumeSessionByFingerprint(
     );
     return sessions
       .filter((session) => session.updatedAt >= cutoff)
-      .filter((session) => session.projectId === projectId)
+      .filter((session) => uploadCreationIntentsMatch(session, intent))
       .sort((a, b) => b.updatedAt - a.updatedAt)[0];
   } catch {
     return undefined;

--- a/src/lib/videoUpload.ts
+++ b/src/lib/videoUpload.ts
@@ -8,8 +8,11 @@ import {
 } from "@/lib/uploadLimits";
 import {
   deleteUploadResumeSession,
+  getUploadResumeIntent,
   saveUploadResumeSession,
   type MultipartUploadResumeSession,
+  type UploadCreationIntent,
+  uploadCreationIntentsMatch,
 } from "@/lib/uploadResumeDb";
 
 export type UploadProgressUpdate = {
@@ -406,7 +409,7 @@ async function persistResumeSession(session: MultipartUploadResumeSession) {
 
 async function uploadMultipartFile(args: {
   file: File;
-  projectId: Id<"projects">;
+  creationIntent: UploadCreationIntent;
   videoId: Id<"videos">;
   initiate: InitiateMultipart;
   actions: VideoUploadActions;
@@ -418,7 +421,7 @@ async function uploadMultipartFile(args: {
 }) {
   const {
     file,
-    projectId,
+    creationIntent,
     videoId,
     initiate,
     actions,
@@ -437,7 +440,8 @@ async function uploadMultipartFile(args: {
     resumeSession.partCount === initiate.partCount &&
     resumeSession.fileSize === file.size &&
     resumeSession.fileLastModified === file.lastModified &&
-    resumeSession.fileName === file.name;
+    resumeSession.fileName === file.name &&
+    uploadCreationIntentsMatch(resumeSession, creationIntent);
   onResumingChange?.(canReuseResumeSession);
   if (resumeSession && !canReuseResumeSession) {
     await deleteUploadResumeSession(resumeSession.videoId);
@@ -500,7 +504,7 @@ async function uploadMultipartFile(args: {
 
   const resumeBase: MultipartUploadResumeSession = {
     videoId,
-    projectId,
+    creationIntent: getUploadResumeIntent(creationIntent),
     fileName: file.name,
     fileSize: file.size,
     fileLastModified: file.lastModified,
@@ -600,11 +604,12 @@ async function uploadMultipartFile(args: {
 
 export async function uploadVideoFile(args: {
   file: File;
-  projectId: Id<"projects">;
+  creationIntent: UploadCreationIntent;
   videoId: Id<"videos">;
   actions: VideoUploadActions;
   signal: AbortSignal;
   onProgress: (update: UploadProgressUpdate) => void;
+  onProcessing?: () => void;
   resumeSession?: MultipartUploadResumeSession;
   onResumingChange?: (resuming: boolean) => void;
   fileFingerprint?: string;
@@ -630,7 +635,7 @@ export async function uploadVideoFile(args: {
   } else {
     await uploadMultipartFile({
       file: args.file,
-      projectId: args.projectId,
+      creationIntent: args.creationIntent,
       videoId: args.videoId,
       initiate,
       actions: args.actions,
@@ -642,6 +647,7 @@ export async function uploadVideoFile(args: {
     });
   }
 
+  args.onProcessing?.();
   try {
     await args.actions.markUploadComplete({ videoId: args.videoId });
   } catch (error) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "edge-runtime",
+    include: ["convex/**/*.vitest.ts"],
+  },
+});


### PR DESCRIPTION
## What changed

- add slim, backward-compatible video version stacks without a new table or route
- keep dashboard cards/counts focused on the latest version while preserving version-specific links, comments, media, and downloads
- add new-version upload, resume isolation, cancellation rollback, version navigation, move/delete behavior, and dashboard stack affordances
- add focused unit and Convex coverage for authorization, concurrency, lifecycle rollback, stack limits, and resume behavior

## User impact

Users can upload v2, v3, and later revisions from a video detail page. Versions stay grouped naturally in the dashboard, old links remain pinned to the exact version shared, and standalone v1 videos retain the existing uncluttered appearance.

## Validation

- `bun run check`
- `git diff --check`
- 18 unit tests passed
- 8 Convex tests passed

No dev or build commands were run.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add video version stacks with upload, browsing, and deletion support
> - Adds a versioning model to the `videos` table via new `versionStackId`, `versionNumber`, and `supersededByVideoId` fields and indexes in [convex/schema.ts](https://github.com/pingdotgg/lawn/pull/43/files#diff-00e6e27e65e72a0fd4a73f6942f41e1cf3f476a59f263513f3f47fdf801a0eb1), with a 100-version stack limit.
> - Dropping a video file onto the player page uploads it as a new version (member+ access required); the drag overlay reflects version-upload state.
> - The video page gains a `VersionSelector` dropdown to switch between versions, a new version upload button, per-version delete (owner/admin only), and a retry action for failed processing.
> - Project grids show a
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c08ca53.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->