### PR TITLE
Add video version deletion

### DIFF
--- a/app/routes/dashboard/-video.tsx
+++ b/app/routes/dashboard/-video.tsx
@@ -46,6 +46,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Id } from "@convex/_generated/dataModel";
 import { projectPath, teamHomePath, videoPath } from "@/lib/routes";
+import { findPreferredReplacementVideoId } from "@/lib/videoVersionDeletion";
 import { useRoutePrewarmIntent } from "@/lib/useRoutePrewarmIntent";
 import { prewarmProject } from "./-project.data";
 import { prewarmTeam } from "./-team.data";
@@ -544,10 +545,12 @@ export default function VideoPage() {
       setDeleteNotice(null);
 
       try {
-        const deleteRequest = deleteVideo({ videoId: versionToDelete._id }).then(
-          (result) => ({ ok: true as const, result }),
-          (error: unknown) => ({ ok: false as const, error }),
-        );
+        const requestDelete = () =>
+          deleteVideo({ videoId: versionToDelete._id }).then(
+            (result) => ({ ok: true as const, result }),
+            (error: unknown) => ({ ok: false as const, error }),
+          );
+        const nonCurrentDeleteRequest = isCurrentVersion ? null : requestDelete();
 
         if (animateSelectorRow) {
           const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -556,7 +559,31 @@ export default function VideoPage() {
           }
         }
 
-        const outcome = await deleteRequest;
+        const preferredReplacementVideoId =
+          isCurrentVersion && animateSelectorRow
+            ? findPreferredReplacementVideoId(versions, versionToDelete._id)
+            : null;
+
+        if (isCurrentVersion) {
+          if (preferredReplacementVideoId) {
+            prewarmVideo(convex, {
+              teamSlug: resolvedTeamSlug,
+              projectId: resolvedProjectId,
+              videoId: preferredReplacementVideoId,
+            });
+            await navigate({
+              to: videoPath(resolvedTeamSlug, resolvedProjectId, preferredReplacementVideoId),
+              replace: true,
+            });
+          } else {
+            await navigate({
+              to: projectPath(resolvedTeamSlug, resolvedProjectId),
+              replace: true,
+            });
+          }
+        }
+
+        const outcome = await (nonCurrentDeleteRequest ?? requestDelete());
         if (outcome.ok === false) {
           throw outcome.error;
         }
@@ -573,30 +600,41 @@ export default function VideoPage() {
         });
 
         if (isCurrentVersion) {
-          if (result.replacementVideoId) {
-            navigate({
-              to: videoPath(resolvedTeamSlug, resolvedProjectId, result.replacementVideoId),
-              replace: true,
-            });
-          } else {
-            navigate({
-              to: projectPath(resolvedTeamSlug, resolvedProjectId),
-              replace: true,
-            });
+          if (result.replacementVideoId !== preferredReplacementVideoId) {
+            if (result.replacementVideoId) {
+              prewarmVideo(convex, {
+                teamSlug: resolvedTeamSlug,
+                projectId: resolvedProjectId,
+                videoId: result.replacementVideoId,
+              });
+              await navigate({
+                to: videoPath(resolvedTeamSlug, resolvedProjectId, result.replacementVideoId),
+                replace: true,
+              });
+            } else {
+              await navigate({
+                to: projectPath(resolvedTeamSlug, resolvedProjectId),
+                replace: true,
+              });
+            }
           }
         }
       } catch (error) {
         console.error("Failed to delete video version:", error);
-        setDeleteNotice({
-          tone: "error",
-          message: "Couldn't delete that video version. Please try again.",
-        });
+        if (isCurrentVersion) {
+          window.alert("Couldn't delete that video version. Please try again.");
+        } else {
+          setDeleteNotice({
+            tone: "error",
+            message: "Couldn't delete that video version. Please try again.",
+          });
+        }
       } finally {
         deletePendingRef.current = false;
         setDeletingVideoId(null);
       }
     },
