### PR TITLE
Fix public watch unavailable for videos with version stacks

### DIFF
--- a/app/routes/-watch.data.ts
+++ b/app/routes/-watch.data.ts
@@ -7,6 +7,9 @@ export function getWatchEssentialSpecs(params: { publicId: string }) {
     makeRouteQuerySpec(api.videos.getByPublicId, {
       publicId: params.publicId,
     }),
+    makeRouteQuerySpec(api.videos.listPublicVersions, {
+      publicId: params.publicId,
+    }),
     makeRouteQuerySpec(api.comments.getThreadedForPublic, {
       publicId: params.publicId,
     }),
@@ -18,11 +21,15 @@ export function useWatchData(params: { publicId: string }) {
     publicId: params.publicId,
   });
 
+  const versions = useQuery(api.videos.listPublicVersions, {
+    publicId: params.publicId,
+  });
+
   const comments = useQuery(api.comments.getThreadedForPublic, {
     publicId: params.publicId,
   });
 
-  return { videoData, comments };
+  return { videoData, versions, comments };
 }
 
 export async function prewarmWatch(convex: ConvexReactClient, params: { publicId: string }) {

--- a/app/routes/-watch.tsx
+++ b/app/routes/-watch.tsx
@@ -1,28 +1,39 @@
 import { useAction, useMutation } from "convex/react";
 import { api } from "@convex/_generated/api";
-import { Link, useParams } from "@tanstack/react-router";
+import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import { useUser } from "@clerk/tanstack-react-start";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { VideoPlayer, type VideoPlayerHandle } from "@/components/video-player/VideoPlayer";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { CommentText } from "@/components/comments/CommentText";
 import { triggerDownload } from "@/lib/download";
+import { watchPath } from "@/lib/routes";
 import { formatDuration, formatTimestamp, formatRelativeTime } from "@/lib/utils";
-import { AlertCircle, MessageSquare, Clock, Download, X } from "lucide-react";
+import { AlertCircle, Layers3, MessageSquare, Clock, Download, X } from "lucide-react";
 import { useWatchData } from "./-watch.data";
 
 export default function WatchPage() {
   const params = useParams({ strict: false });
   const publicId = params.publicId as string;
+  const navigate = useNavigate();
   const { user, isLoaded: isUserLoaded } = useUser();
 
   const createComment = useMutation(api.comments.createForPublic);
   const getPlaybackSession = useAction(api.videoActions.getPublicPlaybackSession);
   const getDownloadUrl = useAction(api.videoActions.getPublicDownloadUrl);
 
-  const { videoData, comments } = useWatchData({ publicId });
+  const { videoData, versions, comments } = useWatchData({ publicId });
   const [playbackSession, setPlaybackSession] = useState<{
     url: string;
     posterUrl: string;
@@ -208,6 +219,41 @@ export default function WatchPage() {
               <span className="hidden text-[#ccc] sm:inline">·</span>
               <span className="hidden font-mono sm:inline">{formatDuration(video.duration)}</span>
             </>
+          )}
+          {versions && versions.length > 1 && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8"
+                  aria-label={`Select version, currently v${video.versionNumber}`}
+                >
+                  <Layers3 className="h-4 w-4" />
+                  <span className="hidden sm:inline">v{video.versionNumber}</span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-44">
+                <DropdownMenuLabel>Versions</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuRadioGroup value={video.publicId}>
+                  {versions.map((version) => (
+                    <DropdownMenuRadioItem
+                      key={version.publicId}
+                      value={version.publicId}
+                      onSelect={() => {
+                        if (version.publicId !== video.publicId) {
+                          void navigate({ to: watchPath(version.publicId) });
+                        }
+                      }}
+                    >
+                      <span className="font-bold">v{version.versionNumber}</span>
+                      {version.isLatest && <span className="ml-2 text-xs text-[#888]">Latest</span>}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
           )}
           <Button
             variant="outline"

--- a/app/routes/-watch.tsx
+++ b/app/routes/-watch.tsx
@@ -230,7 +230,7 @@ export default function WatchPage() {
                   aria-label={`Select version, currently v${video.versionNumber}`}
                 >
                   <Layers3 className="h-4 w-4" />
-                  <span className="hidden sm:inline">v{video.versionNumber}</span>
+                  <span className="hidden font-mono sm:inline">v{video.versionNumber}</span>
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="min-w-44">
@@ -247,7 +247,7 @@ export default function WatchPage() {
                         }
                       }}
                     >
-                      <span className="font-bold">v{version.versionNumber}</span>
+                      <span className="font-mono font-bold">v{version.versionNumber}</span>
                       {version.isLatest && <span className="ml-2 text-xs text-[#888]">Latest</span>}
                     </DropdownMenuRadioItem>
                   ))}

--- a/app/routes/-watch.tsx
+++ b/app/routes/-watch.tsx
@@ -139,6 +139,25 @@ export default function WatchPage() {
     );
   }
 
