### PR TITLE
Default dashboard video playback to 720p

### DIFF
--- a/app/routes/dashboard/-video.tsx
+++ b/app/routes/dashboard/-video.tsx
@@ -52,6 +52,10 @@ import { Id } from "@convex/_generated/dataModel";
 import { projectPath, teamHomePath, videoPath } from "@/lib/routes";
 import { findPreferredReplacementVideoId } from "@/lib/videoVersionDeletion";
 import { useRoutePrewarmIntent } from "@/lib/useRoutePrewarmIntent";
+import {
+  selectDashboardPlaybackUrl,
+  type DashboardPlaybackSource,
+} from "@/lib/dashboardPlaybackSource";
 import { prewarmProject } from "./-project.data";
 import { prewarmTeam } from "./-team.data";
 import { prewarmVideo, useVideoData } from "./-video.data";
@@ -325,7 +329,7 @@ export default function VideoPage() {
   } | null>(null);
   const [sourcePreference, setSourcePreference] = useState<{
     videoId: Id<"videos">;
-    source: "mux720" | "original";
+    source: DashboardPlaybackSource;
   } | null>(null);
   const [failedOriginalVideoId, setFailedOriginalVideoId] = useState<Id<"videos"> | null>(null);
   const [originalPlaybackIssue, setOriginalPlaybackIssue] = useState<{
@@ -347,14 +351,17 @@ export default function VideoPage() {
     playbackRequest?.videoId === resolvedVideoId ? playbackRequest.attempt : 0;
   const processingFailed = video?.status === "failed";
   const preferredSource =
-    sourcePreference?.videoId === resolvedVideoId ? sourcePreference.source : "original";
+    sourcePreference?.videoId === resolvedVideoId ? sourcePreference.source : "mux720";
   const originalPlaybackFailed = !processingFailed && failedOriginalVideoId === resolvedVideoId;
   const usableOriginalPlaybackUrl = originalPlaybackFailed ? null : originalPlaybackUrl;
   const activePlaybackUrl = processingFailed
     ? null
-    : preferredSource === "mux720"
-      ? (playbackUrl ?? usableOriginalPlaybackUrl)
-      : (usableOriginalPlaybackUrl ?? playbackUrl);
+    : selectDashboardPlaybackUrl({
+        preferredSource,
+        muxPlaybackReady: isPlayable,
+        muxUrl: playbackUrl,
+        originalUrl: usableOriginalPlaybackUrl,
+      });
   const activeQualityId =
     activePlaybackUrl && playbackUrl && activePlaybackUrl === playbackUrl ? "mux720" : "original";
   const isUsingOriginalFallback = Boolean(

--- a/src/lib/dashboardPlaybackSource.test.ts
+++ b/src/lib/dashboardPlaybackSource.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { selectDashboardPlaybackUrl } from "./dashboardPlaybackSource";
+
+test("waits for the 720p session when Mux playback is ready", () => {
+  assert.equal(
+    selectDashboardPlaybackUrl({
+      preferredSource: "mux720",
+      muxPlaybackReady: true,
+      muxUrl: null,
+      originalUrl: "https://storage.example/original.mov",
+    }),
+    null,
+  );
+});
+
+test("uses 720p by default once its session is available", () => {
+  assert.equal(
+    selectDashboardPlaybackUrl({
+      preferredSource: "mux720",
+      muxPlaybackReady: true,
+      muxUrl: "https://stream.example/video.m3u8",
+      originalUrl: "https://storage.example/original.mov",
+    }),
+    "https://stream.example/video.m3u8",
+  );
+});
+
+test("falls back to the original while Mux is still processing", () => {
+  assert.equal(
+    selectDashboardPlaybackUrl({
+      preferredSource: "mux720",
+      muxPlaybackReady: false,
+      muxUrl: null,
+      originalUrl: "https://storage.example/original.mov",
+    }),
+    "https://storage.example/original.mov",
+  );
+});
+
+test("honors an explicit Original selection", () => {
+  assert.equal(
+    selectDashboardPlaybackUrl({
+      preferredSource: "original",
+      muxPlaybackReady: true,
+      muxUrl: "https://stream.example/video.m3u8",
+      originalUrl: "https://storage.example/original.mov",
+    }),
+    "https://storage.example/original.mov",
+  );
+});

--- a/src/lib/dashboardPlaybackSource.ts
+++ b/src/lib/dashboardPlaybackSource.ts
@@ -1,0 +1,27 @@
+export type DashboardPlaybackSource = "mux720" | "original";
+
+export function selectDashboardPlaybackUrl({
+  preferredSource,
+  muxPlaybackReady,
+  muxUrl,
+  originalUrl,
+}: {
+  preferredSource: DashboardPlaybackSource;
+  muxPlaybackReady: boolean;
+  muxUrl: string | null;
+  originalUrl: string | null;
+}) {
+  if (preferredSource === "original") {
+    return originalUrl ?? muxUrl;
+  }
+
+  // Once Mux is ready, wait for its session instead of briefly starting the
+  // original and swapping sources when the session request completes.
+  if (muxPlaybackReady) {
+    return muxUrl;
+  }
+
+  // While Mux is still processing, the original remains the fastest available
+  // way into the video.
+  return originalUrl ?? muxUrl;
+}


### PR DESCRIPTION
## Summary

- default ready dashboard videos to the Mux 720p stream instead of the raw original
- wait for the 720p playback session rather than briefly starting Original and swapping sources
- preserve Original as an explicit choice and as a temporary fallback while Mux is still processing

## Root cause

The reported production source is a 4.5 GB, 74-second QuickTime with 3840x2160 Apple ProRes 422 10-bit video and 24-bit PCM audio at about 487 Mbps. That editing master is not a reliably supported browser playback codec and is far too heavy for robust direct web streaming. The Mux rendition is H.264 at 1280x720 and about 0.93 Mbps.

## Validation

- `bun run check`
  - Prettier
  - TypeScript
  - Convex typecheck
  - ESLint
  - 46 unit tests
  - 35 Convex tests
- verified the constrained Mux manifest exposes only 1280x720 H.264
- `git diff --check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default dashboard video playback to 720p via Mux instead of original source
> - Adds a `selectDashboardPlaybackUrl` utility in [`dashboardPlaybackSource.ts`](https://github.com/pingdotgg/lawn/pull/50/files#diff-09fefe0d4e1f71845666f33082e755b63c1efc5402ab4b694bc56abf1c645401) that selects a playback URL based on `preferredSource`, `muxPlaybackReady`, and URL availability.
> - Changes the default `sourcePreference` in the `VideoPage` component from `'original'` to `'mux720'`, so videos prefer Mux 720p when no explicit preference is set.
> - Behavioral Change: when Mux is ready but a session URL hasn't been obtained yet, the player receives `null` (waits for Mux) instead of falling back to the original URL. The original URL is only used while Mux is still processing.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2adfab9. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved video playback source selection with intelligent fallback logic that automatically chooses between available video formats and quality options based on readiness and user preferences

* **Tests**
  * Added comprehensive test coverage for video playback source selection, validating correct format selection across different video processing states, format availability conditions, and user preference scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->