### PR TITLE
Make original video playback recover reliably

### DIFF
--- a/app/routes/-home.tsx
+++ b/app/routes/-home.tsx
@@ -6,23 +6,24 @@ import { dashboardHomePath } from "@/lib/routes";
 
 function HomeNavActions({ scrolled }: { scrolled: boolean }) {
   const { isLoaded, userId } = useAuth();
-  const startPath = userId ? dashboardHomePath() : "/sign-up";
-  const startClassName = `px-4 py-2 border-2 transition-colors ${scrolled ? "border-[#1a1a1a] hover:bg-[#1a1a1a] hover:text-[#f0f0e8]" : "border-[#f0f0e8] hover:bg-[#f0f0e8] hover:text-[#1a1a1a]"}`;
+  const startClassName = `inline-flex min-w-[76px] justify-center px-4 py-2 border-2 transition-colors ${scrolled ? "border-[#1a1a1a] hover:bg-[#1a1a1a] hover:text-[#f0f0e8]" : "border-[#f0f0e8] hover:bg-[#f0f0e8] hover:text-[#1a1a1a]"}`;
 
-  // "Start" renders immediately so it never pops or shifts. "Log in" only shows
-  // once auth resolves to a signed-out visitor — no reserved gap for signed-in
-  // users.
-  return (
-    <div className="flex items-center gap-6">
-      {isLoaded && !userId && (
-        <Link to="/sign-in" className="underline-offset-4 hover:underline">
-          Log in
-        </Link>
-      )}
-      <Link to={startPath} className={startClassName}>
-        Start
-      </Link>
-    </div>
+  if (!isLoaded) {
+    return (
+      <span className={`${startClassName} invisible`} aria-hidden="true">
+        Log in
+      </span>
+    );
+  }
+
+  return userId ? (
+    <Link to={dashboardHomePath()} className={startClassName}>
+      Start
+    </Link>
+  ) : (
+    <Link to="/sign-in" className={startClassName}>
+      Log in
+    </Link>
   );
 }
 

--- a/app/routes/dashboard/-video.tsx
+++ b/app/routes/dashboard/-video.tsx
@@ -5,7 +5,11 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
-import { VideoPlayer, type VideoPlayerHandle } from "@/components/video-player/VideoPlayer";
+import {
+  VideoPlayer,
+  type VideoPlaybackIssue,
+  type VideoPlayerHandle,
+} from "@/components/video-player/VideoPlayer";
 import { CommentList } from "@/components/comments/CommentList";
 import { CommentInput } from "@/components/comments/CommentInput";
 import { ShareDialog } from "@/components/ShareDialog";
@@ -59,6 +63,8 @@ type VideoVersion = {
   status: string;
   isLatestVersion: boolean;
 };
+
+const MAX_AUTOMATIC_PLAYBACK_ATTEMPTS = 3;
 
 function versionStatusLabel(status: string) {
   switch (status) {
@@ -303,6 +309,11 @@ export default function VideoPage() {
     posterUrl: string;
   } | null>(null);
   const [isLoadingPlayback, setIsLoadingPlayback] = useState(false);
+  const [playbackLoadError, setPlaybackLoadError] = useState<string | null>(null);
+  const [playbackRequest, setPlaybackRequest] = useState<{
+    videoId: Id<"videos">;
+    attempt: number;
+  } | null>(null);
   const [originalPlaybackUrl, setOriginalPlaybackUrl] = useState<string | null>(null);
   const [isLoadingOriginalPlayback, setIsLoadingOriginalPlayback] = useState(false);
   const [isRetryingFailedProcessing, setIsRetryingFailedProcessing] = useState(false);
@@ -312,19 +323,53 @@ export default function VideoPage() {
     tone: "success" | "error";
     message: string;
   } | null>(null);
-  const [preferredSource, setPreferredSource] = useState<"mux720" | "original">("original");
+  const [sourcePreference, setSourcePreference] = useState<{
+    videoId: Id<"videos">;
+    source: "mux720" | "original";
+  } | null>(null);
+  const [failedOriginalVideoId, setFailedOriginalVideoId] = useState<Id<"videos"> | null>(null);
+  const [originalPlaybackIssue, setOriginalPlaybackIssue] = useState<{
+    videoId: Id<"videos">;
+    type: VideoPlaybackIssue["type"];
+  } | null>(null);
+  const [playbackResume, setPlaybackResume] = useState<{
+    videoId: Id<"videos">;
+    currentTime: number;
+    wasPlaying: boolean;
+  } | null>(null);
   const playerRef = useRef<VideoPlayerHandle | null>(null);
   const deletePendingRef = useRef(false);
+  const muxRecoveryVideoIdRef = useRef<Id<"videos"> | null>(null);
+  const playbackRetryTimeoutRef = useRef<number | null>(null);
   const isPlayable = video?.status === "ready" && Boolean(video?.muxPlaybackId);
   const playbackUrl = playbackSession?.url ?? null;
-  const activePlaybackUrl =
-    preferredSource === "mux720"
-      ? (playbackUrl ?? originalPlaybackUrl)
-      : (originalPlaybackUrl ?? playbackUrl);
+  const playbackRequestAttempt =
+    playbackRequest?.videoId === resolvedVideoId ? playbackRequest.attempt : 0;
+  const processingFailed = video?.status === "failed";
+  const preferredSource =
+    sourcePreference?.videoId === resolvedVideoId ? sourcePreference.source : "original";
+  const originalPlaybackFailed = !processingFailed && failedOriginalVideoId === resolvedVideoId;
+  const usableOriginalPlaybackUrl = originalPlaybackFailed ? null : originalPlaybackUrl;
+  const activePlaybackUrl = processingFailed
+    ? null
+    : preferredSource === "mux720"
+      ? (playbackUrl ?? usableOriginalPlaybackUrl)
+      : (usableOriginalPlaybackUrl ?? playbackUrl);
   const activeQualityId =
     activePlaybackUrl && playbackUrl && activePlaybackUrl === playbackUrl ? "mux720" : "original";
   const isUsingOriginalFallback = Boolean(
     activePlaybackUrl && activePlaybackUrl === originalPlaybackUrl && !playbackUrl,
+  );
+  const isWaitingForMuxAfterOriginalFailure = originalPlaybackFailed && !playbackUrl;
+  const activePlaybackResume = playbackResume?.videoId === resolvedVideoId ? playbackResume : null;
+  const activeOriginalPlaybackIssue =
+    !processingFailed && originalPlaybackIssue?.videoId === resolvedVideoId
+      ? originalPlaybackIssue
+      : null;
+  const isAutomaticPlaybackRetryPending = Boolean(
+    activeOriginalPlaybackIssue &&
+    playbackLoadError &&
+    playbackRequestAttempt < MAX_AUTOMATIC_PLAYBACK_ATTEMPTS - 1,
   );
   const shouldCanonicalize =
     !!context && !context.isCanonical && pathname !== context.canonicalPath;
@@ -342,6 +387,35 @@ export default function VideoPage() {
     videoId: resolvedVideoId,
     enabled: Boolean(resolvedVideoId),
   });
+
+  useEffect(() => {
+    setSourcePreference(null);
+    setFailedOriginalVideoId(null);
+    setOriginalPlaybackIssue(null);
+    setPlaybackResume(null);
+    setPlaybackLoadError(null);
+    setPlaybackRequest(null);
+    muxRecoveryVideoIdRef.current = null;
+    if (playbackRetryTimeoutRef.current !== null) {
+      window.clearTimeout(playbackRetryTimeoutRef.current);
+      playbackRetryTimeoutRef.current = null;
+    }
+  }, [resolvedVideoId]);
+
+  useEffect(() => {
+    if (video?.status !== "failed") return;
+    setSourcePreference(null);
+    setFailedOriginalVideoId(null);
+    setOriginalPlaybackIssue(null);
+    setPlaybackResume(null);
+    setPlaybackLoadError(null);
+    setPlaybackRequest(null);
+    muxRecoveryVideoIdRef.current = null;
+    if (playbackRetryTimeoutRef.current !== null) {
+      window.clearTimeout(playbackRetryTimeoutRef.current);
+      playbackRetryTimeoutRef.current = null;
+    }
+  }, [video?.status]);
 
   useEffect(() => {
     if (shouldCanonicalize && context) {
@@ -388,6 +462,7 @@ export default function VideoPage() {
 
     let cancelled = false;
     setIsLoadingPlayback(true);
+    setPlaybackLoadError(null);
 
     void getPlaybackSession({ videoId: resolvedVideoId })
       .then((session) => {
@@ -397,6 +472,22 @@ export default function VideoPage() {
       .catch(() => {
         if (cancelled) return;
         setPlaybackSession(null);
+        setPlaybackLoadError("The 720p stream could not be loaded.");
+        if (
+          muxRecoveryVideoIdRef.current === resolvedVideoId &&
+          playbackRequestAttempt < MAX_AUTOMATIC_PLAYBACK_ATTEMPTS - 1
+        ) {
+          playbackRetryTimeoutRef.current = window.setTimeout(
+            () => {
+              playbackRetryTimeoutRef.current = null;
+              setPlaybackRequest((request) => ({
+                videoId: resolvedVideoId,
+                attempt: request?.videoId === resolvedVideoId ? request.attempt + 1 : 1,
+              }));
+            },
+            1_000 * (playbackRequestAttempt + 1),
+          );
+        }
       })
       .finally(() => {
         if (cancelled) return;
@@ -405,8 +496,18 @@ export default function VideoPage() {
 
     return () => {
       cancelled = true;
+      if (playbackRetryTimeoutRef.current !== null) {
+        window.clearTimeout(playbackRetryTimeoutRef.current);
+        playbackRetryTimeoutRef.current = null;
+      }
     };
-  }, [getPlaybackSession, isPlayable, resolvedVideoId, video?.muxPlaybackId]);
+  }, [
+    getPlaybackSession,
+    isPlayable,
+    playbackRequestAttempt,
+    resolvedVideoId,
+    video?.muxPlaybackId,
+  ]);
 
   useEffect(() => {
     if (!resolvedVideoId || !video || video.status === "uploading" || video.status === "failed") {
@@ -440,6 +541,56 @@ export default function VideoPage() {
   const handleTimeUpdate = useCallback((time: number) => {
     setCurrentTime(time);
   }, []);
+
+  const handleOriginalPlaybackIssue = useCallback(
+    (issue: VideoPlaybackIssue) => {
+      if (!resolvedVideoId) return;
+      setPlaybackResume({
+        videoId: resolvedVideoId,
+        currentTime: issue.currentTime,
+        wasPlaying: issue.wasPlaying,
+      });
+      muxRecoveryVideoIdRef.current = resolvedVideoId;
+      setFailedOriginalVideoId(resolvedVideoId);
+      setOriginalPlaybackIssue({ videoId: resolvedVideoId, type: issue.type });
+      setSourcePreference({ videoId: resolvedVideoId, source: "mux720" });
+      if (isPlayable && !playbackUrl && !isLoadingPlayback) {
+        setPlaybackRequest((request) => ({
+          videoId: resolvedVideoId,
+          attempt: request?.videoId === resolvedVideoId ? request.attempt + 1 : 1,
+        }));
+      }
+    },
+    [isLoadingPlayback, isPlayable, playbackUrl, resolvedVideoId],
+  );
+
+  const handleSelectQuality = useCallback(
+    (id: string) => {
+      if (!resolvedVideoId || (id !== "mux720" && id !== "original")) return;
+      if (id === "original") {
+        muxRecoveryVideoIdRef.current = null;
+        if (playbackRetryTimeoutRef.current !== null) {
+          window.clearTimeout(playbackRetryTimeoutRef.current);
+          playbackRetryTimeoutRef.current = null;
+        }
+        setFailedOriginalVideoId((failedVideoId) =>
+          failedVideoId === resolvedVideoId ? null : failedVideoId,
+        );
+        setOriginalPlaybackIssue((issue) => (issue?.videoId === resolvedVideoId ? null : issue));
+      }
+      setSourcePreference({ videoId: resolvedVideoId, source: id });
+    },
+    [resolvedVideoId],
+  );
+
+  const handleRetryPlaybackSession = useCallback(() => {
+    if (!resolvedVideoId || !isPlayable || isLoadingPlayback) return;
+    muxRecoveryVideoIdRef.current = resolvedVideoId;
+    setPlaybackRequest((request) => ({
+      videoId: resolvedVideoId,
+      attempt: request?.videoId === resolvedVideoId ? request.attempt + 1 : 1,
+    }));
+  }, [isLoadingPlayback, isPlayable, resolvedVideoId]);
 
   const handleMarkerClick = useCallback((comment: { _id: string }) => {
     setHighlightedCommentId(comment._id as Id<"comments">);
@@ -925,10 +1076,36 @@ export default function VideoPage() {
             </div>
           ) : null}
 
+          {activeOriginalPlaybackIssue ? (
+            <div
+              className="flex flex-shrink-0 items-center gap-2 bg-[#2a2114] px-4 py-2 text-sm text-[#fff1d5]"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+            >
+              <span className="inline-flex h-2.5 w-2.5 rounded-full bg-[#f0b45d]" />
+              <span className="font-semibold">
+                {activeOriginalPlaybackIssue.type === "frozen-video"
+                  ? "Original playback stalled."
+                  : "Original playback was unavailable."}
+              </span>
+              <span className="text-[#d8c6a8]">
+                {playbackUrl
+                  ? "Switched to 720p."
+                  : playbackLoadError && !isAutomaticPlaybackRetryPending
+                    ? "720p needs another try."
+                    : "Preparing 720p…"}
+              </span>
+            </div>
+          ) : null}
+
           {activePlaybackUrl ? (
             <VideoPlayer
+              key={resolvedVideoId}
               ref={playerRef}
               src={activePlaybackUrl}
+              initialTime={activePlaybackResume?.currentTime}
+              initialPlay={activePlaybackResume?.wasPlaying}
               poster={playbackSession?.posterUrl}
               comments={comments || []}
               onTimeUpdate={handleTimeUpdate}
@@ -950,20 +1127,32 @@ export default function VideoPage() {
                 },
               ]}
               selectedQualityId={activeQualityId}
-              onSelectQuality={(id) => {
-                if (id === "mux720" || id === "original") {
-                  setPreferredSource(id);
-                }
-              }}
+              onSelectQuality={handleSelectQuality}
+              onPlaybackIssue={
+                activeQualityId === "original" ? handleOriginalPlaybackIssue : undefined
+              }
             />
           ) : (
             <div className="flex flex-1 items-center justify-center">
-              {video.status === "ready" && !playbackUrl ? (
+              {isWaitingForMuxAfterOriginalFailure || (video.status === "ready" && !playbackUrl) ? (
                 <div className="flex flex-col items-center gap-3 text-white">
-                  <div className="h-8 w-8 animate-spin rounded-full border-2 border-white/20 border-t-white/80" />
-                  <p className="text-sm font-medium text-white/85">
-                    {isLoadingPlayback ? "Loading stream..." : "Preparing stream..."}
-                  </p>
+                  {playbackLoadError && !isLoadingPlayback && !isAutomaticPlaybackRetryPending ? (
+                    <>
+                      <p className="text-sm font-medium text-white/85">{playbackLoadError}</p>
+                      <Button variant="primary" onClick={handleRetryPlaybackSession}>
+                        Retry 720p
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      <div className="h-8 w-8 animate-spin rounded-full border-2 border-white/20 border-t-white/80" />
+                      <p className="text-sm font-medium text-white/85">
+                        {isLoadingPlayback || isAutomaticPlaybackRetryPending
+                          ? "Loading 720p stream..."
+                          : "Preparing stream..."}
+                      </p>
+                    </>
+                  )}
                 </div>
               ) : (
                 <div className="text-center">

--- a/src/components/video-player/VideoPlayer.tsx
+++ b/src/components/video-player/VideoPlayer.tsx
@@ -27,6 +27,12 @@ import {
 } from "lucide-react";
 import { cn, formatDuration, formatTimestamp } from "@/lib/utils";
 import { triggerDownload } from "@/lib/download";
+import {
+  createVideoPlaybackHealthState,
+  markVideoPlaybackIssueReported,
+  observeVideoPlayback,
+  resetVideoPlaybackHealthWindow,
+} from "@/lib/videoPlaybackHealth";
 
 interface Comment {
   _id: string;
@@ -46,6 +52,8 @@ interface VideoPlayerProps {
   onTimeUpdate?: (currentTime: number) => void;
   onMarkerClick?: (comment: Comment) => void;
   initialTime?: number;
+  initialPlay?: boolean;
+  onPlaybackIssue?: (issue: VideoPlaybackIssue) => void;
   className?: string;
   allowDownload?: boolean;
   downloadUrl?: string;
@@ -65,6 +73,20 @@ interface VideoPlayerProps {
   /** Render controls below the video frame instead of overlaid. Ideal for mobile. */
   controlsBelow?: boolean;
 }
+
+export type VideoPlaybackIssue =
+  | {
+      type: "frozen-video";
+      currentTime: number;
+      wasPlaying: boolean;
+    }
+  | {
+      type: "media-error";
+      currentTime: number;
+      wasPlaying: boolean;
+      code: number;
+      message: string;
+    };
 
 export interface VideoPlayerHandle {
   seekTo: (time: number, options?: { play?: boolean }) => void;
@@ -94,6 +116,8 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
     onTimeUpdate,
     onMarkerClick,
     initialTime,
+    initialPlay = false,
+    onPlaybackIssue,
     className,
     allowDownload = false,
     downloadUrl,
@@ -139,6 +163,13 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
   const isPlayingRef = useRef(false);
   const isScrubbingRef = useRef(false);
   const resumeTimeOnSourceChangeRef = useRef<number | null>(null);
+  const resumePlaybackOnSourceChangeRef = useRef(initialPlay);
+  const hasAttachedSourceRef = useRef(false);
+  const onPlaybackIssueRef = useRef(onPlaybackIssue);
+
+  useEffect(() => {
+    onPlaybackIssueRef.current = onPlaybackIssue;
+  }, [onPlaybackIssue]);
 
   const groupedMarkers = useMemo(() => {
     if (!duration || comments.length === 0) return [] as { position: number; comment: Comment }[];
@@ -440,16 +471,86 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
     if (!video) return;
 
     let cancelled = false;
+    let waitingForResumeSeek = false;
+    let metadataLoaded = false;
+    let frameCallbackId: number | null = null;
+    let healthIntervalId: number | null = null;
+    let healthMonitoringActive = false;
+    let latestPresentedFrames = 0;
+    let playbackHealth = createVideoPlaybackHealthState();
+
+    const reportPlaybackIssue = (issue: VideoPlaybackIssue) => {
+      if (playbackHealth.issueReported) return;
+      resumePlaybackOnSourceChangeRef.current = issue.wasPlaying;
+      playbackHealth = markVideoPlaybackIssueReported(playbackHealth);
+      onPlaybackIssueRef.current?.(issue);
+      stopPlaybackHealthMonitor();
+    };
+
+    const resetPlaybackHealth = () => {
+      playbackHealth = resetVideoPlaybackHealthWindow(
+        playbackHealth,
+        video.currentTime,
+        latestPresentedFrames,
+      );
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        resetPlaybackHealth();
+      }
+    };
+
+    function stopPlaybackHealthMonitor() {
+      healthMonitoringActive = false;
+      if (frameCallbackId !== null) {
+        video.cancelVideoFrameCallback(frameCallbackId);
+        frameCallbackId = null;
+      }
+      if (healthIntervalId !== null) {
+        window.clearInterval(healthIntervalId);
+        healthIntervalId = null;
+      }
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    }
+
+    const resumePlaybackIfReady = () => {
+      if (
+        cancelled ||
+        !metadataLoaded ||
+        waitingForResumeSeek ||
+        !resumePlaybackOnSourceChangeRef.current ||
+        video.readyState < HTMLMediaElement.HAVE_FUTURE_DATA
+      ) {
+        return;
+      }
+
+      resumePlaybackOnSourceChangeRef.current = false;
+      const playPromise = video.play();
+      if (playPromise) {
+        playPromise.catch(() => {
+          // A browser may still reject resumed playback after a source swap.
+        });
+      }
+    };
 
     const handleLoadedMetadata = () => {
       if (cancelled) return;
+      metadataLoaded = true;
       setDuration(video.duration || 0);
       updateBuffered();
-      const resumeTime = initialTime ?? resumeTimeOnSourceChangeRef.current ?? undefined;
-      if (resumeTime && resumeTime > 0) {
-        video.currentTime = clamp(resumeTime, 0, video.duration || resumeTime);
+      const isFirstSource = !hasAttachedSourceRef.current;
+      const resumeTime =
+        resumeTimeOnSourceChangeRef.current ?? (isFirstSource ? initialTime : undefined);
+      hasAttachedSourceRef.current = true;
+      if (resumeTime !== undefined && resumeTime > 0) {
+        const nextTime = clamp(resumeTime, 0, video.duration || resumeTime);
+        waitingForResumeSeek = Math.abs(video.currentTime - nextTime) > 0.01;
+        video.currentTime = nextTime;
+        setCurrentTime(nextTime);
       }
       resumeTimeOnSourceChangeRef.current = null;
+      resumePlaybackIfReady();
     };
 
     const handleLoadedData = () => {
@@ -479,6 +580,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
 
     const handlePause = () => {
       if (cancelled) return;
+      resetPlaybackHealth();
       setIsPlaying(false);
       setIsBuffering(false);
       setControlsVisible(true);
@@ -498,12 +600,33 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
     const handleCanPlay = () => {
       if (cancelled) return;
       setIsMediaReady(true);
+      resumePlaybackIfReady();
     };
 
     const handleError = () => {
       if (cancelled) return;
       setIsMediaReady(true);
       setIsBuffering(false);
+      const mediaError = video.error;
+      reportPlaybackIssue({
+        type: "media-error",
+        currentTime: video.currentTime,
+        wasPlaying: isPlayingRef.current || (!video.paused && !video.ended),
+        code: mediaError?.code ?? 0,
+        message: mediaError?.message ?? "The browser could not play this video source.",
+      });
+    };
+
+    const handleSeeking = () => {
+      if (cancelled) return;
+      resetPlaybackHealth();
+    };
+
+    const handleSeeked = () => {
+      if (cancelled) return;
+      waitingForResumeSeek = false;
+      resetPlaybackHealth();
+      resumePlaybackIfReady();
     };
 
     const handleVolumeChange = () => {
@@ -526,6 +649,47 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
       if (cancelled) return;
       setIsPlaying(false);
       setControlsVisible(true);
+    };
+
+    const startPlaybackHealthMonitor = () => {
+      if (isHlsSource(src) || typeof video.requestVideoFrameCallback !== "function") return;
+      healthMonitoringActive = true;
+      document.addEventListener("visibilitychange", handleVisibilityChange);
+
+      const recordPresentedFrame: VideoFrameRequestCallback = (_now, metadata) => {
+        if (cancelled || !healthMonitoringActive) return;
+        latestPresentedFrames = metadata.presentedFrames;
+        frameCallbackId = video.requestVideoFrameCallback(recordPresentedFrame);
+      };
+
+      frameCallbackId = video.requestVideoFrameCallback(recordPresentedFrame);
+      healthIntervalId = window.setInterval(() => {
+        if (cancelled) return;
+        const result = observeVideoPlayback(playbackHealth, {
+          nowMs: performance.now(),
+          mediaTime: video.currentTime,
+          presentedFrames: latestPresentedFrames,
+          playing: !video.paused && !video.ended,
+          seeking: video.seeking,
+          buffering: video.readyState < HTMLMediaElement.HAVE_FUTURE_DATA,
+          visible: document.visibilityState === "visible",
+        });
+        playbackHealth = result.state;
+        if (playbackHealth.monitoringComplete) {
+          stopPlaybackHealthMonitor();
+          return;
+        }
+        if (result.issueDetected) {
+          const issue = {
+            type: "frozen-video",
+            currentTime: video.currentTime,
+            wasPlaying: !video.paused && !video.ended,
+          } as const;
+          resumePlaybackOnSourceChangeRef.current = issue.wasPlaying;
+          onPlaybackIssueRef.current?.(issue);
+          stopPlaybackHealthMonitor();
+        }
+      }, 500);
     };
 
     const attachSource = async () => {
@@ -594,6 +758,8 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
       } else {
         video.src = src;
       }
+
+      startPlaybackHealthMonitor();
     };
 
     video.addEventListener("loadedmetadata", handleLoadedMetadata);
@@ -606,6 +772,8 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
     video.addEventListener("playing", handlePlaying);
     video.addEventListener("canplay", handleCanPlay);
     video.addEventListener("error", handleError);
+    video.addEventListener("seeking", handleSeeking);
+    video.addEventListener("seeked", handleSeeked);
     video.addEventListener("volumechange", handleVolumeChange);
     video.addEventListener("ratechange", handleRateChange);
     video.addEventListener("progress", handleProgress);
@@ -624,6 +792,12 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
       if (ct > 0) {
         resumeTimeOnSourceChangeRef.current = ct;
       }
+      resumePlaybackOnSourceChangeRef.current =
+        resumePlaybackOnSourceChangeRef.current ||
+        isPlayingRef.current ||
+        (!video.paused && !video.ended);
+
+      stopPlaybackHealthMonitor();
 
       video.removeEventListener("loadedmetadata", handleLoadedMetadata);
       video.removeEventListener("loadeddata", handleLoadedData);
@@ -635,6 +809,8 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
       video.removeEventListener("playing", handlePlaying);
       video.removeEventListener("canplay", handleCanPlay);
       video.removeEventListener("error", handleError);
+      video.removeEventListener("seeking", handleSeeking);
+      video.removeEventListener("seeked", handleSeeked);
       video.removeEventListener("volumechange", handleVolumeChange);
       video.removeEventListener("ratechange", handleRateChange);
       video.removeEventListener("progress", handleProgress);

--- a/src/lib/videoPlaybackHealth.test.ts
+++ b/src/lib/videoPlaybackHealth.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createVideoPlaybackHealthState,
+  markVideoPlaybackIssueReported,
+  observeVideoPlayback,
+  resetVideoPlaybackHealthWindow,
+} from "./videoPlaybackHealth";
+
+const playingSample = {
+  mediaTime: 0,
+  presentedFrames: 1,
+  playing: true,
+  seeking: false,
+  buffering: false,
+  visible: true,
+};
+
+test("allows a five-second opening hold before confirming a startup freeze", () => {
+  let state = createVideoPlaybackHealthState();
+  state = observeVideoPlayback(state, { ...playingSample, nowMs: 0 }).state;
+  state = observeVideoPlayback(state, { ...playingSample, nowMs: 500, mediaTime: 0.5 }).state;
+  const result = observeVideoPlayback(state, {
+    ...playingSample,
+    nowMs: 5_500,
+    mediaTime: 5.5,
+  });
+
+  assert.equal(result.issueDetected, false);
+  assert.equal(result.state.issueReported, false);
+});
+
+test("confirms a startup freeze after eight seconds of media-clock-only progress", () => {
+  let state = createVideoPlaybackHealthState();
+  state = observeVideoPlayback(state, { ...playingSample, nowMs: 0 }).state;
+  state = observeVideoPlayback(state, { ...playingSample, nowMs: 500, mediaTime: 0.5 }).state;
+  const result = observeVideoPlayback(state, {
+    ...playingSample,
+    nowMs: 8_500,
+    mediaTime: 8.5,
+  });
+
+  assert.equal(result.issueDetected, true);
+  assert.equal(result.state.issueReported, true);
+});
+
+test("healthy frame progress completes startup monitoring before a held frame", () => {
+  let state = createVideoPlaybackHealthState();
+  state = observeVideoPlayback(state, { ...playingSample, nowMs: 0 }).state;
+  const healthy = observeVideoPlayback(state, {
+    ...playingSample,
+    nowMs: 500,
+    mediaTime: 0.5,
+    presentedFrames: 2,
+  });
+  const later = observeVideoPlayback(
+    healthy.state,
+    { ...playingSample, nowMs: 30_000, mediaTime: 30, presentedFrames: 2 },
+    2_500,
+  );
+
+  assert.equal(healthy.state.monitoringComplete, true);
+  assert.equal(later.issueDetected, false);
+});
+
+test("does not confirm a freeze without future buffered data", () => {
+  let state = createVideoPlaybackHealthState();
+  state = observeVideoPlayback(state, { ...playingSample, nowMs: 0 }).state;
+  const result = observeVideoPlayback(state, {
+    ...playingSample,
+    nowMs: 10_000,
+    mediaTime: 10,
+    playing: true,
+    buffering: true,
+  });
+
+  assert.equal(result.issueDetected, false);
+  assert.equal(result.state.frozenSinceMs, null);
+});
+
+test("seeking and pausing reset the freeze window", () => {
+  let state = createVideoPlaybackHealthState();
+  state = observeVideoPlayback(state, { ...playingSample, nowMs: 0 }).state;
+  state = observeVideoPlayback(state, { ...playingSample, nowMs: 500, mediaTime: 0.5 }).state;
+  state = observeVideoPlayback(state, {
+    ...playingSample,
+    nowMs: 2_000,
+    mediaTime: 10,
+    seeking: true,
+  }).state;
+  const paused = observeVideoPlayback(state, {
+    ...playingSample,
+    nowMs: 5_000,
+    mediaTime: 10,
+    playing: false,
+  });
+
+  assert.equal(paused.issueDetected, false);
+  assert.equal(paused.state.frozenSinceMs, null);
+});
+
+test("hidden playback resets and gates the startup freeze window", () => {
+  let state = createVideoPlaybackHealthState();
+  state = observeVideoPlayback(state, { ...playingSample, nowMs: 0 }).state;
+  state = observeVideoPlayback(state, { ...playingSample, nowMs: 500, mediaTime: 0.5 }).state;
+  const hidden = observeVideoPlayback(state, {
+    ...playingSample,
+    nowMs: 10_000,
+    mediaTime: 10,
+    visible: false,
+  });
+  const visibleAgain = observeVideoPlayback(
+    hidden.state,
+    { ...playingSample, nowMs: 10_500, mediaTime: 10.5 },
+    2_500,
+  );
+
+  assert.equal(hidden.issueDetected, false);
+  assert.equal(hidden.state.frozenSinceMs, null);
+  assert.equal(visibleAgain.issueDetected, false);
+});
+
+test("reports at most once until a new source state is created", () => {
+  const reported = markVideoPlaybackIssueReported(createVideoPlaybackHealthState());
+  const reset = resetVideoPlaybackHealthWindow(reported, 1, 1);
+  const result = observeVideoPlayback(
+    { ...reset, frozenSinceMs: 0 },
+    { ...playingSample, nowMs: 10_000, mediaTime: 2 },
+    100,
+  );
+
+  assert.equal(result.issueDetected, false);
+  assert.equal(result.state.issueReported, true);
+  assert.equal(createVideoPlaybackHealthState().issueReported, false);
+});

--- a/src/lib/videoPlaybackHealth.ts
+++ b/src/lib/videoPlaybackHealth.ts
@@ -1,0 +1,122 @@
+export const VIDEO_FREEZE_GRACE_MS = 8_000;
+
+export type VideoPlaybackHealthState = {
+  lastMediaTime: number | null;
+  lastPresentedFrames: number | null;
+  frozenSinceMs: number | null;
+  issueReported: boolean;
+  hasSeenPresentedFrame: boolean;
+  monitoringComplete: boolean;
+};
+
+export type VideoPlaybackObservation = {
+  nowMs: number;
+  mediaTime: number;
+  presentedFrames: number;
+  playing: boolean;
+  seeking: boolean;
+  buffering: boolean;
+  visible: boolean;
+};
+
+export function createVideoPlaybackHealthState(): VideoPlaybackHealthState {
+  return {
+    lastMediaTime: null,
+    lastPresentedFrames: null,
+    frozenSinceMs: null,
+    issueReported: false,
+    hasSeenPresentedFrame: false,
+    monitoringComplete: false,
+  };
+}
+
+export function resetVideoPlaybackHealthWindow(
+  state: VideoPlaybackHealthState,
+  mediaTime: number | null = null,
+  presentedFrames: number | null = null,
+) {
+  return {
+    lastMediaTime: mediaTime,
+    lastPresentedFrames: presentedFrames,
+    frozenSinceMs: null,
+    issueReported: state.issueReported,
+    hasSeenPresentedFrame: state.hasSeenPresentedFrame,
+    monitoringComplete: state.monitoringComplete,
+  };
+}
+
+export function markVideoPlaybackIssueReported(state: VideoPlaybackHealthState) {
+  return {
+    ...state,
+    frozenSinceMs: null,
+    issueReported: true,
+  };
+}
+
+export function observeVideoPlayback(
+  state: VideoPlaybackHealthState,
+  observation: VideoPlaybackObservation,
+  freezeGraceMs = VIDEO_FREEZE_GRACE_MS,
+) {
+  const baseline = {
+    lastMediaTime: observation.mediaTime,
+    lastPresentedFrames: observation.presentedFrames,
+  };
+
+  if (
+    state.monitoringComplete ||
+    !observation.visible ||
+    !observation.playing ||
+    observation.seeking ||
+    observation.buffering
+  ) {
+    return {
+      state: {
+        ...state,
+        ...baseline,
+        frozenSinceMs: null,
+      },
+      issueDetected: false,
+    };
+  }
+
+  if (state.lastMediaTime === null || state.lastPresentedFrames === null) {
+    return {
+      state: {
+        ...state,
+        ...baseline,
+        hasSeenPresentedFrame: state.hasSeenPresentedFrame || observation.presentedFrames > 0,
+        monitoringComplete: state.monitoringComplete || observation.presentedFrames > 1,
+      },
+      issueDetected: false,
+    };
+  }
+
+  const mediaAdvanced = observation.mediaTime > state.lastMediaTime + 0.01;
+  const framesAdvanced = observation.presentedFrames > state.lastPresentedFrames;
+  const presentedFrameDelta = observation.presentedFrames - state.lastPresentedFrames;
+  const monitoringComplete =
+    framesAdvanced && mediaAdvanced && (state.hasSeenPresentedFrame || presentedFrameDelta > 1);
+  const hasSeenPresentedFrame =
+    state.hasSeenPresentedFrame || observation.presentedFrames > state.lastPresentedFrames;
+  const frozenSinceMs =
+    monitoringComplete || framesAdvanced || !mediaAdvanced
+      ? null
+      : (state.frozenSinceMs ?? observation.nowMs);
+  const issueDetected =
+    !state.issueReported &&
+    frozenSinceMs !== null &&
+    observation.nowMs - frozenSinceMs >= freezeGraceMs;
+
+  return {
+    state: {
+      ...state,
+      ...baseline,
+      frozenSinceMs: issueDetected ? null : frozenSinceMs,
+      issueReported: state.issueReported || issueDetected,
+      hasSeenPresentedFrame,
+      monitoringComplete,
+    },
+    issueDetected,
+  };
+}


### PR DESCRIPTION
## Summary

- detect startup-only Original playback stalls where media time advances without presented video frames
- preserve playback time and play intent while falling back to the existing 720p Mux stream
- retry failed 720p session requests with a visible manual recovery path and accessible status messaging
- show signed-out homepage visitors only a bordered Log in CTA while preserving the signed-in Start action

## Validation

- `bun run check`
  - Prettier
  - TypeScript
  - Convex typecheck
  - ESLint
  - 42 unit tests
  - 35 Convex tests
- `git diff --check`

## Review

- independent correctness review: no actionable findings after fixes
- independent design/UX review: no actionable findings after fixes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make original video playback recover reliably by switching to 720p on freeze or error
> - When original video playback freezes or hits a media error, `VideoPlayer` detects the issue via a new `videoPlaybackHealth` state machine and fires an `onPlaybackIssue` callback.
> - `VideoPage` handles the callback by recording the current time and play state, switching `sourcePreference` to `mux720`, and retrying the new source up to 3 times with incremental backoff.
> - A status banner shows whether the switch is in progress, preparing, or needs a manual retry; playback resumes at the original position once the new source is ready.
> - The home nav is simplified to a single button: 'Log in' for signed-out users or 'Start' for signed-in users, with an invisible placeholder to prevent layout shift while auth loads.
> - Risk: `VideoPlayer` now remounts on each `resolvedVideoId` change (via `key` prop), which resets all player state including volume and playback position for new videos.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf041bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic recovery mechanism for video playback failures with 720p stream fallback
  * Real-time detection of video playback issues including frozen frames and media errors

* **Bug Fixes**
  * Improved UI stability and layout consistency during authentication state changes
  * Enhanced video quality fallback handling

* **Tests**
  * Added comprehensive test suite for video playback health monitoring

<!-- end of auto-generated comment: release notes by coderabbit.ai -->