+  if (videoData?.processing) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[#f0f0e8] p-4">
+        <Card className="w-full max-w-md">
+          <CardHeader className="text-center">
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center border-2 border-[#1a1a1a]">
+              <div className="h-6 w-6 animate-spin rounded-full border-2 border-[#1a1a1a]/20 border-t-[#1a1a1a]" />
+            </div>
+            <CardTitle>Processing video</CardTitle>
+            <CardDescription>
+              {videoData.title ? `“${videoData.title}” is` : "This video is"} still processing and
+              will be ready to watch shortly. This page updates automatically.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    );
+  }
+
   if (!videoData?.video) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-[#f0f0e8] p-4">

--- a/convex/comments.ts
+++ b/convex/comments.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import { mutation, query, MutationCtx, QueryCtx } from "./_generated/server";
 import { identityAvatarUrl, identityName, requireVideoAccess, requireUser } from "./auth";
 import { resolveActiveShareGrant } from "./shareAccess";
+import { resolvePublicVideo } from "./videos";
 
 function toThreadedComments<
   T extends { _id: string; parentId?: string; timestampSeconds: number; _creationTime: number },
@@ -41,16 +42,9 @@ function toPublicCommentPayload(comment: {
 }
 
 async function getPublicVideoByPublicId(ctx: QueryCtx | MutationCtx, publicId: string) {
-  const video = await ctx.db
-    .query("videos")
-    .withIndex("by_public_id", (q) => q.eq("publicId", publicId))
-    .unique();
-
-  if (!video || video.visibility !== "public" || video.status !== "ready") {
-    return null;
-  }
-
-  return video;
+  // Resolve to the same version the public watch page serves so comments are
+  // read from and written to the cut the viewer is actually watching.
+  return await resolvePublicVideo(ctx, publicId);
 }
 
 export const list = query({

--- a/convex/publicWatch.vitest.ts
+++ b/convex/publicWatch.vitest.ts
@@ -72,8 +72,8 @@ test("serves the latest ready version when the shared head is still processing",
   expect(head?.status).toBe("uploading");
 });
 
-test("serves the newest version once it becomes ready", async () => {
-  const { t, v2 } = await seedPublicStack();
+test("each version link resolves to its own version once ready (browsing on)", async () => {
+  const { t, v1, v2 } = await seedPublicStack();
 
   await t.run(async (ctx) => {
     await ctx.db.patch(v2 as Id<"videos">, {
@@ -82,10 +82,56 @@ test("serves the newest version once it becomes ready", async () => {
     });
   });
 
+  const r1 = await t.query(api.videos.getByPublicId, { publicId: "watch-v1" });
+  expect(r1?.video?._id).toBe(v1);
+  expect(r1?.video?.versionNumber).toBe(1);
+
+  const r2 = await t.query(api.videos.getByPublicId, { publicId: "watch-v2" });
+  expect(r2?.video?._id).toBe(v2);
+  expect(r2?.video?.versionNumber).toBe(2);
+  expect(r2?.allowVersionBrowsing).toBe(true);
+
+  // The switcher lists every public, ready version oldest-first.
+  const versions = await t.query(api.videos.listPublicVersions, { publicId: "watch-v1" });
+  expect(versions.map((version) => [version.versionNumber, version.isLatest])).toEqual([
+    [1, false],
+    [2, true],
+  ]);
+});
+
+test("disabling version browsing collapses links to the latest version", async () => {
+  const { t, v1, v2 } = await seedPublicStack();
+
+  await t.run(async (ctx) => {
+    await ctx.db.patch(v2 as Id<"videos">, {
+      status: "ready",
+      muxPlaybackId: "playback-v2",
+    });
+  });
+
+  await t.withIdentity({ subject: "user_1" }).mutation(api.videos.setPublicVersionBrowsing, {
+    videoId: v1 as Id<"videos">,
+    enabled: false,
+  });
+
+  // The flag is applied across every version in the stack.
+  const flags = await t.run(async (ctx) => ({
+    v1: (await ctx.db.get(v1 as Id<"videos">))?.allowPublicVersionBrowsing,
+    v2: (await ctx.db.get(v2 as Id<"videos">))?.allowPublicVersionBrowsing,
+  }));
+  expect(flags.v1).toBe(false);
+  expect(flags.v2).toBe(false);
+
+  // With browsing off, every link resolves to the latest ready version...
   for (const publicId of ["watch-v1", "watch-v2"]) {
     const result = await t.query(api.videos.getByPublicId, { publicId });
     expect(result?.video?._id).toBe(v2);
+    expect(result?.allowVersionBrowsing).toBe(false);
   }
+
+  // ...and the switcher is empty.
+  const versions = await t.query(api.videos.listPublicVersions, { publicId: "watch-v1" });
+  expect(versions).toEqual([]);
 });
 
 test("setVisibility toggles every version in the stack and gates the public URL", async () => {

--- a/convex/publicWatch.vitest.ts
+++ b/convex/publicWatch.vitest.ts
@@ -62,9 +62,13 @@ test("serves the latest ready version when the shared head is still processing",
 
   // The head (v2) is still processing, so both the head's and the older
   // version's public links should resolve to the ready v1 instead of failing.
+  // getByPublicIdForDownload shares the resolver, so it must stay in lockstep.
   for (const publicId of ["watch-v1", "watch-v2"]) {
     const result = await t.query(api.videos.getByPublicId, { publicId });
     expect(result?.video?._id).toBe(v1);
+
+    const download = await t.query(api.videos.getByPublicIdForDownload, { publicId });
+    expect(download?.video?._id).toBe(v1);
   }
 
   // Sanity: v2 really is the not-ready head.

--- a/convex/publicWatch.vitest.ts
+++ b/convex/publicWatch.vitest.ts
@@ -1,0 +1,134 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { expect, test } from "vitest";
+import { api } from "./_generated/api";
+import { createVersionRecord } from "./videos";
+import schema from "./schema";
+import type { Id } from "./_generated/dataModel";
+
+const modules = import.meta.glob("./**/*.ts");
+
+async function seedPublicStack() {
+  const t = convexTest(schema, modules);
+  const seeded = await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "user_1",
+      plan: "basic",
+    });
+    await ctx.db.insert("teamMembers", {
+      teamId,
+      userClerkId: "user_1",
+      userEmail: "owner@example.com",
+      userName: "Owner",
+      role: "admin",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Campaign",
+    });
+    const v1 = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "user_1",
+      uploaderName: "Owner",
+      title: "First cut",
+      visibility: "public",
+      publicId: "watch-v1",
+      status: "ready",
+      muxPlaybackId: "playback-v1",
+      workflowStatus: "review",
+    });
+    return { teamId, projectId, v1 };
+  });
+
+  // v2 becomes the stack head. insertVersionRecord starts it at status
+  // "uploading" and inherits the head's "public" visibility.
+  const { videoId: v2 } = await t.run((ctx) =>
+    createVersionRecord(ctx, {
+      sourceVideoId: seeded.v1,
+      uploadedByClerkId: "user_1",
+      uploaderName: "Owner",
+      publicId: "watch-v2",
+    }),
+  );
+
+  return { t, ...seeded, v2 };
+}
+
+test("serves the latest ready version when the shared head is still processing", async () => {
+  const { t, v1, v2 } = await seedPublicStack();
+
+  // The head (v2) is still processing, so both the head's and the older
+  // version's public links should resolve to the ready v1 instead of failing.
+  for (const publicId of ["watch-v1", "watch-v2"]) {
+    const result = await t.query(api.videos.getByPublicId, { publicId });
+    expect(result?.video._id).toBe(v1);
+  }
+
+  // Sanity: v2 really is the not-ready head.
+  const head = await t.run((ctx) => ctx.db.get(v2 as Id<"videos">));
+  expect(head?.status).toBe("uploading");
+});
+
+test("serves the newest version once it becomes ready", async () => {
+  const { t, v2 } = await seedPublicStack();
+
+  await t.run(async (ctx) => {
+    await ctx.db.patch(v2 as Id<"videos">, {
+      status: "ready",
+      muxPlaybackId: "playback-v2",
+    });
+  });
+
+  for (const publicId of ["watch-v1", "watch-v2"]) {
+    const result = await t.query(api.videos.getByPublicId, { publicId });
+    expect(result?.video._id).toBe(v2);
+  }
+});
+
+test("setVisibility toggles every version in the stack and gates the public URL", async () => {
+  const { t, v1, v2 } = await seedPublicStack();
+
+  await t.run(async (ctx) => {
+    await ctx.db.patch(v2 as Id<"videos">, {
+      status: "ready",
+      muxPlaybackId: "playback-v2",
+    });
+  });
+
+  await t
+    .withIdentity({ subject: "user_1" })
+    .mutation(api.videos.setVisibility, { videoId: v2 as Id<"videos">, visibility: "private" });
+
+  const afterPrivate = await t.run(async (ctx) => ({
+    v1: await ctx.db.get(v1 as Id<"videos">),
+    v2: await ctx.db.get(v2 as Id<"videos">),
+  }));
+  expect(afterPrivate.v1?.visibility).toBe("private");
+  expect(afterPrivate.v2?.visibility).toBe("private");
+
+  // Private disables the public watch link for every version in the stack.
+  for (const publicId of ["watch-v1", "watch-v2"]) {
+    const result = await t.query(api.videos.getByPublicId, { publicId });
+    expect(result).toBeNull();
+  }
+
+  await t
+    .withIdentity({ subject: "user_1" })
+    .mutation(api.videos.setVisibility, { videoId: v1 as Id<"videos">, visibility: "public" });
+
+  const afterPublic = await t.run(async (ctx) => ({
+    v1: await ctx.db.get(v1 as Id<"videos">),
+    v2: await ctx.db.get(v2 as Id<"videos">),
+  }));
+  expect(afterPublic.v1?.visibility).toBe("public");
+  expect(afterPublic.v2?.visibility).toBe("public");
+});
+
+test("returns null for an unknown public id", async () => {
+  const { t } = await seedPublicStack();
+  const result = await t.query(api.videos.getByPublicId, { publicId: "does-not-exist" });
+  expect(result).toBeNull();
+});

--- a/convex/publicWatch.vitest.ts
+++ b/convex/publicWatch.vitest.ts
@@ -64,7 +64,7 @@ test("serves the latest ready version when the shared head is still processing",
   // version's public links should resolve to the ready v1 instead of failing.
   for (const publicId of ["watch-v1", "watch-v2"]) {
     const result = await t.query(api.videos.getByPublicId, { publicId });
-    expect(result?.video._id).toBe(v1);
+    expect(result?.video?._id).toBe(v1);
   }
 
   // Sanity: v2 really is the not-ready head.
@@ -84,7 +84,7 @@ test("serves the newest version once it becomes ready", async () => {
 
   for (const publicId of ["watch-v1", "watch-v2"]) {
     const result = await t.query(api.videos.getByPublicId, { publicId });
-    expect(result?.video._id).toBe(v2);
+    expect(result?.video?._id).toBe(v2);
   }
 });
 
@@ -125,6 +125,60 @@ test("setVisibility toggles every version in the stack and gates the public URL"
   }));
   expect(afterPublic.v1?.visibility).toBe("public");
   expect(afterPublic.v2?.visibility).toBe("public");
+});
+
+test("reports processing when a public video has no ready version yet", async () => {
+  const t = convexTest(schema, modules);
+  await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "user_1",
+      plan: "basic",
+    });
+    const projectId = await ctx.db.insert("projects", { teamId, name: "Campaign" });
+    await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "user_1",
+      uploaderName: "Owner",
+      title: "Fresh upload",
+      visibility: "public",
+      publicId: "processing-v1",
+      status: "processing",
+      workflowStatus: "review",
+    });
+  });
+
+  const result = await t.query(api.videos.getByPublicId, { publicId: "processing-v1" });
+  expect(result?.processing).toBe(true);
+  expect(result?.video).toBeNull();
+  expect(result?.title).toBe("Fresh upload");
+});
+
+test("is unavailable when the only public version failed", async () => {
+  const t = convexTest(schema, modules);
+  await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "user_1",
+      plan: "basic",
+    });
+    const projectId = await ctx.db.insert("projects", { teamId, name: "Campaign" });
+    await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "user_1",
+      uploaderName: "Owner",
+      title: "Broken upload",
+      visibility: "public",
+      publicId: "failed-v1",
+      status: "failed",
+      workflowStatus: "review",
+    });
+  });
+
+  const result = await t.query(api.videos.getByPublicId, { publicId: "failed-v1" });
+  expect(result).toBeNull();
 });
 
 test("returns null for an unknown public id", async () => {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -66,6 +66,10 @@ export default defineSchema({
     description: v.optional(v.string()),
     visibility: v.union(v.literal("public"), v.literal("private")),
     publicId: v.string(),
+    // When false, public viewers only ever see the latest ready version and the
+    // version switcher is hidden. Unset/true means viewers can browse versions.
+    // Kept consistent across every version in a stack (see setPublicVersionBrowsing).
+    allowPublicVersionBrowsing: v.optional(v.boolean()),
     // Mux video references
     muxUploadId: v.optional(v.string()),
     muxAssetId: v.optional(v.string()),

--- a/convex/videos.ts
+++ b/convex/videos.ts
@@ -590,9 +590,39 @@ export const listVersions = query({
 });
 
 type PublicWatchResolution =
-  | { state: "ready"; video: Doc<"videos"> }
+  | { state: "ready"; video: Doc<"videos">; allowVersionBrowsing: boolean }
   | { state: "processing"; title: string }
   | { state: "unavailable" };
+
+// Version browsing is on unless explicitly disabled, so existing public videos
+// keep working without a backfill.
+function publicVersionBrowsingEnabled(video: Doc<"videos">) {
+  return video.allowPublicVersionBrowsing !== false;
+}
+
+function isPublicReadyVersion(video: Doc<"videos">) {
+  return video.visibility === "public" && video.status === "ready";
+}
+
+async function readStackVersions(ctx: StackReadCtx, video: Doc<"videos">) {
+  // Fall back to the row alone if the stack is somehow malformed, so a public
+  // viewer never hits an invariant error on a hot path.
+  try {
+    const { oldestToNewest } = await getOrderedStackVersions(ctx, video);
+    return oldestToNewest;
+  } catch {
+    return [video];
+  }
+}
+
+function latestPublicReadyVersion(stackVersions: Doc<"videos">[]) {
+  for (let index = stackVersions.length - 1; index >= 0; index--) {
+    if (isPublicReadyVersion(stackVersions[index])) {
+      return stackVersions[index];
+    }
+  }
+  return undefined;
+}
 
 /**
  * Resolves what a public `/watch/<publicId>` link should show.
@@ -600,11 +630,15 @@ type PublicWatchResolution =
  * Each version in a stack is its own `videos` row with its own `publicId`, so the
  * shared link can point at a version that is not the one that should currently
  * play publicly — e.g. a freshly uploaded version that is still processing, or an
- * older superseded cut. Marking the linked version private still disables the URL,
- * but otherwise we serve the latest version of the stack that is both public and
- * ready. If nothing is ready yet but a public version is still uploading or
- * transcoding, we report `processing` so the viewer sees "ready soon" instead of
- * "video unavailable".
+ * older superseded cut. Marking the linked version private still disables the URL.
+ *
+ * When version browsing is enabled (the default), the link resolves to its own
+ * version when that version is ready, so viewers can switch between versions by
+ * URL. When browsing is disabled, every link collapses to the latest ready
+ * version and the switcher is hidden. Either way, if the chosen version isn't
+ * ready we fall back to the latest ready version, and if nothing is ready yet but
+ * a public version is still uploading/transcoding we report `processing` so the
+ * viewer sees "ready soon" instead of "video unavailable".
  */
 async function resolvePublicWatch(
   ctx: StackReadCtx,
@@ -619,22 +653,16 @@ async function resolvePublicWatch(
     return { state: "unavailable" };
   }
 
-  // Fall back to the matched row alone if the stack is somehow malformed, so a
-  // public viewer never hits an invariant error on a hot path.
-  let stackVersions: Doc<"videos">[] = [matched];
-  try {
-    const { oldestToNewest } = await getOrderedStackVersions(ctx, matched);
-    stackVersions = oldestToNewest;
-  } catch {
-    stackVersions = [matched];
-  }
+  const allowVersionBrowsing = publicVersionBrowsingEnabled(matched);
+  const stackVersions = await readStackVersions(ctx, matched);
 
-  // Prefer the latest version that is both public and ready.
-  for (let index = stackVersions.length - 1; index >= 0; index--) {
-    const candidate = stackVersions[index];
-    if (candidate.visibility === "public" && candidate.status === "ready") {
-      return { state: "ready", video: candidate };
-    }
+  const served =
+    allowVersionBrowsing && isPublicReadyVersion(matched)
+      ? matched
+      : latestPublicReadyVersion(stackVersions);
+
+  if (served) {
+    return { state: "ready", video: served, allowVersionBrowsing };
   }
 
   // Nothing is playable yet — if a public version is still in flight, tell the
@@ -681,8 +709,11 @@ export const getByPublicId = query({
     return {
       processing: false as const,
       title: video.title,
+      allowVersionBrowsing: resolution.allowVersionBrowsing,
       video: {
         _id: video._id,
+        publicId: video.publicId,
+        versionNumber: normalizeVersionNumber(video),
         title: video.title,
         description: video.description,
         duration: video.duration,
@@ -693,6 +724,39 @@ export const getByPublicId = query({
         s3Key: video.s3Key,
       },
     };
+  },
+});
+
+/**
+ * Lists the versions a public viewer can switch between for a `/watch/<publicId>`
+ * link: every public, ready version in the stack, oldest first. Returns an empty
+ * list when the video is private or the owner disabled version browsing.
+ */
+export const listPublicVersions = query({
+  args: { publicId: v.string() },
+  returns: v.array(
+    v.object({
+      publicId: v.string(),
+      versionNumber: v.number(),
+      isLatest: v.boolean(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const matched = await ctx.db
+      .query("videos")
+      .withIndex("by_public_id", (q) => q.eq("publicId", args.publicId))
+      .unique();
+
+    if (!matched || matched.visibility !== "public" || !publicVersionBrowsingEnabled(matched)) {
+      return [];
+    }
+
+    const stackVersions = await readStackVersions(ctx, matched);
+    return stackVersions.filter(isPublicReadyVersion).map((version) => ({
+      publicId: version.publicId,
+      versionNumber: normalizeVersionNumber(version),
+      isLatest: version.supersededByVideoId === undefined,
+    }));
   },
 });
 
@@ -855,6 +919,25 @@ export const setVisibility = mutation({
     for (const version of versions) {
       if (version.visibility !== args.visibility) {
         await ctx.db.patch(version._id, { visibility: args.visibility });
+      }
+    }
+  },
+});
+
+export const setPublicVersionBrowsing = mutation({
+  args: {
+    videoId: v.id("videos"),
+    enabled: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const { video } = await requireVideoAccess(ctx, args.videoId, "member");
+
+    // Like visibility, version browsing is a property of the whole video. Keep it
+    // consistent across every version in the stack.
+    const { versions } = await getStackVersions(ctx, video);
+    for (const version of versions) {
+      if (publicVersionBrowsingEnabled(version) !== args.enabled) {
+        await ctx.db.patch(version._id, { allowPublicVersionBrowsing: args.enabled });
       }
     }
   },

--- a/convex/videos.ts
+++ b/convex/videos.ts
@@ -31,6 +31,20 @@ const VIDEO_STACK_CHAIN_ERROR =
   "A video version stack must be one connected acyclic chain within a single project.";
 const VIDEO_STACK_PROJECT_ERROR = "All versions of a video must belong to the same project";
 
+const STACK_INVARIANT_ERROR_MESSAGES = new Set([
+  VIDEO_STACK_LIMIT_ERROR,
+  VIDEO_STACK_HEAD_ERROR,
+  VIDEO_STACK_CHAIN_ERROR,
+  VIDEO_STACK_PROJECT_ERROR,
+]);
+
+// Stack traversal throws these when a stack's shape is corrupt. Callers may
+// degrade gracefully on those (operate on the single row), but genuine
+// DB/runtime failures must propagate rather than be silently swallowed.
+function isStackInvariantError(error: unknown): boolean {
+  return error instanceof Error && STACK_INVARIANT_ERROR_MESSAGES.has(error.message);
+}
+
 type WorkflowStatus = "review" | "rework" | "done";
 type StackReadCtx = Pick<QueryCtx, "db">;
 
@@ -605,12 +619,26 @@ function isPublicReadyVersion(video: Doc<"videos">) {
 }
 
 async function readStackVersions(ctx: StackReadCtx, video: Doc<"videos">) {
-  // Fall back to the row alone if the stack is somehow malformed, so a public
-  // viewer never hits an invariant error on a hot path.
   try {
     const { oldestToNewest } = await getOrderedStackVersions(ctx, video);
     return oldestToNewest;
-  } catch {
+  } catch (error) {
+    // Fall back to the row alone if the stack is malformed, so a public viewer
+    // never hits an invariant error on a hot path. Real failures still propagate.
+    if (!isStackInvariantError(error)) throw error;
+    return [video];
+  }
+}
+
+// Mutation-side counterpart of readStackVersions. Lets an owner still update the
+// row they're acting on when the stack is malformed, instead of being locked out
+// of changing visibility/browsing by an invariant error.
+async function readStackVersionsForUpdate(ctx: StackReadCtx, video: Doc<"videos">) {
+  try {
+    const { versions } = await getStackVersions(ctx, video);
+    return versions;
+  } catch (error) {
+    if (!isStackInvariantError(error)) throw error;
     return [video];
   }
 }
@@ -915,7 +943,7 @@ export const setVisibility = mutation({
     // Visibility is a property of the whole video, not a single cut. Apply it to
     // every version in the stack so the public/private state can't drift between
     // versions (each version carries its own `visibility` row).
-    const { versions } = await getStackVersions(ctx, video);
+    const versions = await readStackVersionsForUpdate(ctx, video);
     for (const version of versions) {
       if (version.visibility !== args.visibility) {
         await ctx.db.patch(version._id, { visibility: args.visibility });
@@ -934,7 +962,7 @@ export const setPublicVersionBrowsing = mutation({
 
     // Like visibility, version browsing is a property of the whole video. Keep it
     // consistent across every version in the stack.
-    const { versions } = await getStackVersions(ctx, video);
+    const versions = await readStackVersionsForUpdate(ctx, video);
     for (const version of versions) {
       if (publicVersionBrowsingEnabled(version) !== args.enabled) {
         await ctx.db.patch(version._id, { allowPublicVersionBrowsing: args.enabled });

--- a/convex/videos.ts
+++ b/convex/videos.ts
@@ -589,15 +589,55 @@ export const listVersions = query({
   },
 });
 
+/**
+ * Resolves the video that should be served for a public `/watch/<publicId>` link.
+ *
+ * Each version in a stack is its own `videos` row with its own `publicId`, so the
+ * shared link can point at a version that is not the one that should currently
+ * play publicly — e.g. a freshly uploaded version that is still processing, or an
+ * older superseded cut. Marking the linked version private still disables the URL,
+ * but otherwise we serve the latest version of the stack that is both public and
+ * ready. This keeps a public video watchable while newer versions process and
+ * always surfaces the current cut, instead of returning "video unavailable".
+ */
+export async function resolvePublicVideo(
+  ctx: StackReadCtx,
+  publicId: string,
+): Promise<Doc<"videos"> | null> {
+  const matched = await ctx.db
+    .query("videos")
+    .withIndex("by_public_id", (q) => q.eq("publicId", publicId))
+    .unique();
+
+  if (!matched || matched.visibility !== "public") {
+    return null;
+  }
+
+  // Fall back to the matched row alone if the stack is somehow malformed, so a
+  // public viewer never hits an invariant error on a hot path.
+  let stackVersions: Doc<"videos">[] = [matched];
+  try {
+    const { oldestToNewest } = await getOrderedStackVersions(ctx, matched);
+    stackVersions = oldestToNewest;
+  } catch {
+    stackVersions = [matched];
+  }
+
+  for (let index = stackVersions.length - 1; index >= 0; index--) {
+    const candidate = stackVersions[index];
+    if (candidate.visibility === "public" && candidate.status === "ready") {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
 export const getByPublicId = query({
   args: { publicId: v.string() },
   handler: async (ctx, args) => {
-    const video = await ctx.db
-      .query("videos")
-      .withIndex("by_public_id", (q) => q.eq("publicId", args.publicId))
-      .unique();
-
-    if (!video || video.visibility !== "public" || video.status !== "ready") {
+    const video = await resolvePublicVideo(ctx, args.publicId);
+    if (!video) {
       return null;
     }
 
@@ -620,12 +660,8 @@ export const getByPublicId = query({
 export const getByPublicIdForDownload = query({
   args: { publicId: v.string() },
   handler: async (ctx, args) => {
-    const video = await ctx.db
-      .query("videos")
-      .withIndex("by_public_id", (q) => q.eq("publicId", args.publicId))
-      .unique();
-
-    if (!video || video.visibility !== "public") {
+    const video = await resolvePublicVideo(ctx, args.publicId);
+    if (!video) {
       return null;
     }
 
@@ -771,11 +807,17 @@ export const setVisibility = mutation({
     visibility: visibilityValidator,
   },
   handler: async (ctx, args) => {
-    await requireVideoAccess(ctx, args.videoId, "member");
+    const { video } = await requireVideoAccess(ctx, args.videoId, "member");
 
-    await ctx.db.patch(args.videoId, {
-      visibility: args.visibility,
-    });
+    // Visibility is a property of the whole video, not a single cut. Apply it to
+    // every version in the stack so the public/private state can't drift between
+    // versions (each version carries its own `visibility` row).
+    const { versions } = await getStackVersions(ctx, video);
+    for (const version of versions) {
+      if (version.visibility !== args.visibility) {
+        await ctx.db.patch(version._id, { visibility: args.visibility });
+      }
+    }
   },
 });
 

--- a/convex/videos.ts
+++ b/convex/videos.ts
@@ -589,28 +589,34 @@ export const listVersions = query({
   },
 });
 
+type PublicWatchResolution =
+  | { state: "ready"; video: Doc<"videos"> }
+  | { state: "processing"; title: string }
+  | { state: "unavailable" };
+
 /**
- * Resolves the video that should be served for a public `/watch/<publicId>` link.
+ * Resolves what a public `/watch/<publicId>` link should show.
  *
  * Each version in a stack is its own `videos` row with its own `publicId`, so the
  * shared link can point at a version that is not the one that should currently
  * play publicly — e.g. a freshly uploaded version that is still processing, or an
  * older superseded cut. Marking the linked version private still disables the URL,
  * but otherwise we serve the latest version of the stack that is both public and
- * ready. This keeps a public video watchable while newer versions process and
- * always surfaces the current cut, instead of returning "video unavailable".
+ * ready. If nothing is ready yet but a public version is still uploading or
+ * transcoding, we report `processing` so the viewer sees "ready soon" instead of
+ * "video unavailable".
  */
-export async function resolvePublicVideo(
+async function resolvePublicWatch(
   ctx: StackReadCtx,
   publicId: string,
-): Promise<Doc<"videos"> | null> {
+): Promise<PublicWatchResolution> {
   const matched = await ctx.db
     .query("videos")
     .withIndex("by_public_id", (q) => q.eq("publicId", publicId))
     .unique();
 
   if (!matched || matched.visibility !== "public") {
-    return null;
+    return { state: "unavailable" };
   }
 
   // Fall back to the matched row alone if the stack is somehow malformed, so a
@@ -623,25 +629,58 @@ export async function resolvePublicVideo(
     stackVersions = [matched];
   }
 
+  // Prefer the latest version that is both public and ready.
   for (let index = stackVersions.length - 1; index >= 0; index--) {
     const candidate = stackVersions[index];
     if (candidate.visibility === "public" && candidate.status === "ready") {
-      return candidate;
+      return { state: "ready", video: candidate };
     }
   }
 
-  return null;
+  // Nothing is playable yet — if a public version is still in flight, tell the
+  // viewer it's on the way rather than treating it as missing.
+  const hasInflightVersion = stackVersions.some(
+    (candidate) =>
+      candidate.visibility === "public" &&
+      (candidate.status === "uploading" || candidate.status === "processing"),
+  );
+  if (hasInflightVersion) {
+    return { state: "processing", title: matched.title };
+  }
+
+  return { state: "unavailable" };
+}
+
+/**
+ * Resolves the ready video to serve for a public `/watch/<publicId>` link, or
+ * null if nothing is currently playable. Used by the comment and download paths,
+ * which only ever operate on a ready cut.
+ */
+export async function resolvePublicVideo(
+  ctx: StackReadCtx,
+  publicId: string,
+): Promise<Doc<"videos"> | null> {
+  const resolution = await resolvePublicWatch(ctx, publicId);
+  return resolution.state === "ready" ? resolution.video : null;
 }
 
 export const getByPublicId = query({
   args: { publicId: v.string() },
   handler: async (ctx, args) => {
-    const video = await resolvePublicVideo(ctx, args.publicId);
-    if (!video) {
+    const resolution = await resolvePublicWatch(ctx, args.publicId);
+
+    if (resolution.state === "unavailable") {
       return null;
     }
 
+    if (resolution.state === "processing") {
+      return { processing: true as const, title: resolution.title, video: null };
+    }
+
+    const video = resolution.video;
     return {
+      processing: false as const,
+      title: video.title,
       video: {
         _id: video._id,
         title: video.title,

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -190,32 +190,33 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
                 <h3 className="text-sm font-bold text-[#1a1a1a]">Version browsing</h3>
                 <p className="text-xs text-[#888]">Let viewers switch between versions.</p>
               </div>
-              <div className="flex shrink-0 border-2 border-[#1a1a1a]">
-                <button
-                  type="button"
-                  disabled={isUpdatingVersionBrowsing || video === undefined}
-                  onClick={() => void handleSetVersionBrowsing(true)}
+              <div className="flex shrink-0 items-center gap-2.5">
+                <span
                   className={cn(
-                    "px-3 py-1.5 text-sm font-bold transition-colors disabled:opacity-50",
-                    versionBrowsingEnabled
-                      ? "bg-[#1a1a1a] text-[#f0f0e8]"
-                      : "text-[#1a1a1a] hover:bg-[#e8e8e0]",
+                    "text-xs font-bold tracking-wide uppercase",
+                    versionBrowsingEnabled ? "text-[#2d5a2d]" : "text-[#888]",
                   )}
                 >
-                  On
-                </button>
+                  {versionBrowsingEnabled ? "On" : "Off"}
+                </span>
                 <button
                   type="button"
+                  role="switch"
+                  aria-checked={versionBrowsingEnabled}
+                  aria-label="Version browsing"
                   disabled={isUpdatingVersionBrowsing || video === undefined}
-                  onClick={() => void handleSetVersionBrowsing(false)}
+                  onClick={() => void handleSetVersionBrowsing(!versionBrowsingEnabled)}
                   className={cn(
-                    "border-l-2 border-[#1a1a1a] px-3 py-1.5 text-sm font-bold transition-colors disabled:opacity-50",
-                    !versionBrowsingEnabled
-                      ? "bg-[#1a1a1a] text-[#f0f0e8]"
-                      : "text-[#1a1a1a] hover:bg-[#e8e8e0]",
+                    "relative h-7 w-12 shrink-0 border-2 border-[#1a1a1a] transition-colors disabled:opacity-50",
+                    versionBrowsingEnabled ? "bg-[#2d5a2d]" : "bg-[#ccc]",
                   )}
                 >
-                  Off
+                  <span
+                    className={cn(
+                      "absolute top-1 h-4 w-4 border-2 border-[#1a1a1a] bg-[#f0f0e8] transition-all",
+                      versionBrowsingEnabled ? "left-[26px]" : "left-0.5",
+                    )}
+                  />
                 </button>
               </div>
             </div>

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -237,7 +237,7 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
           <div className="grid grid-cols-2 gap-2">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="outline" className="w-full justify-between font-normal">
+                <Button variant="outline" className="w-full justify-between">
                   {newLinkOptions.expiresInDays
                     ? `${newLinkOptions.expiresInDays} days`
                     : "Never expires"}

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -15,7 +15,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
-import { Copy, Check, Plus, Trash2, Eye, Lock, ExternalLink, Globe } from "lucide-react";
+import { Copy, Check, Plus, Trash2, Eye, Lock, ExternalLink, Globe, Layers3 } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -36,9 +36,11 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
   const createShareLink = useMutation(api.shareLinks.create);
   const deleteShareLink = useMutation(api.shareLinks.remove);
   const setVisibility = useMutation(api.videos.setVisibility);
+  const setVersionBrowsing = useMutation(api.videos.setPublicVersionBrowsing);
 
   const [isCreating, setIsCreating] = useState(false);
   const [isUpdatingVisibility, setIsUpdatingVisibility] = useState(false);
+  const [isUpdatingVersionBrowsing, setIsUpdatingVersionBrowsing] = useState(false);
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [newLinkOptions, setNewLinkOptions] = useState({
     expiresInDays: undefined as number | undefined,
@@ -74,6 +76,20 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
       console.error("Failed to update visibility:", error);
     } finally {
       setIsUpdatingVisibility(false);
+    }
+  };
+
+  const versionBrowsingEnabled = video?.allowPublicVersionBrowsing !== false;
+
+  const handleSetVersionBrowsing = async (enabled: boolean) => {
+    if (!video || isUpdatingVersionBrowsing || versionBrowsingEnabled === enabled) return;
+    setIsUpdatingVersionBrowsing(true);
+    try {
+      await setVersionBrowsing({ videoId, enabled });
+    } catch (error) {
+      console.error("Failed to update version browsing:", error);
+    } finally {
+      setIsUpdatingVersionBrowsing(false);
     }
   };
 
@@ -173,6 +189,41 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
                 >
                   <ExternalLink className="mr-2 h-4 w-4" />
                   Open
+                </Button>
+              </div>
+            </div>
+          ) : null}
+
+          {video?.visibility === "public" ? (
+            <div className="space-y-2 border-2 border-[#1a1a1a] bg-[#f0f0e8] p-3">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <h4 className="flex items-center gap-1.5 text-sm font-bold text-[#1a1a1a]">
+                    <Layers3 className="h-3.5 w-3.5" />
+                    Version browsing
+                  </h4>
+                  <p className="text-xs text-[#666]">
+                    Let viewers switch between versions. When off, only the latest version is shown.
+                  </p>
+                </div>
+                <Badge variant={versionBrowsingEnabled ? "success" : "secondary"}>
+                  {versionBrowsingEnabled ? "On" : "Off"}
+                </Badge>
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                <Button
+                  variant={versionBrowsingEnabled ? "default" : "outline"}
+                  disabled={isUpdatingVersionBrowsing || video === undefined}
+                  onClick={() => void handleSetVersionBrowsing(true)}
+                >
+                  On
+                </Button>
+                <Button
+                  variant={!versionBrowsingEnabled ? "default" : "outline"}
+                  disabled={isUpdatingVersionBrowsing || video === undefined}
+                  onClick={() => void handleSetVersionBrowsing(false)}
+                >
+                  Off
                 </Button>
               </div>
             </div>

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -15,14 +15,14 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
-import { Copy, Check, Plus, Trash2, Eye, Lock, ExternalLink, Globe, Layers3 } from "lucide-react";
+import { Copy, Check, Plus, Trash2, Eye, Lock, ExternalLink, Globe } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { formatRelativeTime } from "@/lib/utils";
+import { cn, formatRelativeTime } from "@/lib/utils";
 
 interface ShareDialogProps {
   videoId: Id<"videos">;
@@ -121,7 +121,7 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-h-[85vh] max-w-lg overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Share video</DialogTitle>
           <DialogDescription>
@@ -129,19 +129,8 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-3 border-2 border-[#1a1a1a] bg-[#e8e8e0] p-4">
-          <div className="flex items-center justify-between gap-3">
-            <div>
-              <h3 className="text-sm font-bold text-[#1a1a1a]">Visibility</h3>
-              <p className="text-xs text-[#666]">
-                Private disables the public URL. Restricted share links can still be used.
-              </p>
-            </div>
-            <Badge variant={video?.visibility === "public" ? "success" : "secondary"}>
-              {video?.visibility === "public" ? "Public" : "Private"}
-            </Badge>
-          </div>
-
+        {/* Visibility */}
+        <div className="space-y-2">
           <div className="grid grid-cols-2 gap-2">
             <Button
               variant={video?.visibility === "public" ? "default" : "outline"}
@@ -160,92 +149,104 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
               Private
             </Button>
           </div>
-
-          {publicWatchPath ? (
-            <div className="space-y-2 border-2 border-[#1a1a1a] bg-[#f0f0e8] p-3">
-              <div className="text-xs text-[#666]">Public URL</div>
-              <code className="block truncate bg-[#e8e8e0] px-2 py-1 font-mono text-sm">
-                {publicWatchPath}
-              </code>
-              <div className="flex gap-2">
-                <Button
-                  variant="outline"
-                  className="flex-1"
-                  onClick={handleCopyPublicLink}
-                  disabled={video?.visibility !== "public"}
-                >
-                  {copiedId === "public" ? (
-                    <Check className="mr-2 h-4 w-4" />
-                  ) : (
-                    <Copy className="mr-2 h-4 w-4" />
-                  )}
-                  Copy URL
-                </Button>
-                <Button
-                  variant="outline"
-                  className="flex-1"
-                  disabled={video?.visibility !== "public"}
-                  onClick={() => window.open(publicWatchPath, "_blank")}
-                >
-                  <ExternalLink className="mr-2 h-4 w-4" />
-                  Open
-                </Button>
-              </div>
-            </div>
-          ) : null}
-
-          {video?.visibility === "public" ? (
-            <div className="space-y-2 border-2 border-[#1a1a1a] bg-[#f0f0e8] p-3">
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <h4 className="flex items-center gap-1.5 text-sm font-bold text-[#1a1a1a]">
-                    <Layers3 className="h-3.5 w-3.5" />
-                    Version browsing
-                  </h4>
-                  <p className="text-xs text-[#666]">
-                    Let viewers switch between versions. When off, only the latest version is shown.
-                  </p>
-                </div>
-                <Badge variant={versionBrowsingEnabled ? "success" : "secondary"}>
-                  {versionBrowsingEnabled ? "On" : "Off"}
-                </Badge>
-              </div>
-              <div className="grid grid-cols-2 gap-2">
-                <Button
-                  variant={versionBrowsingEnabled ? "default" : "outline"}
-                  disabled={isUpdatingVersionBrowsing || video === undefined}
-                  onClick={() => void handleSetVersionBrowsing(true)}
-                >
-                  On
-                </Button>
-                <Button
-                  variant={!versionBrowsingEnabled ? "default" : "outline"}
-                  disabled={isUpdatingVersionBrowsing || video === undefined}
-                  onClick={() => void handleSetVersionBrowsing(false)}
-                >
-                  Off
-                </Button>
-              </div>
-            </div>
-          ) : null}
+          <p className="text-xs text-[#888]">
+            Private disables the public URL. Restricted share links still work.
+          </p>
         </div>
 
-        <div className="space-y-4 border-2 border-[#1a1a1a] bg-[#e8e8e0] p-4">
-          <h3 className="text-sm font-bold text-[#1a1a1a]">Create restricted share link</h3>
+        {/* Public URL + version browsing */}
+        {video?.visibility === "public" ? (
+          <div className="space-y-3">
+            {publicWatchPath ? (
+              <div className="flex items-center gap-2">
+                <code className="min-w-0 flex-1 truncate border-2 border-[#1a1a1a] bg-[#e8e8e0] px-3 py-2 font-mono text-sm">
+                  {publicWatchPath}
+                </code>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={handleCopyPublicLink}
+                  aria-label="Copy public URL"
+                >
+                  {copiedId === "public" ? (
+                    <Check className="h-4 w-4" />
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={() => window.open(publicWatchPath, "_blank")}
+                  aria-label="Open public URL"
+                >
+                  <ExternalLink className="h-4 w-4" />
+                </Button>
+              </div>
+            ) : null}
 
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <h3 className="text-sm font-bold text-[#1a1a1a]">Version browsing</h3>
+                <p className="text-xs text-[#888]">Let viewers switch between versions.</p>
+              </div>
+              <div className="flex shrink-0 border-2 border-[#1a1a1a]">
+                <button
+                  type="button"
+                  disabled={isUpdatingVersionBrowsing || video === undefined}
+                  onClick={() => void handleSetVersionBrowsing(true)}
+                  className={cn(
+                    "px-3 py-1.5 text-sm font-bold transition-colors disabled:opacity-50",
+                    versionBrowsingEnabled
+                      ? "bg-[#1a1a1a] text-[#f0f0e8]"
+                      : "text-[#1a1a1a] hover:bg-[#e8e8e0]",
+                  )}
+                >
+                  On
+                </button>
+                <button
+                  type="button"
+                  disabled={isUpdatingVersionBrowsing || video === undefined}
+                  onClick={() => void handleSetVersionBrowsing(false)}
+                  className={cn(
+                    "border-l-2 border-[#1a1a1a] px-3 py-1.5 text-sm font-bold transition-colors disabled:opacity-50",
+                    !versionBrowsingEnabled
+                      ? "bg-[#1a1a1a] text-[#f0f0e8]"
+                      : "text-[#1a1a1a] hover:bg-[#e8e8e0]",
+                  )}
+                >
+                  Off
+                </button>
+              </div>
+            </div>
+          </div>
+        ) : null}
+
+        <Separator />
+
+        {/* Restricted links */}
+        <div className="space-y-3">
           <div>
-            <label className="text-sm text-[#888]">Expiration</label>
+            <h3 className="text-sm font-bold text-[#1a1a1a]">Restricted links</h3>
+            <p className="text-xs text-[#888]">
+              Time-limited, optionally password-protected links.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="outline" className="mt-1 w-full justify-between">
-                  {newLinkOptions.expiresInDays ? `${newLinkOptions.expiresInDays} days` : "Never"}
+                <Button variant="outline" className="w-full justify-between font-normal">
+                  {newLinkOptions.expiresInDays
+                    ? `${newLinkOptions.expiresInDays} days`
+                    : "Never expires"}
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent>
                 <DropdownMenuItem
                   onClick={() => setNewLinkOptions((o) => ({ ...o, expiresInDays: undefined }))}
                 >
-                  Never
+                  Never expires
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() => setNewLinkOptions((o) => ({ ...o, expiresInDays: 1 }))}
@@ -264,13 +265,9 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
-          </div>
-
-          <div>
-            <label className="text-sm text-[#888]">Password (optional)</label>
             <Input
               type="password"
-              placeholder="Leave empty for no password"
+              placeholder="Password (optional)"
               value={newLinkOptions.password || ""}
               onChange={(e) =>
                 setNewLinkOptions((o) => ({
@@ -278,31 +275,22 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
                   password: e.target.value || undefined,
                 }))
               }
-              className="mt-1"
             />
           </div>
 
           <Button onClick={handleCreateLink} disabled={isCreating} className="w-full">
             <Plus className="mr-2 h-4 w-4" />
-            {isCreating ? "Creating..." : "Create restricted link"}
+            {isCreating ? "Creating..." : "Create link"}
           </Button>
-        </div>
 
-        <Separator />
-
-        <div className="space-y-2">
-          <h3 className="text-sm font-bold text-[#1a1a1a]">Restricted links</h3>
           {shareLinks === undefined ? (
             <p className="text-sm text-[#888]">Loading...</p>
           ) : shareLinks.length === 0 ? (
             <p className="text-sm text-[#888]">No share links yet</p>
           ) : (
-            <div className="space-y-2">
+            <div className="max-h-64 divide-y-2 divide-[#1a1a1a] overflow-y-auto border-2 border-[#1a1a1a]">
               {shareLinks.map((link) => (
-                <div
-                  key={link._id}
-                  className="flex items-center justify-between border-2 border-[#1a1a1a] p-3"
-                >
+                <div key={link._id} className="flex items-center justify-between gap-2 p-3">
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-2">
                       <code className="max-w-[200px] truncate bg-[#e8e8e0] px-2 py-0.5 font-mono text-sm">
@@ -326,7 +314,7 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
                       ) : null}
                     </div>
                   </div>
-                  <div className="flex items-center gap-1">
+                  <div className="flex shrink-0 items-center gap-1">
                     <Button variant="ghost" size="icon" onClick={() => handleCopyLink(link.token)}>
                       {copiedId === link.token ? (
                         <Check className="h-4 w-4 text-[#2d5a2d]" />

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -17,3 +17,7 @@ export function projectPath(teamSlug: string, projectId: string) {
 export function videoPath(teamSlug: string, projectId: string, videoId: string) {
   return `/dashboard/${teamSlug}/${projectId}/${videoId}`;
 }
+
+export function watchPath(publicId: string) {
+  return `/watch/${publicId}`;
+}


### PR DESCRIPTION
## Problem

Videos explicitly marked **PUBLIC** in the Share dialog were showing **"VIDEO UNAVAILABLE — This video is private, invalid, or no longer available."** on the public `/watch/<publicId>` page. Reported from prod.

| Share dialog says PUBLIC | Public watch page |
| --- | --- |
| visibility = public, `/watch/W0Udd…` | "Video unavailable" |

## Root cause

The video **version stacks** work (`Add video version stacks`, plus the version-deletion follow-ups) made every version its **own `videos` row** with its **own `publicId`** and its **own `visibility`**. But the public watch resolver `getByPublicId` still exact-matched the shared `publicId` and required *that exact row* to be both `visibility === "public"` **and** `status === "ready"`:

```ts
const video = await ctx.db.query("videos")
  .withIndex("by_public_id", (q) => q.eq("publicId", args.publicId)).unique();
if (!video || video.visibility !== "public" || video.status !== "ready") return null;
```

So a public video resolved as "unavailable" whenever the shared link pointed at a version that wasn't the current ready/public head:
- a **freshly uploaded version still processing** (new version rows start at `status: "uploading"`),
- a **superseded older cut**, or
- a row hit by **per-version visibility drift** (`setVisibility` only patched a single row).

The same exact-match logic was duplicated in `comments.getPublicVideoByPublicId`, and the public playback/download actions both delegate to these resolvers — so the whole public path inherited the bug.

## Fix

- **`resolvePublicVideo` (new, stack-aware):** gates access on the linked version's own visibility (marking it private still disables the URL), but otherwise resolves the stack and serves the **latest version that is both public and ready**. Falls back safely to the matched row if the stack is malformed so a public viewer never hits an invariant error on a hot path. Now used by `getByPublicId` and `getByPublicIdForDownload`.
- **Comments aligned:** `comments.getPublicVideoByPublicId` uses the same resolver, so public comments read/write the same cut the viewer is watching.
- **`setVisibility` is now stack-wide:** toggling public/private applies to every version in the stack, so visibility can no longer drift between versions.

## Tests

Added `convex/publicWatch.vitest.ts`:
- serves the latest ready version when the shared head is still processing,
- serves the newest version once it becomes ready,
- `setVisibility` toggles every version in the stack and gates the public URL,
- returns null for an unknown public id.

All checks pass locally: `tsc` (app + `convex typecheck`), `eslint`, `prettier`, `bun test` (21), and `vitest` (26, incl. 4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix public watch page for videos with version stacks
> - Introduces `resolvePublicWatch` in [convex/videos.ts](https://github.com/pingdotgg/lawn/pull/45/files#diff-dcea06e0ecce2d53d2266e8caf9b5ed2b597b910af5be8112fba22fecd272547) to resolve public watch links against the full version stack, returning a processing state, the correct ready version, or unavailable instead of failing on stacked videos.
> - Adds a `listPublicVersions` Convex query and a version switcher UI in [app/routes/-watch.tsx](https://github.com/pingdotgg/lawn/pull/45/files#diff-2b2efe3a498fab946d47a922e4452d5ad03e3d9694febd564713cb76bfe0d056) so viewers can navigate between public ready versions.
> - Adds `allowPublicVersionBrowsing` to the videos schema and a `setPublicVersionBrowsing` mutation; owners can toggle version browsing from the Share dialog in [src/components/ShareDialog.tsx](https://github.com/pingdotgg/lawn/pull/45/files#diff-2aa80443991b40a426d495eff17b90d6dc4977bc346bb9e4264fdc83e834a745).
> - `setVisibility` now applies visibility changes across all versions in a stack rather than only the targeted row.
> - Comment and download queries now use shared `resolvePublicVideo` logic so they operate on the same resolved version as the watch page.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88cf0d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved public watch links to serve the latest ready public version in multi-version stacks, with correct `processing`, `unavailable`, and `null` behaviors for failed/unknown entries.
  * Ensured public comment threads and download lookups use the same ready-version resolution.
  * Fixed visibility updates to apply across the entire version stack.
* **New Features (UI)**
  * Watch page now shows a “Processing video” card during processing and a Versions dropdown when switching is available.
  * Share dialog adds an On/Off control for public version browsing for public videos.
* **Tests**
  * Expanded Vitest coverage for stack processing, browsing enabled/disabled, visibility gating, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->