-    [deleteVideo, navigate, resolvedProjectId, resolvedTeamSlug, resolvedVideoId],
+    [convex, deleteVideo, navigate, resolvedProjectId, resolvedTeamSlug, resolvedVideoId, versions],
   );
 
   const handleRetryFailedProcessing = useCallback(async () => {

--- a/app/routes/dashboard/-video.tsx
+++ b/app/routes/dashboard/-video.tsx
@@ -13,7 +13,7 @@ import {
   VideoWorkflowStatusControl,
   type VideoWorkflowStatus,
 } from "@/components/videos/VideoWorkflowStatusControl";
-import { formatDuration } from "@/lib/utils";
+import { cn, formatDuration } from "@/lib/utils";
 import { buildCommentsCsv, buildCommentsCsvFilename } from "@/lib/commentCsv";
 import { triggerTextDownload } from "@/lib/download";
 import { useVideoPresence } from "@/lib/useVideoPresence";
@@ -51,6 +51,14 @@ import { prewarmProject } from "./-project.data";
 import { prewarmTeam } from "./-team.data";
 import { prewarmVideo, useVideoData } from "./-video.data";
 
+type VideoVersion = {
+  _id: Id<"videos">;
+  projectId: Id<"projects">;
+  versionNumber: number;
+  status: string;
+  isLatestVersion: boolean;
+};
+
 function versionStatusLabel(status: string) {
   switch (status) {
     case "uploading":
@@ -64,24 +72,43 @@ function versionStatusLabel(status: string) {
   }
 }
 
+function focusNearestSurvivingVersion(deleteItem: HTMLElement) {
+  const deletingRow = deleteItem.closest<HTMLElement>("[data-version-row]");
+  const rowContainer = deletingRow?.parentElement;
+  if (!deletingRow || !rowContainer) return;
+
+  const versionRows = Array.from(rowContainer.children).filter(
+    (child): child is HTMLElement =>
+      child instanceof HTMLElement && child.dataset.versionRow !== undefined,
+  );
+  const deletingIndex = versionRows.indexOf(deletingRow);
+  if (deletingIndex === -1) return;
+
+  const nearestRow = versionRows[deletingIndex + 1] ?? versionRows[deletingIndex - 1];
+  nearestRow?.querySelector<HTMLElement>("[data-version-radio-item]")?.focus();
+}
+
 function VersionSelectorOption({
   version,
   teamSlug,
   currentVideoId,
   onSelect,
+  canDelete,
+  deletingVideoId,
+  onDelete,
 }: {
-  version: {
-    _id: Id<"videos">;
-    projectId: Id<"projects">;
-    versionNumber: number;
-    status: string;
-    isLatestVersion: boolean;
-  };
+  version: VideoVersion;
   teamSlug: string;
   currentVideoId: Id<"videos">;
   onSelect: (videoId: Id<"videos">) => void;
+  canDelete: boolean;
+  deletingVideoId: Id<"videos"> | null;
+  onDelete: (version: VideoVersion, beforeDelete: () => void) => void;
 }) {
   const convex = useConvex();
+  const isDeleting = deletingVideoId === version._id;
+  const deletionPending = deletingVideoId !== null;
+  const selectionDisabled = isDeleting || deletingVideoId === currentVideoId;
   const prewarmIntentHandlers = useRoutePrewarmIntent(() =>
     prewarmVideo(convex, {
       teamSlug,
@@ -91,20 +118,51 @@ function VersionSelectorOption({
   );
 
   return (
-    <DropdownMenuRadioItem
-      value={version._id}
-      onSelect={() => onSelect(version._id)}
-      {...prewarmIntentHandlers}
+    <div
+      role="presentation"
+      data-version-row
+      className={cn(
+        "grid max-h-12 grid-cols-[minmax(0,1fr)_auto] overflow-hidden opacity-100 transition-[max-height,opacity,transform] duration-[180ms] motion-reduce:transition-none",
+        isDeleting && "max-h-0 -translate-x-4 opacity-0",
+      )}
     >
-      <span className="font-bold">v{version.versionNumber}</span>
-      <span className="ml-2 text-xs text-[#888]">
-        {version._id === currentVideoId
-          ? `${version.isLatestVersion ? "Viewing latest" : "Viewing"} · ${versionStatusLabel(version.status)}`
-          : version.isLatestVersion
-            ? `Latest · ${versionStatusLabel(version.status)}`
-            : versionStatusLabel(version.status)}
-      </span>
-    </DropdownMenuRadioItem>
+      <DropdownMenuRadioItem
+        value={version._id}
+        disabled={selectionDisabled}
+        data-version-radio-item
+        className="min-w-0"
+        onSelect={() => onSelect(version._id)}
+        {...prewarmIntentHandlers}
+      >
+        <span className="font-bold">v{version.versionNumber}</span>
+        <span className="ml-2 truncate text-xs text-[#888]">
+          {version._id === currentVideoId
+            ? `${version.isLatestVersion ? "Viewing latest" : "Viewing"} · ${versionStatusLabel(version.status)}`
+            : version.isLatestVersion
+              ? `Latest · ${versionStatusLabel(version.status)}`
+              : versionStatusLabel(version.status)}
+        </span>
+      </DropdownMenuRadioItem>
+      {canDelete && (
+        <DropdownMenuItem
+          disabled={deletionPending}
+          aria-label={`Delete version v${version.versionNumber}`}
+          className="h-10 w-10 justify-center p-0 text-[#dc2626] focus:text-[#dc2626]"
+          onSelect={(event) => {
+            event.preventDefault();
+            const deleteItem = event.currentTarget;
+            onDelete(version, () => {
+              if (deleteItem instanceof HTMLElement) {
+                focusNearestSurvivingVersion(deleteItem);
+              }
+            });
+          }}
+        >
+          <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+          <span className="sr-only">Delete version v{version.versionNumber}</span>
+        </DropdownMenuItem>
+      )}
+    </div>
   );
 }
 
@@ -114,62 +172,89 @@ function VersionSelector({
   currentVersionNumber,
   teamSlug,
   onSelect,
+  canDelete,
+  deletingVideoId,
+  onDelete,
   compact = false,
 }: {
-  versions:
-    | Array<{
-        _id: Id<"videos">;
-        projectId: Id<"projects">;
-        versionNumber: number;
-        status: string;
-        isLatestVersion: boolean;
-      }>
-    | undefined;
+  versions: Array<VideoVersion> | undefined;
   currentVideoId: Id<"videos">;
   currentVersionNumber: number;
   teamSlug: string;
   onSelect: (videoId: Id<"videos">) => void;
+  canDelete: boolean;
+  deletingVideoId: Id<"videos"> | null;
+  onDelete: (version: VideoVersion, beforeDelete: () => void) => void;
   compact?: boolean;
 }) {
+  const [open, setOpen] = useState(false);
+  const lastSettledVersionsRef = useRef(versions);
+  useEffect(() => {
+    if (!deletingVideoId) {
+      lastSettledVersionsRef.current = versions;
+    }
+  }, [deletingVideoId, versions]);
+  const displayedVersions = deletingVideoId ? lastSettledVersionsRef.current : versions;
+  const deletingVersionNumber = displayedVersions?.find(
+    (version) => version._id === deletingVideoId,
+  )?.versionNumber;
+  const deletionPending = deletingVideoId !== null;
+  const triggerLabel = deletionPending
+    ? deletingVersionNumber
+      ? `Deleting version v${deletingVersionNumber}`
+      : "Deleting video version"
+    : `Select video version, currently v${currentVersionNumber}`;
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="outline"
-          size={compact ? "icon" : "default"}
-          className={compact ? "h-8 w-8" : undefined}
-          aria-label={`Select video version, currently v${currentVersionNumber}`}
-        >
-          {versions === undefined ? (
-            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+    <>
+      <DropdownMenu open={open} onOpenChange={setOpen}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            size={compact ? "icon" : "default"}
+            className={compact ? "h-8 w-8" : undefined}
+            aria-label={triggerLabel}
+            aria-busy={deletionPending}
+          >
+            {deletionPending || displayedVersions === undefined ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <Layers3 className="h-4 w-4" aria-hidden="true" />
+            )}
+            {!compact && <span>v{currentVersionNumber}</span>}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="min-w-52" aria-busy={deletionPending}>
+          <DropdownMenuLabel>Video versions</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          {displayedVersions === undefined ? (
+            <DropdownMenuItem disabled>Loading versions…</DropdownMenuItem>
+          ) : displayedVersions.length === 0 ? (
+            <DropdownMenuItem disabled>No versions available</DropdownMenuItem>
           ) : (
-            <Layers3 className="h-4 w-4" aria-hidden="true" />
+            <DropdownMenuRadioGroup value={currentVideoId}>
+              {displayedVersions.map((version) => (
+                <VersionSelectorOption
+                  key={version._id}
+                  version={version}
+                  teamSlug={teamSlug}
+                  currentVideoId={currentVideoId}
+                  onSelect={onSelect}
+                  canDelete={canDelete}
+                  deletingVideoId={deletingVideoId}
+                  onDelete={onDelete}
+                />
+              ))}
+            </DropdownMenuRadioGroup>
           )}
-          {!compact && <span>v{currentVersionNumber}</span>}
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="min-w-52">
-        <DropdownMenuLabel>Video versions</DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        {versions === undefined ? (
-          <DropdownMenuItem disabled>Loading versions…</DropdownMenuItem>
-        ) : versions.length === 0 ? (
-          <DropdownMenuItem disabled>No versions available</DropdownMenuItem>
-        ) : (
-          <DropdownMenuRadioGroup value={currentVideoId}>
-            {versions.map((version) => (
-              <VersionSelectorOption
-                key={version._id}
-                version={version}
-                teamSlug={teamSlug}
-                currentVideoId={currentVideoId}
-                onSelect={onSelect}
-              />
-            ))}
-          </DropdownMenuRadioGroup>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {deletionPending && (
+        <span className="sr-only" role="status" aria-live="polite">
+          {triggerLabel}
+        </span>
+      )}
+    </>
   );
 }
 
@@ -221,8 +306,14 @@ export default function VideoPage() {
   const [isLoadingOriginalPlayback, setIsLoadingOriginalPlayback] = useState(false);
   const [isRetryingFailedProcessing, setIsRetryingFailedProcessing] = useState(false);
   const [retryFailedProcessingError, setRetryFailedProcessingError] = useState<string | null>(null);
+  const [deletingVideoId, setDeletingVideoId] = useState<Id<"videos"> | null>(null);
+  const [deleteNotice, setDeleteNotice] = useState<{
+    tone: "success" | "error";
+    message: string;
+  } | null>(null);
   const [preferredSource, setPreferredSource] = useState<"mux720" | "original">("original");
   const playerRef = useRef<VideoPlayerHandle | null>(null);
+  const deletePendingRef = useRef(false);
   const isPlayable = video?.status === "ready" && Boolean(video?.muxPlaybackId);
   const playbackUrl = playbackSession?.url ?? null;
   const activePlaybackUrl =
@@ -425,33 +516,88 @@ export default function VideoPage() {
     [requestVersionUpload, resolvedProjectId, resolvedVideoId, video?.versionStackId],
   );
 
-  const handleDeleteVersion = useCallback(async () => {
-    if (!video || !resolvedVideoId || !resolvedProjectId) return;
-    if (
-      !window.confirm(
-        `Delete ${video.isLatestVersion ? "the latest" : "the current"} version (v${video.versionNumber})? Its comments and share links will be deleted.${video.isLatestVersion ? " The previous version will become latest." : ""}`,
-      )
-    ) {
-      return;
-    }
-
-    try {
-      const result = await deleteVideo({ videoId: resolvedVideoId });
-      if (result.replacementVideoId) {
-        navigate({
-          to: videoPath(resolvedTeamSlug, resolvedProjectId, result.replacementVideoId),
-          replace: true,
-        });
-      } else {
-        navigate({
-          to: projectPath(resolvedTeamSlug, resolvedProjectId),
-          replace: true,
-        });
+  const handleDeleteVersion = useCallback(
+    async (versionToDelete: VideoVersion, animateSelectorRow = true, beforeDelete?: () => void) => {
+      if (deletePendingRef.current || !resolvedVideoId || !resolvedProjectId) return;
+      const isCurrentVersion = versionToDelete._id === resolvedVideoId;
+      const versionChangeCopy = animateSelectorRow
+        ? versionToDelete.isLatestVersion
+          ? " The previous version will become latest."
+          : " Later versions will be renumbered."
+        : "";
+      const destinationCopy = isCurrentVersion
+        ? animateSelectorRow
+          ? " You will be taken to the nearest remaining version."
+          : " You will return to the project."
+        : "";
+      if (
+        !window.confirm(
+          `Delete ${versionToDelete.isLatestVersion ? "latest " : ""}version v${versionToDelete.versionNumber}? Its comments and share links will be deleted.${versionChangeCopy}${destinationCopy} This can't be undone.`,
+        )
+      ) {
+        return;
       }
-    } catch (error) {
-      console.error("Failed to delete video version:", error);
-    }
-  }, [deleteVideo, navigate, resolvedProjectId, resolvedTeamSlug, resolvedVideoId, video]);
+
+      beforeDelete?.();
+      deletePendingRef.current = true;
+      setDeletingVideoId(versionToDelete._id);
+      setDeleteNotice(null);
+
+      try {
+        const deleteRequest = deleteVideo({ videoId: versionToDelete._id }).then(
+          (result) => ({ ok: true as const, result }),
+          (error: unknown) => ({ ok: false as const, error }),
+        );
+
+        if (animateSelectorRow) {
+          const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+          if (!reduceMotion) {
+            await new Promise<void>((resolve) => window.setTimeout(resolve, 180));
+          }
+        }
+
+        const outcome = await deleteRequest;
+        if (outcome.ok === false) {
+          throw outcome.error;
+        }
+
+        const result = outcome.result;
+        const successMessage = animateSelectorRow
+          ? versionToDelete.isLatestVersion
+            ? `Version v${versionToDelete.versionNumber} deleted. The previous version is now latest.`
+            : `Version v${versionToDelete.versionNumber} deleted. Later versions were renumbered.`
+          : "Video deleted. Returning to the project.";
+        setDeleteNotice({
+          tone: "success",
+          message: successMessage,
+        });
+
+        if (isCurrentVersion) {
+          if (result.replacementVideoId) {
+            navigate({
+              to: videoPath(resolvedTeamSlug, resolvedProjectId, result.replacementVideoId),
+              replace: true,
+            });
+          } else {
+            navigate({
+              to: projectPath(resolvedTeamSlug, resolvedProjectId),
+              replace: true,
+            });
+          }
+        }
+      } catch (error) {
+        console.error("Failed to delete video version:", error);
+        setDeleteNotice({
+          tone: "error",
+          message: "Couldn't delete that video version. Please try again.",
+        });
+      } finally {
+        deletePendingRef.current = false;
+        setDeletingVideoId(null);
+      }
+    },
+    [deleteVideo, navigate, resolvedProjectId, resolvedTeamSlug, resolvedVideoId],
+  );
 
   const handleRetryFailedProcessing = useCallback(async () => {
     if (!resolvedVideoId) return;
@@ -581,6 +727,11 @@ export default function VideoPage() {
               currentVersionNumber={video.versionNumber}
               teamSlug={resolvedTeamSlug}
               onSelect={handleVersionSelected}
+              canDelete={canDelete}
+              deletingVideoId={deletingVideoId}
+              onDelete={(versionToDelete, beforeDelete) =>
+                void handleDeleteVersion(versionToDelete, true, beforeDelete)
+              }
             />
           )}
           {canEdit && (
@@ -616,10 +767,22 @@ export default function VideoPage() {
                 <MessageSquare className="mr-2 h-4 w-4" />
                 Comments{comments && comments.length > 0 ? ` (${comments.length})` : ""}
               </DropdownMenuItem>
-              {canDelete && (
+              {canDelete && !showVersionSelector && (
                 <DropdownMenuItem
                   className="text-[#dc2626] focus:text-[#dc2626]"
-                  onSelect={() => void handleDeleteVersion()}
+                  disabled={deletingVideoId !== null}
+                  onSelect={() =>
+                    void handleDeleteVersion(
+                      {
+                        _id: resolvedVideoId,
+                        projectId: resolvedProjectId,
+                        versionNumber: video.versionNumber,
+                        status: video.status,
+                        isLatestVersion: video.isLatestVersion,
+                      },
+                      false,
+                    )
+                  }
                 >
                   <Trash2 className="mr-2 h-4 w-4" />
                   {`Delete ${video.isLatestVersion ? "latest" : "current"} version (v${video.versionNumber})`}
@@ -638,6 +801,11 @@ export default function VideoPage() {
               currentVersionNumber={video.versionNumber}
               teamSlug={resolvedTeamSlug}
               onSelect={handleVersionSelected}
+              canDelete={canDelete}
+              deletingVideoId={deletingVideoId}
+              onDelete={(versionToDelete, beforeDelete) =>
+                void handleDeleteVersion(versionToDelete, true, beforeDelete)
+              }
               compact
             />
           )}
@@ -681,10 +849,22 @@ export default function VideoPage() {
                 <MessageSquare className="mr-2 h-4 w-4" />
                 Comments{comments && comments.length > 0 ? ` (${comments.length})` : ""}
               </DropdownMenuItem>
-              {canDelete && (
+              {canDelete && !showVersionSelector && (
                 <DropdownMenuItem
                   className="text-[#dc2626] focus:text-[#dc2626]"
-                  onSelect={() => void handleDeleteVersion()}
+                  disabled={deletingVideoId !== null}
+                  onSelect={() =>
+                    void handleDeleteVersion(
+                      {
+                        _id: resolvedVideoId,
+                        projectId: resolvedProjectId,
+                        versionNumber: video.versionNumber,
+                        status: video.status,
+                        isLatestVersion: video.isLatestVersion,
+                      },
+                      false,
+                    )
+                  }
                 >
                   <Trash2 className="mr-2 h-4 w-4" />
                   {`Delete ${video.isLatestVersion ? "latest" : "current"} version (v${video.versionNumber})`}
@@ -900,6 +1080,29 @@ export default function VideoPage() {
         open={shareDialogOpen}
         onOpenChange={setShareDialogOpen}
       />
+      {deleteNotice ? (
+        <div
+          className={cn(
+            "fixed top-4 right-4 z-50 flex items-center gap-3 border-2 px-3 py-2 text-sm font-bold shadow-[4px_4px_0px_0px_var(--shadow-color)]",
+            deleteNotice.tone === "error"
+              ? "border-[#dc2626] bg-[#fef2f2] text-[#dc2626]"
+              : "border-[#1a1a1a] bg-[#f0f0e8] text-[#1a1a1a]",
+          )}
+          role={deleteNotice.tone === "error" ? "alert" : "status"}
+          aria-live={deleteNotice.tone === "error" ? "assertive" : "polite"}
+          aria-atomic="true"
+        >
+          <span>{deleteNotice.message}</span>
+          <button
+            type="button"
+            onClick={() => setDeleteNotice(null)}
+            className="inline-flex h-7 w-7 flex-shrink-0 items-center justify-center"
+            aria-label="Dismiss deletion notice"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -94,6 +94,8 @@ export default defineSchema({
     workflowStatus: v.union(v.literal("review"), v.literal("rework"), v.literal("done")),
     // Existing rows are implicit v1 videos. These fields are materialized when
     // the first additional version is created, so no backfill is required.
+    // versionStackId is an opaque stable identity and can keep referencing a
+    // deleted original v1 row.
     versionStackId: v.optional(v.id("videos")),
     versionNumber: v.optional(v.number()),
     supersededByVideoId: v.optional(v.id("videos")),

--- a/convex/videoVersions.vitest.ts
+++ b/convex/videoVersions.vitest.ts
@@ -760,6 +760,74 @@ test("deletes dependents in resumable batches after removing the version row", a
   }
 });
 
+test("finishes deletion jobs queued before version rows were removed eagerly", async () => {
+  vi.useFakeTimers();
+  try {
+    const t = convexTest(schema, modules);
+    const videoId = await t.run(async (ctx) => {
+      const teamId = await ctx.db.insert("teams", {
+        name: "Garden",
+        slug: "garden",
+        ownerClerkId: "owner",
+        plan: "basic",
+      });
+      const projectId = await ctx.db.insert("projects", {
+        teamId,
+        name: "Campaign",
+      });
+      const legacyVideoId = await ctx.db.insert("videos", {
+        projectId,
+        uploadedByClerkId: "owner",
+        uploaderName: "Owner",
+        title: "Legacy queued deletion",
+        visibility: "public",
+        publicId: "legacy-queued-delete",
+        status: "ready",
+        workflowStatus: "review",
+      });
+      for (let index = 0; index < 10; index += 1) {
+        await ctx.db.insert("comments", {
+          videoId: legacyVideoId,
+          userClerkId: "owner",
+          userName: "Owner",
+          text: `Legacy comment ${index}`,
+          timestampSeconds: index,
+          resolved: false,
+        });
+      }
+      return legacyVideoId;
+    });
+
+    await t.mutation(internal.videos.continueVideoDelete, { videoId });
+
+    const immediate = await t.run(async (ctx) => ({
+      video: await ctx.db.get(videoId),
+      comments: await ctx.db
+        .query("comments")
+        .withIndex("by_video", (q) => q.eq("videoId", videoId))
+        .collect(),
+    }));
+    expect(immediate.video).not.toBeNull();
+    expect(immediate.comments).toHaveLength(2);
+
+    await t.finishAllScheduledFunctions(() => vi.runAllTimers());
+
+    const completed = await t.run(async (ctx) => ({
+      video: await ctx.db.get(videoId),
+      comments: await ctx.db
+        .query("comments")
+        .withIndex("by_video", (q) => q.eq("videoId", videoId))
+        .collect(),
+    }));
+    expect(completed).toEqual({
+      video: null,
+      comments: [],
+    });
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
 test("deletes an unstacked legacy video with no replacement", async () => {
   const t = convexTest(schema, modules);
   const videoId = await t.run(async (ctx) => {

--- a/convex/videoVersions.vitest.ts
+++ b/convex/videoVersions.vitest.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 import { convexTest } from "convex-test";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { api, internal } from "./_generated/api";
 import { getTeamStorageUsedBytes } from "./billingHelpers";
 import { createVersionRecord, MAX_VIDEO_STACK_SIZE } from "./videos";
@@ -220,6 +220,127 @@ test("rejects a stack with more than one head", async () => {
   ).rejects.toThrow("exactly one latest version");
 });
 
+test("rejects deletion when the stack is not one connected chain", async () => {
+  const t = convexTest(schema, modules);
+  const seeded = await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "owner",
+      plan: "basic",
+    });
+    await ctx.db.insert("teamMembers", {
+      teamId,
+      userClerkId: "owner",
+      userEmail: "owner@example.com",
+      userName: "Owner",
+      role: "owner",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Campaign",
+    });
+    const v1 = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      title: "Cut",
+      visibility: "public",
+      publicId: "disconnected-v1",
+      status: "ready",
+      workflowStatus: "review",
+      versionNumber: 1,
+    });
+    await ctx.db.patch(v1, { versionStackId: v1 });
+    const v2 = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      title: "Cut",
+      visibility: "public",
+      publicId: "disconnected-v2",
+      status: "ready",
+      workflowStatus: "review",
+      versionStackId: v1,
+      versionNumber: 2,
+    });
+    const v3 = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      title: "Cut",
+      visibility: "public",
+      publicId: "disconnected-v3",
+      status: "ready",
+      workflowStatus: "review",
+      versionStackId: v1,
+      versionNumber: 3,
+    });
+    await ctx.db.patch(v1, { supersededByVideoId: v2 });
+    await ctx.db.patch(v3, { supersededByVideoId: v3 });
+    return { v1 };
+  });
+
+  await expect(
+    t.withIdentity({ subject: "owner" }).mutation(api.videos.remove, {
+      videoId: seeded.v1,
+    }),
+  ).rejects.toThrow("one connected acyclic chain");
+});
+
+test("rejects deletion when stack versions cross projects", async () => {
+  const t = convexTest(schema, modules);
+  const seeded = await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "owner",
+      plan: "basic",
+    });
+    await ctx.db.insert("teamMembers", {
+      teamId,
+      userClerkId: "owner",
+      userEmail: "owner@example.com",
+      userName: "Owner",
+      role: "owner",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Campaign",
+    });
+    const otherProjectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Other",
+    });
+    const v1 = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      title: "Cut",
+      visibility: "public",
+      publicId: "cross-project-v1",
+      status: "ready",
+      workflowStatus: "review",
+    });
+    return { otherProjectId, v1 };
+  });
+  const { videoId: v2 } = await t.run((ctx) =>
+    createVersionRecord(ctx, {
+      sourceVideoId: seeded.v1,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      publicId: "cross-project-v2",
+    }),
+  );
+  await t.run((ctx) => ctx.db.patch(v2, { projectId: seeded.otherProjectId }));
+
+  await expect(
+    t.withIdentity({ subject: "owner" }).mutation(api.videos.remove, {
+      videoId: seeded.v1,
+    }),
+  ).rejects.toThrow("must belong to the same project");
+});
+
 test("moves the whole stack and rewires middle and latest deletions", async () => {
   const t = convexTest(schema, modules);
   const seeded = await t.run(async (ctx) => {
@@ -296,13 +417,23 @@ test("moves the whole stack and rewires middle and latest deletions", async () =
     v3: await ctx.db.get(v3),
   }));
   expect(afterMiddleDelete.v2).toBeNull();
-  expect(afterMiddleDelete.v1?.supersededByVideoId).toBe(v3);
+  expect(afterMiddleDelete.v1).toMatchObject({
+    versionNumber: 1,
+    supersededByVideoId: v3,
+  });
+  expect(afterMiddleDelete.v3).toMatchObject({
+    versionNumber: 2,
+  });
   expect(afterMiddleDelete.v3?.supersededByVideoId).toBeUndefined();
 
   const latestDelete = await authed.mutation(api.videos.remove, { videoId: v3 });
   expect(latestDelete.replacementVideoId).toBe(seeded.v1);
 
   const promoted = await t.run((ctx) => ctx.db.get(seeded.v1));
+  expect(promoted).toMatchObject({
+    versionStackId: seeded.v1,
+    versionNumber: 1,
+  });
   expect(promoted?.supersededByVideoId).toBeUndefined();
 
   const visible = await authed.query(api.videos.list, {
@@ -369,7 +500,7 @@ test("refuses to move a stack whose versions do not share the source project", a
   ).rejects.toThrow("must belong to the same project");
 });
 
-test("deleting the first version preserves the remaining stack", async () => {
+test("deleting v1 preserves stable identities and supports creating the next version", async () => {
   const t = convexTest(schema, modules);
   const seeded = await t.run(async (ctx) => {
     const teamId = await ctx.db.insert("teams", {
@@ -418,6 +549,16 @@ test("deleting the first version preserves the remaining stack", async () => {
       publicId: "first-v3",
     }),
   );
+  const survivorShareLinkId = await t.run((ctx) =>
+    ctx.db.insert("shareLinks", {
+      videoId: v2,
+      token: "survivor-share-link",
+      createdByClerkId: "user_1",
+      createdByName: "Owner",
+      allowDownload: true,
+      viewCount: 0,
+    }),
+  );
 
   const authed = t.withIdentity({ subject: "user_1" });
   const result = await authed.mutation(api.videos.remove, { videoId: seeded.v1 });
@@ -425,12 +566,198 @@ test("deleting the first version preserves the remaining stack", async () => {
 
   const versions = await authed.query(api.videos.listVersions, { videoId: v2 });
   expect(versions.map((version) => [version._id, version.versionNumber])).toEqual([
-    [v3, 3],
-    [v2, 2],
+    [v3, 2],
+    [v2, 1],
   ]);
 
+  const preserved = await t.run(async (ctx) => ({
+    v2: await ctx.db.get(v2),
+    v3: await ctx.db.get(v3),
+    survivorShareLink: await ctx.db.get(survivorShareLinkId),
+  }));
+  expect(preserved.v2).toMatchObject({
+    publicId: "first-v2",
+    versionStackId: seeded.v1,
+    versionNumber: 1,
+    supersededByVideoId: v3,
+  });
+  expect(preserved.v3).toMatchObject({
+    publicId: "first-v3",
+    versionStackId: seeded.v1,
+    versionNumber: 2,
+  });
+  expect(preserved.survivorShareLink).toMatchObject({
+    videoId: v2,
+    token: "survivor-share-link",
+  });
+
+  const {
+    videoId: v4,
+    versionStackId,
+    versionNumber,
+  } = await t.run((ctx) =>
+    createVersionRecord(ctx, {
+      sourceVideoId: v2,
+      uploadedByClerkId: "user_1",
+      uploaderName: "Owner",
+      publicId: "first-v4",
+    }),
+  );
+  expect({ versionStackId, versionNumber }).toEqual({
+    versionStackId: seeded.v1,
+    versionNumber: 3,
+  });
+  const appended = await t.run((ctx) => ctx.db.get(v4));
+  expect(appended).toMatchObject({
+    publicId: "first-v4",
+    versionStackId: seeded.v1,
+    versionNumber: 3,
+  });
+
   const visible = await authed.query(api.videos.list, { projectId: seeded.projectId });
-  expect(visible.map((video) => video._id)).toEqual([v3]);
+  expect(visible.map((video) => video._id)).toEqual([v4]);
+});
+
+test("deletes dependents in resumable batches after removing the version row", async () => {
+  vi.useFakeTimers();
+  try {
+    const t = convexTest(schema, modules);
+    const seeded = await t.run(async (ctx) => {
+      const teamId = await ctx.db.insert("teams", {
+        name: "Garden",
+        slug: "garden",
+        ownerClerkId: "owner",
+        plan: "basic",
+      });
+      await ctx.db.insert("teamMembers", {
+        teamId,
+        userClerkId: "owner",
+        userEmail: "owner@example.com",
+        userName: "Owner",
+        role: "owner",
+      });
+      const projectId = await ctx.db.insert("projects", {
+        teamId,
+        name: "Campaign",
+      });
+      const v1 = await ctx.db.insert("videos", {
+        projectId,
+        uploadedByClerkId: "owner",
+        uploaderName: "Owner",
+        title: "Cut",
+        visibility: "public",
+        publicId: "batch-v1",
+        status: "ready",
+        workflowStatus: "review",
+      });
+      return { projectId, v1 };
+    });
+    const { videoId: v2 } = await t.run((ctx) =>
+      createVersionRecord(ctx, {
+        sourceVideoId: seeded.v1,
+        uploadedByClerkId: "owner",
+        uploaderName: "Owner",
+        publicId: "batch-v2",
+      }),
+    );
+    const { videoId: v3 } = await t.run((ctx) =>
+      createVersionRecord(ctx, {
+        sourceVideoId: v2,
+        uploadedByClerkId: "owner",
+        uploaderName: "Owner",
+        publicId: "batch-v3",
+      }),
+    );
+    const dependents = await t.run(async (ctx) => {
+      for (let index = 0; index < 26; index += 1) {
+        await ctx.db.insert("comments", {
+          videoId: v2,
+          userClerkId: "owner",
+          userName: "Owner",
+          text: `Comment ${index}`,
+          timestampSeconds: index,
+          resolved: false,
+        });
+      }
+      const shareLinkId = await ctx.db.insert("shareLinks", {
+        videoId: v2,
+        token: "batch-link",
+        createdByClerkId: "owner",
+        createdByName: "Owner",
+        allowDownload: true,
+        viewCount: 0,
+      });
+      const grantId = await ctx.db.insert("shareAccessGrants", {
+        shareLinkId,
+        token: "batch-grant",
+        expiresAt: Date.now() + 60_000,
+        createdAt: Date.now(),
+      });
+      return { shareLinkId, grantId };
+    });
+
+    const result = await t
+      .withIdentity({ subject: "owner" })
+      .mutation(api.videos.remove, { videoId: v2 });
+    expect(result.replacementVideoId).toBe(v3);
+
+    const immediate = await t.run(async (ctx) => ({
+      target: await ctx.db.get(v2),
+      v1: await ctx.db.get(seeded.v1),
+      v3: await ctx.db.get(v3),
+      remainingComments: await ctx.db
+        .query("comments")
+        .withIndex("by_video", (q) => q.eq("videoId", v2))
+        .collect(),
+    }));
+    expect(immediate.target).toBeNull();
+    expect(immediate.v1).toMatchObject({
+      versionNumber: 1,
+      supersededByVideoId: v3,
+    });
+    expect(immediate.v3).toMatchObject({
+      versionNumber: 2,
+    });
+    expect(immediate.remainingComments).toHaveLength(18);
+
+    vi.runOnlyPendingTimers();
+    await t.finishInProgressScheduledFunctions();
+    const afterFirstContinuation = await t.run((ctx) =>
+      ctx.db
+        .query("comments")
+        .withIndex("by_video", (q) => q.eq("videoId", v2))
+        .collect(),
+    );
+    expect(afterFirstContinuation).toHaveLength(10);
+
+    vi.runOnlyPendingTimers();
+    await t.finishInProgressScheduledFunctions();
+    const afterSecondContinuation = await t.run((ctx) =>
+      ctx.db
+        .query("comments")
+        .withIndex("by_video", (q) => q.eq("videoId", v2))
+        .collect(),
+    );
+    expect(afterSecondContinuation).toHaveLength(2);
+
+    await t.finishAllScheduledFunctions(() => vi.runAllTimers());
+
+    const completed = await t.run(async (ctx) => ({
+      comments: await ctx.db
+        .query("comments")
+        .withIndex("by_video", (q) => q.eq("videoId", v2))
+        .collect(),
+      shareLink: await ctx.db.get(dependents.shareLinkId),
+      grant: await ctx.db.get(dependents.grantId),
+    }));
+    expect(completed).toEqual({
+      comments: [],
+      shareLink: null,
+      grant: null,
+    });
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 test("deletes an unstacked legacy video with no replacement", async () => {
@@ -572,6 +899,11 @@ test("public version paths enforce authentication and member authorization", asy
       contentType: "video/mp4",
     }),
   ).rejects.toThrow("Requires member role or higher");
+  await expect(
+    t.withIdentity({ subject: "member" }).mutation(api.videos.remove, {
+      videoId: seeded.videoId,
+    }),
+  ).rejects.toThrow("Requires admin role or higher");
 
   const versions = await t
     .withIdentity({ subject: "member" })
@@ -637,6 +969,129 @@ test("abandoned version uploads atomically restore the previous head", async () 
     .withIdentity({ subject: "owner" })
     .query(api.videos.list, { projectId: seeded.projectId });
   expect(visible.map((video) => video._id)).toEqual([seeded.v1]);
+});
+
+test("rolling back a provisional middle version renumbers and remains appendable", async () => {
+  vi.useFakeTimers();
+  try {
+    const t = convexTest(schema, modules);
+    const seeded = await t.run(async (ctx) => {
+      const teamId = await ctx.db.insert("teams", {
+        name: "Garden",
+        slug: "garden",
+        ownerClerkId: "owner",
+        plan: "basic",
+      });
+      await ctx.db.insert("teamMembers", {
+        teamId,
+        userClerkId: "owner",
+        userEmail: "owner@example.com",
+        userName: "Owner",
+        role: "owner",
+      });
+      const projectId = await ctx.db.insert("projects", {
+        teamId,
+        name: "Campaign",
+      });
+      const v1 = await ctx.db.insert("videos", {
+        projectId,
+        uploadedByClerkId: "owner",
+        uploaderName: "Owner",
+        title: "Cut",
+        visibility: "public",
+        publicId: "middle-rollback-v1",
+        status: "ready",
+        workflowStatus: "review",
+      });
+      return { v1 };
+    });
+    const { videoId: v2 } = await t.run((ctx) =>
+      createVersionRecord(ctx, {
+        sourceVideoId: seeded.v1,
+        uploadedByClerkId: "owner",
+        uploaderName: "Owner",
+        publicId: "middle-rollback-v2",
+      }),
+    );
+    const { videoId: v3 } = await t.run((ctx) =>
+      createVersionRecord(ctx, {
+        sourceVideoId: v2,
+        uploadedByClerkId: "owner",
+        uploaderName: "Owner",
+        publicId: "middle-rollback-v3",
+      }),
+    );
+    await t.run(async (ctx) => {
+      for (let index = 0; index < 10; index += 1) {
+        await ctx.db.insert("comments", {
+          videoId: v2,
+          userClerkId: "owner",
+          userName: "Owner",
+          text: `Rollback comment ${index}`,
+          timestampSeconds: index,
+          resolved: false,
+        });
+      }
+    });
+
+    const result = await t.mutation(internal.videos.finalizeAbandonedUpload, {
+      videoId: v2,
+      uploadError: "Upload cancelled.",
+    });
+    expect(result.removedVersion).toBe(true);
+
+    const immediate = await t.run(async (ctx) => ({
+      v1: await ctx.db.get(seeded.v1),
+      v2: await ctx.db.get(v2),
+      v3: await ctx.db.get(v3),
+      remainingComments: await ctx.db
+        .query("comments")
+        .withIndex("by_video", (q) => q.eq("videoId", v2))
+        .collect(),
+    }));
+    expect(immediate.v2).toBeNull();
+    expect(immediate.v1).toMatchObject({
+      versionNumber: 1,
+      supersededByVideoId: v3,
+    });
+    expect(immediate.v3).toMatchObject({
+      versionNumber: 2,
+    });
+    expect(immediate.remainingComments).toHaveLength(2);
+
+    const appended = await t.run((ctx) =>
+      createVersionRecord(ctx, {
+        sourceVideoId: seeded.v1,
+        uploadedByClerkId: "owner",
+        uploaderName: "Owner",
+        publicId: "middle-rollback-v4",
+      }),
+    );
+    expect(appended).toMatchObject({
+      versionStackId: seeded.v1,
+      versionNumber: 3,
+    });
+
+    const versions = await t
+      .withIdentity({ subject: "owner" })
+      .query(api.videos.listVersions, { videoId: appended.videoId });
+    expect(versions.map((version) => [version._id, version.versionNumber])).toEqual([
+      [appended.videoId, 3],
+      [v3, 2],
+      [seeded.v1, 1],
+    ]);
+
+    await t.finishAllScheduledFunctions(() => vi.runAllTimers());
+    const remainingComments = await t.run((ctx) =>
+      ctx.db
+        .query("comments")
+        .withIndex("by_video", (q) => q.eq("videoId", v2))
+        .collect(),
+    );
+    expect(remainingComments).toEqual([]);
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 test("hard failure after promotion rolls back a version before a Mux asset exists", async () => {
@@ -936,6 +1391,77 @@ test("concurrent version creation serializes into one ordered chain", async () =
   expect(chain[0]?.[1]).toBeTruthy();
   expect(chain[1]?.[1]).toBeTruthy();
   expect(chain[2]?.[1]).toBeNull();
+});
+
+test("concurrent version creation and deletion preserve a contiguous chain", async () => {
+  const t = convexTest(schema, modules);
+  const seeded = await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "owner",
+      plan: "basic",
+    });
+    await ctx.db.insert("teamMembers", {
+      teamId,
+      userClerkId: "owner",
+      userEmail: "owner@example.com",
+      userName: "Owner",
+      role: "owner",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Campaign",
+    });
+    const v1 = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      title: "Cut",
+      visibility: "public",
+      publicId: "concurrent-delete-v1",
+      status: "ready",
+      workflowStatus: "review",
+    });
+    return { v1 };
+  });
+  const { videoId: v2 } = await t.run((ctx) =>
+    createVersionRecord(ctx, {
+      sourceVideoId: seeded.v1,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      publicId: "concurrent-delete-v2",
+    }),
+  );
+  await t.run((ctx) =>
+    createVersionRecord(ctx, {
+      sourceVideoId: v2,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      publicId: "concurrent-delete-v3",
+    }),
+  );
+
+  const [created] = await Promise.all([
+    t.run((ctx) =>
+      createVersionRecord(ctx, {
+        sourceVideoId: seeded.v1,
+        uploadedByClerkId: "owner",
+        uploaderName: "Owner",
+        publicId: "concurrent-delete-v4",
+      }),
+    ),
+    t.withIdentity({ subject: "owner" }).mutation(api.videos.remove, {
+      videoId: v2,
+    }),
+  ]);
+
+  const versions = await t
+    .withIdentity({ subject: "owner" })
+    .query(api.videos.listVersions, { videoId: created.videoId });
+  expect(versions.map((version) => version.versionNumber)).toEqual([3, 2, 1]);
+  expect(versions.map((version) => version._id)).toContain(created.videoId);
+  await expect(t.run((ctx) => ctx.db.get(v2))).resolves.toBeNull();
 });
 
 test("version stack operations enforce the explicit stack limit", async () => {

--- a/convex/videos.ts
+++ b/convex/videos.ts
@@ -23,10 +23,13 @@ const workflowStatusValidator = v.union(
 
 const visibilityValidator = v.union(v.literal("public"), v.literal("private"));
 
-const VIDEO_DELETE_BATCH_DOCS = 500;
+const VIDEO_DEPENDENT_DELETE_BATCH_DOCS = 8;
 export const MAX_VIDEO_STACK_SIZE = 100;
 const VIDEO_STACK_LIMIT_ERROR = `A video can have at most ${MAX_VIDEO_STACK_SIZE} versions.`;
 const VIDEO_STACK_HEAD_ERROR = "A video version stack must have exactly one latest version.";
+const VIDEO_STACK_CHAIN_ERROR =
+  "A video version stack must be one connected acyclic chain within a single project.";
+const VIDEO_STACK_PROJECT_ERROR = "All versions of a video must belong to the same project";
 
 type WorkflowStatus = "review" | "rework" | "done";
 type StackReadCtx = Pick<QueryCtx, "db">;
@@ -39,10 +42,13 @@ function normalizeVersionNumber(video: Doc<"videos">) {
   return video.versionNumber ?? 1;
 }
 
-async function getStackVersions(ctx: StackReadCtx, video: Doc<"videos">) {
+async function getOrderedStackVersions(ctx: StackReadCtx, video: Doc<"videos">) {
   if (!video.versionStackId) {
+    if (video.supersededByVideoId !== undefined) {
+      throw new Error(VIDEO_STACK_CHAIN_ERROR);
+    }
     return {
-      versions: [video],
+      oldestToNewest: [video],
       latest: video,
     };
   }
@@ -59,19 +65,65 @@ async function getStackVersions(ctx: StackReadCtx, video: Doc<"videos">) {
     throw new Error(VIDEO_STACK_LIMIT_ERROR);
   }
 
-  const latestVersions = versions.filter(
-    (stackVersion) => stackVersion.supersededByVideoId === undefined,
-  );
-  if (latestVersions.length !== 1) {
+  if (!versions.some((stackVersion) => stackVersion._id === video._id)) {
+    throw new Error(VIDEO_STACK_CHAIN_ERROR);
+  }
+  if (!versions.every((stackVersion) => stackVersion.projectId === video.projectId)) {
+    throw new Error(VIDEO_STACK_PROJECT_ERROR);
+  }
+
+  const heads = versions.filter((stackVersion) => stackVersion.supersededByVideoId === undefined);
+  if (heads.length !== 1) {
     throw new Error(VIDEO_STACK_HEAD_ERROR);
   }
 
+  const byId = new Map(versions.map((stackVersion) => [stackVersion._id, stackVersion]));
+  const predecessorCounts = new Map(versions.map((stackVersion) => [stackVersion._id, 0]));
+
+  for (const stackVersion of versions) {
+    if (!stackVersion.supersededByVideoId) continue;
+    if (!byId.has(stackVersion.supersededByVideoId)) {
+      throw new Error(VIDEO_STACK_CHAIN_ERROR);
+    }
+    const predecessorCount = predecessorCounts.get(stackVersion.supersededByVideoId);
+    if (predecessorCount === undefined || predecessorCount > 0) {
+      throw new Error(VIDEO_STACK_CHAIN_ERROR);
+    }
+    predecessorCounts.set(stackVersion.supersededByVideoId, predecessorCount + 1);
+  }
+
+  const roots = versions.filter((stackVersion) => predecessorCounts.get(stackVersion._id) === 0);
+  if (roots.length !== 1) {
+    throw new Error(VIDEO_STACK_CHAIN_ERROR);
+  }
+
+  const oldestToNewest: Doc<"videos">[] = [];
+  const visited = new Set<Id<"videos">>();
+  let current: Doc<"videos"> | undefined = roots[0];
+  while (current) {
+    if (visited.has(current._id)) {
+      throw new Error(VIDEO_STACK_CHAIN_ERROR);
+    }
+    visited.add(current._id);
+    oldestToNewest.push(current);
+    current = current.supersededByVideoId ? byId.get(current.supersededByVideoId) : undefined;
+  }
+
+  if (oldestToNewest.length !== versions.length || oldestToNewest.at(-1)?._id !== heads[0]._id) {
+    throw new Error(VIDEO_STACK_CHAIN_ERROR);
+  }
+
   return {
-    versions: [...versions].sort(
-      (a, b) =>
-        normalizeVersionNumber(b) - normalizeVersionNumber(a) || b._creationTime - a._creationTime,
-    ),
-    latest: latestVersions[0],
+    oldestToNewest,
+    latest: heads[0],
+  };
+}
+
+async function getStackVersions(ctx: StackReadCtx, video: Doc<"videos">) {
+  const { oldestToNewest, latest } = await getOrderedStackVersions(ctx, video);
+  return {
+    versions: [...oldestToNewest].reverse(),
+    latest,
   };
 }
 
@@ -100,7 +152,17 @@ async function failOrRollbackUpload(ctx: MutationCtx, video: Doc<"videos">, uplo
     video.status !== "ready" &&
     !video.muxAssetId
   ) {
-    await deleteVideoAndDependents(ctx, video._id);
+    await deleteVersionAndRenumberStack(ctx, video);
+    const result = await deleteVideoDependentsBatch(
+      ctx,
+      video._id,
+      VIDEO_DEPENDENT_DELETE_BATCH_DOCS,
+    );
+    if (!result.done) {
+      await ctx.scheduler.runAfter(0, internal.videos.continueVideoDelete, {
+        videoId: video._id,
+      });
+    }
     return true;
   }
 
@@ -243,6 +305,78 @@ export async function deleteVideoAndDependentsBatch(
   await rewireStackBeforeDelete(ctx, video);
   await ctx.db.delete(videoId);
   return { deleted: deleted + 1, done: true };
+}
+
+async function deleteVideoDependentsBatch(
+  ctx: MutationCtx,
+  videoId: Id<"videos">,
+  maxDocuments: number,
+) {
+  let remaining = maxDocuments;
+  let deleted = 0;
+
+  const comments = await ctx.db
+    .query("comments")
+    .withIndex("by_video", (q) => q.eq("videoId", videoId))
+    .take(remaining);
+  for (const comment of comments) {
+    await ctx.db.delete(comment._id);
+  }
+  deleted += comments.length;
+  remaining -= comments.length;
+  if (remaining === 0) return { deleted, done: false };
+
+  while (remaining > 0) {
+    const link = await ctx.db
+      .query("shareLinks")
+      .withIndex("by_video", (q) => q.eq("videoId", videoId))
+      .first();
+    if (!link) {
+      return { deleted, done: true };
+    }
+
+    const grants = await ctx.db
+      .query("shareAccessGrants")
+      .withIndex("by_share_link", (q) => q.eq("shareLinkId", link._id))
+      .take(remaining);
+    for (const grant of grants) {
+      await ctx.db.delete(grant._id);
+    }
+    deleted += grants.length;
+    remaining -= grants.length;
+    if (remaining === 0) return { deleted, done: false };
+
+    await ctx.db.delete(link._id);
+    deleted++;
+    remaining--;
+  }
+
+  return { deleted, done: false };
+}
+
+async function deleteVersionAndRenumberStack(ctx: MutationCtx, video: Doc<"videos">) {
+  const { oldestToNewest } = await getOrderedStackVersions(ctx, video);
+  const targetIndex = oldestToNewest.findIndex((stackVersion) => stackVersion._id === video._id);
+  if (targetIndex === -1) {
+    throw new Error(VIDEO_STACK_CHAIN_ERROR);
+  }
+
+  const replacementVideoId =
+    oldestToNewest[targetIndex + 1]?._id ?? oldestToNewest[targetIndex - 1]?._id ?? null;
+  const survivors = oldestToNewest.filter((stackVersion) => stackVersion._id !== video._id);
+
+  if (video.versionStackId) {
+    for (const [index, survivor] of survivors.entries()) {
+      await ctx.db.patch(survivor._id, {
+        versionStackId: video.versionStackId,
+        versionNumber: index + 1,
+        supersededByVideoId: survivors[index + 1]?._id,
+      });
+    }
+  }
+
+  await ctx.db.delete(video._id);
+  return replacementVideoId;
 }
 
 async function insertVersionRecord(
@@ -666,10 +800,12 @@ export const remove = mutation({
   }),
   handler: async (ctx, args) => {
     const { video } = await requireVideoAccess(ctx, args.videoId, "admin");
-    await getStackVersions(ctx, video);
-    const predecessor = await getPredecessor(ctx, args.videoId);
-    const replacementVideoId = video.supersededByVideoId ?? predecessor?._id ?? null;
-    const result = await deleteVideoAndDependentsBatch(ctx, args.videoId, VIDEO_DELETE_BATCH_DOCS);
+    const replacementVideoId = await deleteVersionAndRenumberStack(ctx, video);
+    const result = await deleteVideoDependentsBatch(
+      ctx,
+      args.videoId,
+      VIDEO_DEPENDENT_DELETE_BATCH_DOCS,
+    );
     if (!result.done) {
       await ctx.scheduler.runAfter(0, internal.videos.continueVideoDelete, {
         videoId: args.videoId,
@@ -682,7 +818,11 @@ export const remove = mutation({
 export const continueVideoDelete = internalMutation({
   args: { videoId: v.id("videos") },
   handler: async (ctx, args) => {
-    const result = await deleteVideoAndDependentsBatch(ctx, args.videoId, VIDEO_DELETE_BATCH_DOCS);
+    const result = await deleteVideoDependentsBatch(
+      ctx,
+      args.videoId,
+      VIDEO_DEPENDENT_DELETE_BATCH_DOCS,
+    );
     if (!result.done) {
       await ctx.scheduler.runAfter(0, internal.videos.continueVideoDelete, args);
     }

--- a/convex/videos.ts
+++ b/convex/videos.ts
@@ -818,6 +818,19 @@ export const remove = mutation({
 export const continueVideoDelete = internalMutation({
   args: { videoId: v.id("videos") },
   handler: async (ctx, args) => {
+    const existingVideo = await ctx.db.get(args.videoId);
+    if (existingVideo) {
+      const legacyResult = await deleteVideoAndDependentsBatch(
+        ctx,
+        args.videoId,
+        VIDEO_DEPENDENT_DELETE_BATCH_DOCS,
+      );
+      if (!legacyResult.done) {
+        await ctx.scheduler.runAfter(0, internal.videos.continueVideoDelete, args);
+      }
+      return;
+    }
+
     const result = await deleteVideoDependentsBatch(
       ctx,
       args.videoId,

--- a/src/lib/videoVersionDeletion.test.ts
+++ b/src/lib/videoVersionDeletion.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Id } from "@convex/_generated/dataModel";
+import { findPreferredReplacementVideoId } from "./videoVersionDeletion";
+
+const v1 = "video-v1" as Id<"videos">;
+const v2 = "video-v2" as Id<"videos">;
+const v3 = "video-v3" as Id<"videos">;
+
+test("prefers the newer survivor for a middle version", () => {
+  assert.equal(findPreferredReplacementVideoId([{ _id: v3 }, { _id: v2 }, { _id: v1 }], v2), v3);
+});
+
+test("falls back to the older survivor for the latest version", () => {
+  assert.equal(findPreferredReplacementVideoId([{ _id: v3 }, { _id: v2 }, { _id: v1 }], v3), v2);
+});
+
+test("returns null when no version survives", () => {
+  assert.equal(findPreferredReplacementVideoId([{ _id: v1 }], v1), null);
+});

--- a/src/lib/videoVersionDeletion.ts
+++ b/src/lib/videoVersionDeletion.ts
@@ -1,0 +1,11 @@
+import type { Id } from "@convex/_generated/dataModel";
+
+export function findPreferredReplacementVideoId(
+  versions: ReadonlyArray<{ _id: Id<"videos"> }> | undefined,
+  deletingVideoId: Id<"videos">,
+) {
+  const deletingIndex = versions?.findIndex((version) => version._id === deletingVideoId) ?? -1;
+  if (deletingIndex === -1 || !versions) return null;
+
+  return versions[deletingIndex - 1]?._id ?? versions[deletingIndex + 1]?._id ?? null;
+}


### PR DESCRIPTION
## Summary
- add admin-only trash actions beside every entry in the video version selector
- animate deleted versions out and renumber surviving versions without gaps
- preserve surviving video IDs, public links, and share links while navigating away from deleted current versions
- validate version chains and clean deleted comments/share data in byte-safe resumable batches

## User impact
Admins and owners can remove any video version directly from the selector. Remaining versions keep their order, slide into place, and are relabeled contiguously.

## Validation
- bunx vitest run convex/videoVersions.vitest.ts (21 passed)
- bun run check (18 unit tests and 21 Convex tests passed)
- git diff --check

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add video version deletion with renumbering, optimistic navigation, and async dependent cleanup
> - The `videos.remove` mutation in [convex/videos.ts](https://github.com/pingdotgg/lawn/pull/44/files#diff-dcea06e0ecce2d53d2266e8caf9b5ed2b597b910af5be8112fba22fecd272547) now immediately removes the target version, renumbers the surviving stack to maintain a contiguous sequence, returns a `replacementVideoId`, and processes dependent deletions (comments, share links, grants) asynchronously in resumable batches.
> - The video page gains a delete flow with confirmation dialogs (copy varies by version position and whether navigation will occur), optimistic navigation to a neighboring version before awaiting the server result, and dismissible outcome notices.
> - Each row in the `VersionSelectorOption` dropdown gains a trash icon delete button; the selector marks itself `aria-busy` during deletion, keeps the list stable, and announces progress via an offscreen live region.
> - `findPreferredReplacementVideoId` in [src/lib/videoVersionDeletion.ts](https://github.com/pingdotgg/lawn/pull/44/files#diff-dd86b082e59485c5ab9c877998176aff91445b00c033d8c89d343e92ec314fee) picks the previous version first, then the next, for client-side optimistic navigation.
> - Risk: deleting the currently viewed version navigates optimistically before the server confirms; if the server returns a different replacement, a secondary navigation reconciliation occurs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a2c070.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the dashboard video version deletion experience with clearer, context-aware confirmation prompts and updated selection/trigger behavior.
  * Added improved UI deletion states (disabled actions while deleting), animated row collapse, stable version handling during transitions, and a dismissible deletion notice with live updates.
  * Improved accessibility and orientation with focus moving to the nearest remaining version after deletion.
  * Extended deletion controls to both desktop and compact/mobile action menus.

* **Bug Fixes**
  * Improved reliability of version-stack traversal and deletion/rollback flows, including safer replacement selection and consistent navigation after removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->