### PR TITLE
Make dashboard video links reliable public shares

### DIFF
--- a/app/routes/dashboard/-layout.tsx
+++ b/app/routes/dashboard/-layout.tsx
@@ -1,5 +1,5 @@
 import { useAuth } from "@clerk/tanstack-react-start";
-import { useConvex, useQuery } from "convex/react";
+import { useConvex, useConvexAuth, useQuery } from "convex/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
@@ -16,8 +16,9 @@ import {
 import { UploadProgress } from "@/components/upload/UploadProgress";
 import { useVideoUploadManager } from "./-useVideoUploadManager";
 import { DashboardUploadProvider } from "@/lib/dashboardUploadContext";
-import { videoPath } from "@/lib/routes";
+import { videoPath, watchPath } from "@/lib/routes";
 import { prewarmVideo } from "./-video.data";
+import { resolveDashboardAccess } from "@/lib/dashboardAccess";
 
 const VIDEO_FILE_EXTENSIONS = /\.(mp4|mov|m4v|webm|avi|mkv)$/i;
 
@@ -31,25 +32,44 @@ function dragEventHasFiles(event: DragEvent) {
 
 export default function DashboardLayout() {
   const { isLoaded, userId } = useAuth();
+  const { isLoading: isConvexAuthLoading, isAuthenticated: isConvexAuthenticated } =
+    useConvexAuth();
   const convex = useConvex();
   const navigate = useNavigate({});
   const location = useLocation();
   const { pathname, searchStr } = location;
   const params = useParams({ strict: false });
   const teamSlug = typeof params.teamSlug === "string" ? params.teamSlug : undefined;
-  const routeProjectId =
-    typeof params.projectId === "string" ? (params.projectId as Id<"projects">) : undefined;
-  const routeVideoId =
-    typeof params.videoId === "string" ? (params.videoId as Id<"videos">) : undefined;
+  const rawProjectId = typeof params.projectId === "string" ? params.projectId : undefined;
+  const rawVideoId = typeof params.videoId === "string" ? params.videoId : undefined;
   const publicPlaybackId = useQuery(
     api.videos.getPublicIdByVideoId,
-    routeVideoId ? { videoId: routeVideoId } : "skip",
+    rawVideoId ? { videoId: rawVideoId } : "skip",
   );
-  const detailVideo = useQuery(
-    api.videos.get,
-    routeVideoId && userId ? { videoId: routeVideoId } : "skip",
+  const contextRequired = Boolean(teamSlug || rawProjectId || rawVideoId);
+  const workspaceContext = useQuery(
+    api.workspace.resolveContext,
+    isLoaded && Boolean(userId) && !isConvexAuthLoading && isConvexAuthenticated && contextRequired
+      ? { teamSlug, projectId: rawProjectId, videoId: rawVideoId }
+      : "skip",
   );
-  const uploadTargets = useQuery(api.projects.listUploadTargets, teamSlug ? { teamSlug } : {});
+  const access = resolveDashboardAccess({
+    clerkLoaded: isLoaded,
+    hasClerkUser: Boolean(userId),
+    convexAuthLoading: isConvexAuthLoading,
+    convexAuthenticated: isConvexAuthenticated,
+    contextRequired,
+    workspaceContext,
+    publicLookupRequired: Boolean(rawVideoId),
+    publicId: publicPlaybackId,
+  });
+  const routeProjectId = access.kind === "dashboard" ? workspaceContext?.project?._id : undefined;
+  const routeVideoId = access.kind === "dashboard" ? workspaceContext?.video?._id : undefined;
+  const detailVideo = useQuery(api.videos.get, routeVideoId ? { videoId: routeVideoId } : "skip");
+  const uploadTargets = useQuery(
+    api.projects.listUploadTargets,
+    access.kind === "dashboard" ? (teamSlug ? { teamSlug } : {}) : "skip",
+  );
   const { uploads, uploadFilesToProject, uploadNewVersion, cancelUpload, retryProcessing } =
     useVideoUploadManager();
   const [isGlobalDragActive, setIsGlobalDragActive] = useState(false);
@@ -217,40 +237,80 @@ export default function DashboardLayout() {
     }),
     [requestUpload, requestVersionUpload, uploads, cancelUpload, retryProcessing],
   );
-  const isResolvingPublicPlaybackExemption =
-    Boolean(isLoaded && !userId && routeVideoId) && publicPlaybackId === undefined;
+  const publicRedirectId = access.kind === "redirect-public" ? access.publicId : undefined;
+  const shouldRedirectToSignIn = access.kind === "redirect-sign-in";
 
   useEffect(() => {
-    if (!isLoaded || userId) return;
     if (typeof window === "undefined") return;
 
-    if (routeVideoId) {
-      if (publicPlaybackId === undefined) return;
-      if (publicPlaybackId) {
-        window.location.replace(`/watch/${publicPlaybackId}`);
-        return;
-      }
+    if (publicRedirectId) {
+      window.location.replace(watchPath(publicRedirectId));
+      return;
     }
 
-    const redirectUrl = `${pathname}${searchStr}`;
-    window.location.replace(`/sign-in?redirect_url=${encodeURIComponent(redirectUrl)}`);
-  }, [isLoaded, userId, pathname, searchStr, routeVideoId, publicPlaybackId]);
+    if (shouldRedirectToSignIn) {
+      const redirectUrl = `${pathname}${searchStr}`;
+      window.location.replace(`/sign-in?redirect_url=${encodeURIComponent(redirectUrl)}`);
+    }
+  }, [pathname, publicRedirectId, searchStr, shouldRedirectToSignIn]);
 
-  if (!isLoaded) {
+  if (access.kind === "loading") {
     return (
       <div className="flex h-full items-center justify-center bg-[#f0f0e8]">
-        <div className="text-[#888]">Loading...</div>
+        <div role="status" aria-live="polite" className="text-[#888]">
+          Checking access...
+        </div>
       </div>
     );
   }
 
-  if (!userId) {
+  if (access.kind === "redirect-public" || access.kind === "redirect-sign-in") {
     return (
       <div className="flex h-full items-center justify-center bg-[#f0f0e8]">
-        <div className="text-[#888]">
-          {isResolvingPublicPlaybackExemption
-            ? "Checking public playback access..."
-            : "Redirecting to sign in..."}
+        <div role="status" aria-live="polite" className="text-[#888]">
+          Redirecting...
+        </div>
+      </div>
+    );
+  }
+
+  if (access.kind === "auth-unavailable") {
+    return (
+      <div className="flex h-full items-center justify-center bg-[#f0f0e8] p-6">
+        <div
+          role="alert"
+          className="max-w-md border-2 border-[#1a1a1a] bg-[#f0f0e8] p-5 text-center shadow-[4px_4px_0px_0px_var(--shadow-color)]"
+        >
+          <p className="font-bold text-[#1a1a1a]">We couldn't verify your dashboard session.</p>
+          <p className="mt-1 text-sm text-[#888]">Try again, or return home and sign in again.</p>
+          <div className="mt-4 flex justify-center gap-2">
+            <button
+              type="button"
+              className="border-2 border-[#1a1a1a] bg-[#1a1a1a] px-3 py-2 text-sm font-bold text-[#f0f0e8]"
+              onClick={() => window.location.reload()}
+            >
+              Try again
+            </button>
+            <a
+              href="/"
+              className="border-2 border-[#1a1a1a] px-3 py-2 text-sm font-bold text-[#1a1a1a]"
+            >
+              Go home
+            </a>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (access.kind === "not-found") {
+    return (
+      <div className="flex h-full items-center justify-center bg-[#f0f0e8] p-6">
+        <div role="alert" className="text-center text-[#888]">
+          <p>Video or workspace not found</p>
+          <a className="mt-3 inline-block font-bold text-[#1a1a1a] underline" href="/dashboard">
+            Back to dashboard
+          </a>
         </div>
       </div>
     );

--- a/app/routes/dashboard/-project.tsx
+++ b/app/routes/dashboard/-project.tsx
@@ -38,7 +38,8 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Id } from "@convex/_generated/dataModel";
 import { cn } from "@/lib/utils";
-import { projectPath, teamHomePath, videoPath } from "@/lib/routes";
+import { projectPath, teamHomePath, videoPath, watchPath } from "@/lib/routes";
+import { copyTextToClipboard } from "@/lib/clipboard";
 import { ProjectCard } from "@/components/projects/ProjectCard";
 import { MoveProjectDialog } from "@/components/projects/MoveProjectDialog";
 import { MoveVideoDialog } from "@/components/videos/MoveVideoDialog";
@@ -56,41 +57,14 @@ import { prewarmTeam } from "./-team.data";
 import { prewarmVideo } from "./-video.data";
 import { useDashboardUploadContext } from "@/lib/dashboardUploadContext";
 import { DashboardHeader } from "@/components/DashboardHeader";
+import { createRequestEpoch } from "@/lib/requestEpoch";
 
 type ViewMode = "grid" | "list";
 type ShareToastState = {
   tone: "success" | "error";
   message: string;
+  url?: string;
 };
-
-async function copyTextToClipboard(text: string) {
-  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
-    await navigator.clipboard.writeText(text);
-    return true;
-  }
-
-  if (typeof document === "undefined") {
-    return false;
-  }
-
-  const textarea = document.createElement("textarea");
-  textarea.value = text;
-  textarea.style.position = "fixed";
-  textarea.style.opacity = "0";
-  textarea.style.pointerEvents = "none";
-  document.body.appendChild(textarea);
-  textarea.focus();
-  textarea.select();
-
-  let copied = false;
-  try {
-    copied = document.execCommand("copy");
-  } finally {
-    document.body.removeChild(textarea);
-  }
-
-  return copied;
-}
 
 type VideoIntentTargetProps = {
   className: string;
@@ -193,6 +167,9 @@ export default function ProjectPage({
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
   const [shareToast, setShareToast] = useState<ShareToastState | null>(null);
   const shareToastTimeoutRef = useRef<number | null>(null);
+  const shareRequestEpochRef = useRef(createRequestEpoch());
+  const sharePendingRef = useRef(false);
+  const [sharePending, setSharePending] = useState(false);
   const [createFolderOpen, setCreateFolderOpen] = useState(false);
   const [newFolderName, setNewFolderName] = useState("");
   const [isCreatingFolder, setIsCreatingFolder] = useState(false);
@@ -235,6 +212,7 @@ export default function ProjectPage({
 
   useEffect(
     () => () => {
+      shareRequestEpochRef.current.invalidate();
       if (shareToastTimeoutRef.current !== null) {
         window.clearTimeout(shareToastTimeoutRef.current);
       }
@@ -332,46 +310,54 @@ export default function ProjectPage({
     [updateVideoWorkflowStatus],
   );
 
-  const showShareToast = useCallback((tone: ShareToastState["tone"], message: string) => {
-    setShareToast({ tone, message });
+  const showShareToast = useCallback((toast: ShareToastState, autoDismiss: boolean) => {
+    setShareToast(toast);
     if (shareToastTimeoutRef.current !== null) {
       window.clearTimeout(shareToastTimeoutRef.current);
-    }
-    shareToastTimeoutRef.current = window.setTimeout(() => {
-      setShareToast(null);
       shareToastTimeoutRef.current = null;
-    }, 2400);
+    }
+    if (autoDismiss) {
+      shareToastTimeoutRef.current = window.setTimeout(() => {
+        setShareToast(null);
+        shareToastTimeoutRef.current = null;
+      }, 2400);
+    }
   }, []);
 
   const handleShareVideo = useCallback(
-    async (video: {
-      _id: Id<"videos">;
-      publicId?: string;
-      status: string;
-      visibility: "public" | "private";
-    }) => {
-      const canSharePublicly =
-        Boolean(video.publicId) && video.status === "ready" && video.visibility === "public";
-      const path = canSharePublicly
-        ? `/watch/${video.publicId}`
-        : videoPath(resolvedTeamSlug, projectId, video._id);
+    async (video: { _id: Id<"videos">; publicId?: string; visibility: "public" | "private" }) => {
+      if (sharePendingRef.current) return;
+      sharePendingRef.current = true;
+      setSharePending(true);
+      setShareToast(null);
+      const requestEpoch = shareRequestEpochRef.current.next();
+      const publicWatchPath =
+        video.visibility === "public" && video.publicId ? watchPath(video.publicId) : null;
+      const path = publicWatchPath ?? videoPath(resolvedTeamSlug, projectId, video._id);
       const origin = typeof window !== "undefined" ? window.location.origin : "";
       const url = `${origin}${path}`;
 
       try {
         const copied = await copyTextToClipboard(url);
+        if (!shareRequestEpochRef.current.isCurrent(requestEpoch)) return;
+        sharePendingRef.current = false;
+        setSharePending(false);
         if (!copied) {
-          showShareToast("error", "Could not copy link");
+          showShareToast({ tone: "error", message: "Could not copy link", url }, false);
           return;
         }
         showShareToast(
-          "success",
-          canSharePublicly
-            ? "Share link copied"
-            : "Video link copied (public watch link not available yet)",
+          {
+            tone: "success",
+            message: publicWatchPath ? "Share link copied" : "Private dashboard link copied",
+          },
+          true,
         );
       } catch {
-        showShareToast("error", "Could not copy link");
+        if (!shareRequestEpochRef.current.isCurrent(requestEpoch)) return;
+        sharePendingRef.current = false;
+        setSharePending(false);
+        showShareToast({ tone: "error", message: "Could not copy link", url }, false);
       }
     },
     [projectId, resolvedTeamSlug, showShareToast],
@@ -635,6 +621,7 @@ export default function ProjectPage({
                               </DropdownMenuItem>
                             )}
                             <DropdownMenuItem
+                              disabled={sharePending}
                               onClick={(e) => {
                                 e.stopPropagation();
                                 void handleShareVideo(video);
@@ -854,6 +841,7 @@ export default function ProjectPage({
                           </DropdownMenuItem>
                         )}
                         <DropdownMenuItem
+                          disabled={sharePending}
                           onClick={(e) => {
                             e.stopPropagation();
                             void handleShareVideo(video);
@@ -912,8 +900,10 @@ export default function ProjectPage({
       </div>
 
       {shareToast ? (
-        <div className="fixed top-4 right-4 z-50" aria-live="polite">
+        <div className="fixed top-4 right-4 z-50 w-[min(28rem,calc(100vw-2rem))]">
           <div
+            role={shareToast.tone === "error" ? "alert" : "status"}
+            aria-live={shareToast.tone === "error" ? "assertive" : "polite"}
             className={cn(
               "border-2 px-3 py-2 text-sm font-bold shadow-[4px_4px_0px_0px_var(--shadow-color)]",
               shareToast.tone === "success"
@@ -921,7 +911,22 @@ export default function ProjectPage({
                 : "border-[#dc2626] bg-[#fef2f2] text-[#dc2626]",
             )}
           >
-            {shareToast.message}
+            <p>{shareToast.message}</p>
+            {shareToast.url ? (
+              <div className="mt-2 space-y-2">
+                <Input
+                  aria-label="Link to copy manually"
+                  className="bg-white font-mono text-xs font-normal"
+                  readOnly
+                  value={shareToast.url}
+                  onFocus={(event) => event.currentTarget.select()}
+                  onClick={(event) => event.currentTarget.select()}
+                />
+                <Button size="sm" variant="outline" onClick={() => setShareToast(null)}>
+                  Dismiss
+                </Button>
+              </div>
+            ) : null}
           </div>
         </div>
       ) : null}

--- a/convex/publicWatch.vitest.ts
+++ b/convex/publicWatch.vitest.ts
@@ -236,3 +236,66 @@ test("returns null for an unknown public id", async () => {
   const result = await t.query(api.videos.getByPublicId, { publicId: "does-not-exist" });
   expect(result).toBeNull();
 });
+
+test("dashboard aliases resolve public ids throughout the upload lifecycle", async () => {
+  const { t, projectId } = await seedPublicStack();
+
+  for (const status of ["uploading", "processing", "ready", "failed"] as const) {
+    const videoId = await t.run((ctx) =>
+      ctx.db.insert("videos", {
+        projectId,
+        uploadedByClerkId: "user_1",
+        uploaderName: "Owner",
+        title: `${status} video`,
+        visibility: "public",
+        publicId: `alias-${status}`,
+        status,
+        workflowStatus: "review",
+      }),
+    );
+
+    await expect(t.query(api.videos.getPublicIdByVideoId, { videoId })).resolves.toBe(
+      `alias-${status}`,
+    );
+  }
+});
+
+test("dashboard aliases do not reveal private, missing, or malformed video ids", async () => {
+  const { t, projectId } = await seedPublicStack();
+  const privateVideoId = await t.run((ctx) =>
+    ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "user_1",
+      uploaderName: "Owner",
+      title: "Private video",
+      visibility: "private",
+      publicId: "private-alias",
+      status: "ready",
+      workflowStatus: "review",
+    }),
+  );
+  const missingVideoId = await t.run(async (ctx) => {
+    const videoId = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "user_1",
+      uploaderName: "Owner",
+      title: "Deleted video",
+      visibility: "public",
+      publicId: "deleted-alias",
+      status: "ready",
+      workflowStatus: "review",
+    });
+    await ctx.db.delete(videoId);
+    return videoId;
+  });
+
+  await expect(
+    t.query(api.videos.getPublicIdByVideoId, { videoId: privateVideoId }),
+  ).resolves.toBeNull();
+  await expect(
+    t.query(api.videos.getPublicIdByVideoId, { videoId: missingVideoId }),
+  ).resolves.toBeNull();
+  await expect(
+    t.query(api.videos.getPublicIdByVideoId, { videoId: "not-a-convex-id" }),
+  ).resolves.toBeNull();
+});

--- a/convex/videos.ts
+++ b/convex/videos.ts
@@ -831,7 +831,7 @@ export const getPublicIdByVideoId = query({
     }
 
     const video = await ctx.db.get(normalizedVideoId);
-    if (!video || video.visibility !== "public" || video.status !== "ready" || !video.publicId) {
+    if (!video || video.visibility !== "public" || !video.publicId) {
       return null;
     }
 

--- a/convex/workspace.ts
+++ b/convex/workspace.ts
@@ -18,19 +18,25 @@ function buildCanonicalPath(input: { teamSlug: string; projectId?: string; video
 export const resolveContext = query({
   args: {
     teamSlug: v.optional(v.string()),
-    projectId: v.optional(v.id("projects")),
-    videoId: v.optional(v.id("videos")),
+    projectId: v.optional(v.string()),
+    videoId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const user = await getUser(ctx);
     if (!user) return null;
 
+    const projectId = args.projectId ? ctx.db.normalizeId("projects", args.projectId) : undefined;
+    const videoId = args.videoId ? ctx.db.normalizeId("videos", args.videoId) : undefined;
+    if ((args.projectId && !projectId) || (args.videoId && !videoId)) {
+      return null;
+    }
+
     let team: Doc<"teams"> | null = null;
     let project: Doc<"projects"> | null = null;
     let video: Doc<"videos"> | null = null;
 
-    if (args.videoId) {
-      video = await ctx.db.get(args.videoId);
+    if (videoId) {
+      video = await ctx.db.get(videoId);
       if (!video) return null;
 
       project = await ctx.db.get(video.projectId);
@@ -38,8 +44,8 @@ export const resolveContext = query({
 
       team = await ctx.db.get(project.teamId);
       if (!team) return null;
-    } else if (args.projectId) {
-      project = await ctx.db.get(args.projectId);
+    } else if (projectId) {
+      project = await ctx.db.get(projectId);
       if (!project) return null;
 
       team = await ctx.db.get(project.teamId);

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -65,7 +65,7 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
   activeOpenRef.current = open;
 
   const isViewer = video?.role === "viewer";
-  const canManageSharing = video !== undefined && !isViewer;
+  const canManageSharing = video != null && !isViewer;
 
   const clearCopyFeedback = useCallback(() => {
     copySequenceRef.current += 1;

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Id } from "../../convex/_generated/dataModel";
@@ -23,6 +23,9 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn, formatRelativeTime } from "@/lib/utils";
+import { copyTextToClipboard } from "@/lib/clipboard";
+import { watchPath } from "@/lib/routes";
+import { createRequestEpoch } from "@/lib/requestEpoch";
 
 interface ShareDialogProps {
   videoId: Id<"videos">;
@@ -41,14 +44,88 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
   const [isCreating, setIsCreating] = useState(false);
   const [isUpdatingVisibility, setIsUpdatingVisibility] = useState(false);
   const [isUpdatingVersionBrowsing, setIsUpdatingVersionBrowsing] = useState(false);
+  const [deletingLinkId, setDeletingLinkId] = useState<Id<"shareLinks"> | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [copyStatus, setCopyStatus] = useState<{
+    tone: "success" | "error";
+    message: string;
+  } | null>(null);
+  const [copyFailureUrl, setCopyFailureUrl] = useState<string | null>(null);
+  const [mutationError, setMutationError] = useState<string | null>(null);
   const [newLinkOptions, setNewLinkOptions] = useState({
     expiresInDays: undefined as number | undefined,
     password: undefined as string | undefined,
   });
+  const copySequenceRef = useRef(0);
+  const copyTimeoutRef = useRef<number | null>(null);
+  const mutationContextEpochRef = useRef(createRequestEpoch());
+  const activeVideoIdRef = useRef(videoId);
+  const activeOpenRef = useRef(open);
+  activeVideoIdRef.current = videoId;
+  activeOpenRef.current = open;
+
+  const isViewer = video?.role === "viewer";
+  const canManageSharing = video !== undefined && !isViewer;
+
+  const clearCopyFeedback = useCallback(() => {
+    copySequenceRef.current += 1;
+    if (copyTimeoutRef.current !== null) {
+      window.clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = null;
+    }
+    setCopiedId(null);
+    setCopyStatus(null);
+    setCopyFailureUrl(null);
+  }, []);
+
+  const resetMutationState = useCallback(() => {
+    setIsCreating(false);
+    setIsUpdatingVisibility(false);
+    setIsUpdatingVersionBrowsing(false);
+    setDeletingLinkId(null);
+    setMutationError(null);
+    setNewLinkOptions({ expiresInDays: undefined, password: undefined });
+  }, []);
+
+  const isMutationCurrent = useCallback(
+    (contextEpoch: number, requestVideoId: Id<"videos">) =>
+      mutationContextEpochRef.current.isCurrent(contextEpoch) &&
+      activeVideoIdRef.current === requestVideoId &&
+      activeOpenRef.current,
+    [],
+  );
+
+  useEffect(() => {
+    mutationContextEpochRef.current.invalidate();
+    clearCopyFeedback();
+    resetMutationState();
+
+    return () => {
+      mutationContextEpochRef.current.invalidate();
+      copySequenceRef.current += 1;
+      if (copyTimeoutRef.current !== null) {
+        window.clearTimeout(copyTimeoutRef.current);
+        copyTimeoutRef.current = null;
+      }
+    };
+  }, [clearCopyFeedback, open, resetMutationState, videoId]);
+
+  const handleDialogOpenChange = (nextOpen: boolean) => {
+    activeOpenRef.current = nextOpen;
+    if (!nextOpen) {
+      mutationContextEpochRef.current.invalidate();
+      clearCopyFeedback();
+      resetMutationState();
+    }
+    onOpenChange(nextOpen);
+  };
 
   const handleCreateLink = async () => {
+    if (!canManageSharing) return;
+    const contextEpoch = mutationContextEpochRef.current.current();
+    const requestVideoId = videoId;
     setIsCreating(true);
+    setMutationError(null);
     try {
       await createShareLink({
         videoId,
@@ -56,71 +133,132 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
         allowDownload: false,
         password: newLinkOptions.password,
       });
+      if (!isMutationCurrent(contextEpoch, requestVideoId)) return;
       setNewLinkOptions({
         expiresInDays: undefined,
         password: undefined,
       });
-    } catch (error) {
-      console.error("Failed to create share link:", error);
+    } catch {
+      if (!isMutationCurrent(contextEpoch, requestVideoId)) return;
+      setMutationError("Could not create the restricted link. Please try again.");
     } finally {
-      setIsCreating(false);
+      if (isMutationCurrent(contextEpoch, requestVideoId)) {
+        setIsCreating(false);
+      }
     }
   };
 
   const handleSetVisibility = async (visibility: "public" | "private") => {
-    if (!video || isUpdatingVisibility || video.visibility === visibility) return;
+    if (!video || !canManageSharing || isUpdatingVisibility || video.visibility === visibility)
+      return;
+    const contextEpoch = mutationContextEpochRef.current.current();
+    const requestVideoId = videoId;
     setIsUpdatingVisibility(true);
+    setMutationError(null);
     try {
       await setVisibility({ videoId, visibility });
-    } catch (error) {
-      console.error("Failed to update visibility:", error);
+    } catch {
+      if (!isMutationCurrent(contextEpoch, requestVideoId)) return;
+      setMutationError("Could not update video visibility. Please try again.");
     } finally {
-      setIsUpdatingVisibility(false);
+      if (isMutationCurrent(contextEpoch, requestVideoId)) {
+        setIsUpdatingVisibility(false);
+      }
     }
   };
 
   const versionBrowsingEnabled = video?.allowPublicVersionBrowsing !== false;
 
   const handleSetVersionBrowsing = async (enabled: boolean) => {
-    if (!video || isUpdatingVersionBrowsing || versionBrowsingEnabled === enabled) return;
+    if (
+      !video ||
+      !canManageSharing ||
+      isUpdatingVersionBrowsing ||
+      versionBrowsingEnabled === enabled
+    )
+      return;
+    const contextEpoch = mutationContextEpochRef.current.current();
+    const requestVideoId = videoId;
     setIsUpdatingVersionBrowsing(true);
+    setMutationError(null);
     try {
       await setVersionBrowsing({ videoId, enabled });
-    } catch (error) {
-      console.error("Failed to update version browsing:", error);
+    } catch {
+      if (!isMutationCurrent(contextEpoch, requestVideoId)) return;
+      setMutationError("Could not update version browsing. Please try again.");
     } finally {
-      setIsUpdatingVersionBrowsing(false);
+      if (isMutationCurrent(contextEpoch, requestVideoId)) {
+        setIsUpdatingVersionBrowsing(false);
+      }
     }
   };
 
-  const handleCopyLink = (token: string) => {
-    const url = `${window.location.origin}/share/${token}`;
-    navigator.clipboard.writeText(url);
-    setCopiedId(token);
-    setTimeout(() => setCopiedId(null), 2000);
+  const copyLink = async (id: string, path: string) => {
+    const requestId = copySequenceRef.current + 1;
+    copySequenceRef.current = requestId;
+    if (copyTimeoutRef.current !== null) {
+      window.clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = null;
+    }
+    setCopiedId(null);
+    setCopyStatus(null);
+    setCopyFailureUrl(null);
+    const url = `${window.location.origin}${path}`;
+    const copied = await copyTextToClipboard(url);
+    if (requestId !== copySequenceRef.current || activeVideoIdRef.current !== videoId || !open) {
+      return;
+    }
+    if (!copied) {
+      setCopyStatus({
+        tone: "error",
+        message: "Could not copy the link. Please copy it manually.",
+      });
+      setCopyFailureUrl(url);
+      return;
+    }
+
+    setCopiedId(id);
+    setCopyStatus({ tone: "success", message: "Link copied to clipboard." });
+    copyTimeoutRef.current = window.setTimeout(() => {
+      if (copySequenceRef.current === requestId) {
+        setCopiedId((current) => (current === id ? null : current));
+      }
+      copyTimeoutRef.current = null;
+    }, 2000);
   };
 
-  const handleCopyPublicLink = () => {
+  const handleCopyLink = async (token: string) => {
+    await copyLink(token, `/share/${token}`);
+  };
+
+  const handleCopyPublicLink = async () => {
     if (!video?.publicId) return;
-    const url = `${window.location.origin}/watch/${video.publicId}`;
-    navigator.clipboard.writeText(url);
-    setCopiedId("public");
-    setTimeout(() => setCopiedId(null), 2000);
+    await copyLink("public", watchPath(video.publicId));
   };
 
   const handleDeleteLink = async (linkId: Id<"shareLinks">) => {
+    if (!canManageSharing) return;
     if (!confirm("Are you sure you want to delete this share link?")) return;
+    const contextEpoch = mutationContextEpochRef.current.current();
+    const requestVideoId = videoId;
+    setDeletingLinkId(linkId);
+    setMutationError(null);
     try {
       await deleteShareLink({ linkId });
-    } catch (error) {
-      console.error("Failed to delete share link:", error);
+    } catch {
+      if (!isMutationCurrent(contextEpoch, requestVideoId)) return;
+      setMutationError("Could not delete the restricted link. Please try again.");
+    } finally {
+      if (isMutationCurrent(contextEpoch, requestVideoId)) {
+        setDeletingLinkId(null);
+      }
     }
   };
 
-  const publicWatchPath = video?.publicId ? `/watch/${video.publicId}` : null;
+  const publicWatchPath = video?.publicId ? watchPath(video.publicId) : null;
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleDialogOpenChange}>
       <DialogContent className="max-h-[85vh] max-w-lg overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Share video</DialogTitle>
@@ -129,12 +267,51 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
           </DialogDescription>
         </DialogHeader>
 
+        {isViewer ? (
+          <p className="border-2 border-[#1a1a1a] bg-[#e8e8e0] px-3 py-2 text-sm text-[#1a1a1a]">
+            View-only access: you can copy or open links, but only team members can change sharing
+            settings.
+          </p>
+        ) : null}
+
+        {mutationError ? (
+          <p role="alert" aria-live="assertive" className="text-sm font-bold text-[#991b1b]">
+            {mutationError}
+          </p>
+        ) : null}
+
+        {copyStatus ? (
+          <div
+            role={copyStatus.tone === "error" ? "alert" : "status"}
+            aria-live={copyStatus.tone === "error" ? "assertive" : "polite"}
+            className={cn(
+              "border-2 px-3 py-2 text-sm font-bold",
+              copyStatus.tone === "success"
+                ? "border-[#2d5a2d] bg-[#dce8d8] text-[#2d5a2d]"
+                : "border-[#dc2626] bg-[#fee2e2] text-[#991b1b]",
+            )}
+          >
+            <p>{copyStatus.message}</p>
+            {copyFailureUrl ? (
+              <Input
+                className="mt-2 bg-white font-mono text-xs font-normal"
+                aria-label="Link to copy manually"
+                readOnly
+                value={copyFailureUrl}
+                onFocus={(event) => event.currentTarget.select()}
+                onClick={(event) => event.currentTarget.select()}
+              />
+            ) : null}
+          </div>
+        ) : null}
+
         {/* Visibility */}
         <div className="space-y-2">
           <div className="grid grid-cols-2 gap-2">
             <Button
               variant={video?.visibility === "public" ? "default" : "outline"}
-              disabled={isUpdatingVisibility || video === undefined}
+              disabled={!canManageSharing || isUpdatingVisibility}
+              aria-pressed={video?.visibility === "public"}
               onClick={() => void handleSetVisibility("public")}
             >
               <Globe className="mr-2 h-4 w-4" />
@@ -142,7 +319,8 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
             </Button>
             <Button
               variant={video?.visibility === "private" ? "default" : "outline"}
-              disabled={isUpdatingVisibility || video === undefined}
+              disabled={!canManageSharing || isUpdatingVisibility}
+              aria-pressed={video?.visibility === "private"}
               onClick={() => void handleSetVisibility("private")}
             >
               <Lock className="mr-2 h-4 w-4" />
@@ -165,7 +343,7 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
                 <Button
                   variant="outline"
                   size="icon"
-                  onClick={handleCopyPublicLink}
+                  onClick={() => void handleCopyPublicLink()}
                   aria-label="Copy public URL"
                 >
                   {copiedId === "public" ? (
@@ -204,7 +382,7 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
                   role="switch"
                   aria-checked={versionBrowsingEnabled}
                   aria-label="Version browsing"
-                  disabled={isUpdatingVersionBrowsing || video === undefined}
+                  disabled={!canManageSharing || isUpdatingVersionBrowsing}
                   onClick={() => void handleSetVersionBrowsing(!versionBrowsingEnabled)}
                   className={cn(
                     "relative h-7 w-12 shrink-0 border-2 border-[#1a1a1a] transition-colors disabled:opacity-50",
@@ -234,58 +412,64 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
             </p>
           </div>
 
-          <div className="grid grid-cols-2 gap-2">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="outline" className="w-full justify-between">
-                  {newLinkOptions.expiresInDays
-                    ? `${newLinkOptions.expiresInDays} days`
-                    : "Never expires"}
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent>
-                <DropdownMenuItem
-                  onClick={() => setNewLinkOptions((o) => ({ ...o, expiresInDays: undefined }))}
-                >
-                  Never expires
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onClick={() => setNewLinkOptions((o) => ({ ...o, expiresInDays: 1 }))}
-                >
-                  1 day
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onClick={() => setNewLinkOptions((o) => ({ ...o, expiresInDays: 7 }))}
-                >
-                  7 days
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onClick={() => setNewLinkOptions((o) => ({ ...o, expiresInDays: 30 }))}
-                >
-                  30 days
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-            <Input
-              type="password"
-              placeholder="Password (optional)"
-              value={newLinkOptions.password || ""}
-              onChange={(e) =>
-                setNewLinkOptions((o) => ({
-                  ...o,
-                  password: e.target.value || undefined,
-                }))
-              }
-            />
-          </div>
+          {canManageSharing ? (
+            <>
+              <div className="grid grid-cols-2 gap-2">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="outline" className="w-full justify-between">
+                      {newLinkOptions.expiresInDays
+                        ? `${newLinkOptions.expiresInDays} days`
+                        : "Never expires"}
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent>
+                    <DropdownMenuItem
+                      onClick={() => setNewLinkOptions((o) => ({ ...o, expiresInDays: undefined }))}
+                    >
+                      Never expires
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => setNewLinkOptions((o) => ({ ...o, expiresInDays: 1 }))}
+                    >
+                      1 day
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => setNewLinkOptions((o) => ({ ...o, expiresInDays: 7 }))}
+                    >
+                      7 days
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => setNewLinkOptions((o) => ({ ...o, expiresInDays: 30 }))}
+                    >
+                      30 days
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                <Input
+                  type="password"
+                  placeholder="Password (optional)"
+                  value={newLinkOptions.password || ""}
+                  onChange={(e) =>
+                    setNewLinkOptions((o) => ({
+                      ...o,
+                      password: e.target.value || undefined,
+                    }))
+                  }
+                />
+              </div>
 
-          <Button onClick={handleCreateLink} disabled={isCreating} className="w-full">
-            <Plus className="mr-2 h-4 w-4" />
-            {isCreating ? "Creating..." : "Create link"}
-          </Button>
+              <Button onClick={handleCreateLink} disabled={isCreating} className="w-full">
+                <Plus className="mr-2 h-4 w-4" />
+                {isCreating ? "Creating..." : "Create link"}
+              </Button>
+            </>
+          ) : null}
 
           {shareLinks === undefined ? (
-            <p className="text-sm text-[#888]">Loading...</p>
+            <p role="status" aria-live="polite" className="text-sm text-[#888]">
+              Loading links...
+            </p>
           ) : shareLinks.length === 0 ? (
             <p className="text-sm text-[#888]">No share links yet</p>
           ) : (
@@ -316,7 +500,12 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
                     </div>
                   </div>
                   <div className="flex shrink-0 items-center gap-1">
-                    <Button variant="ghost" size="icon" onClick={() => handleCopyLink(link.token)}>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => void handleCopyLink(link.token)}
+                      aria-label="Copy restricted link"
+                    >
                       {copiedId === link.token ? (
                         <Check className="h-4 w-4 text-[#2d5a2d]" />
                       ) : (
@@ -327,17 +516,22 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
                       variant="ghost"
                       size="icon"
                       onClick={() => window.open(`/share/${link.token}`, "_blank")}
+                      aria-label="Open restricted link"
                     >
                       <ExternalLink className="h-4 w-4" />
                     </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="text-[#dc2626] hover:text-[#dc2626]"
-                      onClick={() => handleDeleteLink(link._id)}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
+                    {canManageSharing ? (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="text-[#dc2626] hover:text-[#dc2626]"
+                        disabled={deletingLinkId !== null}
+                        onClick={() => void handleDeleteLink(link._id)}
+                        aria-label="Delete restricted link"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    ) : null}
                   </div>
                 </div>
               ))}

--- a/src/lib/clipboard.test.ts
+++ b/src/lib/clipboard.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import { copyTextToClipboard } from "./clipboard";
+
+const navigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+const documentDescriptor = Object.getOwnPropertyDescriptor(globalThis, "document");
+
+function setGlobal(name: "navigator" | "document", value: unknown) {
+  Object.defineProperty(globalThis, name, { configurable: true, value });
+}
+
+function restoreGlobal(name: "navigator" | "document", descriptor?: PropertyDescriptor) {
+  if (descriptor) {
+    Object.defineProperty(globalThis, name, descriptor);
+  } else {
+    Reflect.deleteProperty(globalThis, name);
+  }
+}
+
+afterEach(() => {
+  restoreGlobal("navigator", navigatorDescriptor);
+  restoreGlobal("document", documentDescriptor);
+});
+
+test("awaits the native Clipboard API before reporting success", async () => {
+  let written = "";
+  setGlobal("navigator", {
+    clipboard: {
+      writeText: async (text: string) => {
+        written = text;
+      },
+    },
+  });
+  setGlobal("document", undefined);
+
+  assert.equal(await copyTextToClipboard("https://lawn.video/watch/one"), true);
+  assert.equal(written, "https://lawn.video/watch/one");
+});
+
+test("falls back to execCommand when the native Clipboard API rejects", async () => {
+  let appended = false;
+  let removed = false;
+  let copiedValue = "";
+  const textarea = {
+    value: "",
+    style: {},
+    setAttribute: () => undefined,
+    focus: () => undefined,
+    select: () => {
+      copiedValue = textarea.value;
+    },
+  };
+
+  setGlobal("navigator", {
+    clipboard: { writeText: async () => Promise.reject(new Error("permission denied")) },
+  });
+  setGlobal("document", {
+    body: {
+      appendChild: () => {
+        appended = true;
+      },
+      removeChild: () => {
+        removed = true;
+      },
+    },
+    createElement: () => textarea,
+    execCommand: () => true,
+  });
+
+  assert.equal(await copyTextToClipboard("fallback text"), true);
+  assert.equal(copiedValue, "fallback text");
+  assert.equal(appended, true);
+  assert.equal(removed, true);
+});
+
+test("reports failure and still cleans up when both clipboard paths fail", async () => {
+  let removed = false;
+  const textarea = {
+    value: "",
+    style: {},
+    setAttribute: () => undefined,
+    focus: () => undefined,
+    select: () => undefined,
+  };
+
+  setGlobal("navigator", {
+    clipboard: { writeText: async () => Promise.reject(new Error("permission denied")) },
+  });
+  setGlobal("document", {
+    body: {
+      appendChild: () => undefined,
+      removeChild: () => {
+        removed = true;
+      },
+    },
+    createElement: () => textarea,
+    execCommand: () => {
+      throw new Error("copy unsupported");
+    },
+  });
+
+  assert.equal(await copyTextToClipboard("uncopyable"), false);
+  assert.equal(removed, true);
+});
+
+test("reports failure when the fallback cannot be mounted", async () => {
+  setGlobal("navigator", undefined);
+  setGlobal("document", {
+    body: {
+      appendChild: () => {
+        throw new Error("document is no longer active");
+      },
+      removeChild: () => undefined,
+    },
+    createElement: () => ({
+      value: "",
+      style: {},
+      setAttribute: () => undefined,
+      focus: () => undefined,
+      select: () => undefined,
+    }),
+    execCommand: () => true,
+  });
+
+  assert.equal(await copyTextToClipboard("uncopyable"), false);
+});

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,0 +1,43 @@
+export async function copyTextToClipboard(text: string) {
+  try {
+    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // Some browsers expose the Clipboard API but reject it outside a secure or
+    // user-activated context. Fall through to the legacy selection path.
+  }
+
+  if (typeof document === "undefined" || !document.body) {
+    return false;
+  }
+
+  let textarea: HTMLTextAreaElement | undefined;
+  let appended = false;
+
+  try {
+    textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    textarea.style.pointerEvents = "none";
+    document.body.appendChild(textarea);
+    appended = true;
+    textarea.focus();
+    textarea.select();
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    if (textarea && appended) {
+      try {
+        document.body.removeChild(textarea);
+      } catch {
+        // The copy result is still authoritative if another listener already
+        // removed the temporary element.
+      }
+    }
+  }
+}

--- a/src/lib/dashboardAccess.test.ts
+++ b/src/lib/dashboardAccess.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveDashboardAccess } from "./dashboardAccess";
+
+const authenticated = {
+  clerkLoaded: true,
+  hasClerkUser: true,
+  convexAuthLoading: false,
+  convexAuthenticated: true,
+  contextRequired: true,
+  workspaceContext: {},
+  publicLookupRequired: true,
+  publicId: "public-video",
+} as const;
+
+test("waits for Convex authentication before allowing protected dashboard content", () => {
+  assert.deepEqual(
+    resolveDashboardAccess({
+      ...authenticated,
+      convexAuthLoading: true,
+      convexAuthenticated: false,
+      workspaceContext: undefined,
+    }),
+    { kind: "loading" },
+  );
+  assert.deepEqual(
+    resolveDashboardAccess({
+      ...authenticated,
+      convexAuthenticated: false,
+      workspaceContext: undefined,
+      publicId: null,
+    }),
+    { kind: "auth-unavailable" },
+  );
+});
+
+test("uses public playback when Clerk has a user but Convex auth settles unauthenticated", () => {
+  assert.deepEqual(
+    resolveDashboardAccess({
+      ...authenticated,
+      convexAuthenticated: false,
+      workspaceContext: undefined,
+    }),
+    { kind: "redirect-public", publicId: "public-video" },
+  );
+  assert.deepEqual(
+    resolveDashboardAccess({
+      ...authenticated,
+      convexAuthenticated: false,
+      workspaceContext: undefined,
+      publicId: undefined,
+    }),
+    { kind: "loading" },
+  );
+});
+
+test("keeps authenticated team members on the dashboard", () => {
+  assert.deepEqual(resolveDashboardAccess(authenticated), { kind: "dashboard" });
+});
+
+test("redirects anonymous viewers and authenticated non-members to public playback", () => {
+  assert.deepEqual(
+    resolveDashboardAccess({
+      ...authenticated,
+      hasClerkUser: false,
+      convexAuthenticated: false,
+      workspaceContext: undefined,
+    }),
+    { kind: "redirect-public", publicId: "public-video" },
+  );
+  assert.deepEqual(resolveDashboardAccess({ ...authenticated, workspaceContext: null }), {
+    kind: "redirect-public",
+    publicId: "public-video",
+  });
+});
+
+test("does not expose private or missing videos to authenticated non-members", () => {
+  assert.deepEqual(
+    resolveDashboardAccess({ ...authenticated, workspaceContext: null, publicId: null }),
+    { kind: "not-found" },
+  );
+});
+
+test("sends anonymous private links to sign in without mounting dashboard content", () => {
+  assert.deepEqual(
+    resolveDashboardAccess({
+      ...authenticated,
+      hasClerkUser: false,
+      convexAuthenticated: false,
+      workspaceContext: undefined,
+      publicId: null,
+    }),
+    { kind: "redirect-sign-in" },
+  );
+});

--- a/src/lib/dashboardAccess.ts
+++ b/src/lib/dashboardAccess.ts
@@ -1,0 +1,72 @@
+type WorkspaceContext = object | null | undefined;
+
+type DashboardAccessInput = {
+  clerkLoaded: boolean;
+  hasClerkUser: boolean;
+  convexAuthLoading: boolean;
+  convexAuthenticated: boolean;
+  contextRequired: boolean;
+  workspaceContext: WorkspaceContext;
+  publicLookupRequired: boolean;
+  publicId: string | null | undefined;
+};
+
+export type DashboardAccessState =
+  | { kind: "loading" }
+  | { kind: "dashboard" }
+  | { kind: "redirect-public"; publicId: string }
+  | { kind: "redirect-sign-in" }
+  | { kind: "not-found" }
+  | { kind: "auth-unavailable" };
+
+export function resolveDashboardAccess(input: DashboardAccessInput): DashboardAccessState {
+  if (!input.clerkLoaded) {
+    return { kind: "loading" };
+  }
+
+  if (!input.hasClerkUser) {
+    if (input.publicLookupRequired && input.publicId === undefined) {
+      return { kind: "loading" };
+    }
+    if (input.publicLookupRequired && input.publicId) {
+      return { kind: "redirect-public", publicId: input.publicId };
+    }
+    return { kind: "redirect-sign-in" };
+  }
+
+  if (input.convexAuthLoading) {
+    return { kind: "loading" };
+  }
+
+  if (!input.convexAuthenticated) {
+    if (input.publicLookupRequired && input.publicId === undefined) {
+      return { kind: "loading" };
+    }
+    if (input.publicLookupRequired && input.publicId) {
+      return { kind: "redirect-public", publicId: input.publicId };
+    }
+    return { kind: "auth-unavailable" };
+  }
+
+  if (!input.contextRequired) {
+    return { kind: "dashboard" };
+  }
+
+  if (input.workspaceContext === undefined) {
+    return { kind: "loading" };
+  }
+
+  if (input.workspaceContext !== null) {
+    return { kind: "dashboard" };
+  }
+
+  if (input.publicLookupRequired && input.publicId === undefined) {
+    return { kind: "loading" };
+  }
+
+  if (input.publicLookupRequired && input.publicId) {
+    return { kind: "redirect-public", publicId: input.publicId };
+  }
+
+  return { kind: "not-found" };
+}

--- a/src/lib/requestEpoch.test.ts
+++ b/src/lib/requestEpoch.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createRequestEpoch } from "./requestEpoch";
+
+test("a newer request invalidates an older delayed completion", async () => {
+  const epoch = createRequestEpoch();
+  const first = epoch.next();
+  let resolveFirst = () => undefined;
+  const firstResult = new Promise<void>((resolve) => {
+    resolveFirst = resolve;
+  });
+
+  const second = epoch.next();
+  resolveFirst();
+  await firstResult;
+
+  assert.equal(epoch.isCurrent(first), false);
+  assert.equal(epoch.isCurrent(second), true);
+});
+
+test("context invalidation rejects a delayed mutation token", () => {
+  const epoch = createRequestEpoch();
+  const context = epoch.current();
+
+  epoch.invalidate();
+
+  assert.equal(epoch.isCurrent(context), false);
+});

--- a/src/lib/requestEpoch.ts
+++ b/src/lib/requestEpoch.ts
@@ -1,0 +1,15 @@
+export function createRequestEpoch() {
+  let epoch = 0;
+
+  return {
+    current: () => epoch,
+    next: () => {
+      epoch += 1;
+      return epoch;
+    },
+    invalidate: () => {
+      epoch += 1;
+    },
+    isCurrent: (requestEpoch: number) => requestEpoch === epoch,
+  };
+}


### PR DESCRIPTION
## Summary
- make signed-out and non-member dashboard video URLs reliably redirect to the public watch route without racing Clerk and Convex authentication
- keep public links stable through uploading, processing, ready, and failed lifecycle states while preserving private-video access boundaries
- unify robust clipboard behavior across Quick Share and the Share dialog, including race guards, visible errors, and manual-copy recovery
- make sharing controls role-aware and isolate delayed mutations when dialogs close or switch videos

## User impact
Videos remain public by default. Copying a public dashboard video URL now works as a share link: team members stay in the dashboard, while everyone else is sent to the watch page. Private videos are never auto-published or exposed.

## Validation
- `bun run check`
  - Prettier
  - TypeScript
  - Convex typecheck
  - ESLint
  - 35 Bun unit tests
  - 35 Vitest/Convex tests
- independent correctness review: no remaining P0-P3 findings
- independent design/UX review: no remaining P0-P3 findings
- `git diff --check`

No dev server or build command was run, per repository instructions.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make dashboard video links redirect unauthenticated users to public watch pages
> - Adds `resolveDashboardAccess` to determine routing outcome (loading, dashboard, public redirect, sign-in redirect, not-found, auth-unavailable) from auth and workspace context state, replacing ad-hoc redirect logic in `DashboardLayout`.
> - The Share action in `ProjectPage` and `ShareDialog` now copies a public watch URL (via `watchPath`) when the video is public, with success/error feedback and a manual-copy fallback input on clipboard failure.
> - `workspace.resolveContext` now accepts raw string IDs and normalizes them, returning null for malformed input instead of throwing.
> - `videos.getPublicIdByVideoId` now returns a `publicId` for public videos in any status (uploading, processing, ready, failed), not only `ready`.
> - Adds a `copyTextToClipboard` utility with `navigator.clipboard` and `execCommand` fallback, and a `createRequestEpoch` helper to guard against stale async results.
> - Behavioral Change: unauthenticated users visiting a dashboard video link with a public video are now redirected to the public watch page instead of the sign-in page.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 16039fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a robust “copy to clipboard” helper with native support and fallback behavior.
  * Enhanced the share dialog with better success/error feedback, an optional dismissable toast, and a read-only copied-link input.

* **Bug Fixes**
  * Prevented stale share/copy results from updating the UI after navigation, dialog close, or rapid repeat actions.
  * Improved dashboard access routing for public vs signed-in users, including dedicated loading/redirect states.
  * Updated public video aliasing to apply to public videos across statuses.
  * Disabled share actions while requests are pending to avoid duplicates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->