### PR TITLE
Lower multipart upload threshold

### DIFF
--- a/convex/uploadLimits.ts
+++ b/convex/uploadLimits.ts
@@ -2,7 +2,7 @@ export const GIBIBYTE = 1024 ** 3;
 export const MEBIBYTE = 1024 ** 2;
 
 export const MAX_VIDEO_FILE_SIZE_BYTES = 50 * GIBIBYTE;
-export const SINGLE_PUT_MAX_BYTES = 5 * GIBIBYTE;
+export const SINGLE_PUT_MAX_BYTES = 256 * MEBIBYTE;
 export const MULTIPART_PART_SIZE_BYTES = 64 * MEBIBYTE;
 
 export const PRESIGN_SINGLE_PUT_EXPIRES_SEC = 3600;

--- a/convex/uploadLimits.ts
+++ b/convex/uploadLimits.ts
@@ -3,6 +3,7 @@ export const MEBIBYTE = 1024 ** 2;
 
 export const MAX_VIDEO_FILE_SIZE_BYTES = 50 * GIBIBYTE;
 export const SINGLE_PUT_MAX_BYTES = 256 * MEBIBYTE;
+export const LEGACY_SINGLE_PUT_MAX_BYTES = 5 * GIBIBYTE;
 export const MULTIPART_PART_SIZE_BYTES = 64 * MEBIBYTE;
 
 export const PRESIGN_SINGLE_PUT_EXPIRES_SEC = 3600;
@@ -22,6 +23,10 @@ export function computePartCount(fileSize: number, partSize = MULTIPART_PART_SIZ
 
 export function usesMultipartUpload(fileSize: number) {
   return fileSize > SINGLE_PUT_MAX_BYTES;
+}
+
+export function isAboveLegacySinglePutMaxBytes(fileSize: number) {
+  return fileSize > LEGACY_SINGLE_PUT_MAX_BYTES;
 }
 
 export function assertVideoFileSizeAllowed(fileSize: number) {

--- a/convex/videoActions.ts
+++ b/convex/videoActions.ts
@@ -38,6 +38,7 @@ import {
   STALE_UPLOAD_SWEEP_BATCH_SIZE,
   STALE_UPLOAD_THRESHOLD_MS,
   assertVideoFileSizeAllowed,
+  isAboveLegacySinglePutMaxBytes,
   usesMultipartUpload,
 } from "./uploadLimits";
 const ALLOWED_UPLOAD_CONTENT_TYPES = new Set([
@@ -426,6 +427,7 @@ export const initiateVideoUpload = action({
 
     if (usesMultipartUpload(args.fileSize)) {
       if (
+        isAboveLegacySinglePutMaxBytes(args.fileSize) &&
         (video.status === "uploading" || video.status === "failed") &&
         video.s3Key &&
         !video.s3MultipartUploadId &&

--- a/src/lib/uploadLimits.test.ts
+++ b/src/lib/uploadLimits.test.ts
@@ -1,7 +1,17 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { MAX_VIDEO_FILE_SIZE_BYTES, assertVideoFileSizeAllowed } from "@convex/uploadLimits";
-import { isFileTooLarge } from "@/lib/uploadLimits";
+import {
+  MAX_VIDEO_FILE_SIZE_BYTES,
+  MEBIBYTE as SERVER_MEBIBYTE,
+  SINGLE_PUT_MAX_BYTES as SERVER_SINGLE_PUT_MAX_BYTES,
+  assertVideoFileSizeAllowed,
+  usesMultipartUpload,
+} from "@convex/uploadLimits";
+import {
+  MEBIBYTE as CLIENT_MEBIBYTE,
+  SINGLE_PUT_MAX_BYTES as CLIENT_SINGLE_PUT_MAX_BYTES,
+  isFileTooLarge,
+} from "@/lib/uploadLimits";
 
 test("all teams can upload videos up to 50 GiB", () => {
   assert.equal(isFileTooLarge(MAX_VIDEO_FILE_SIZE_BYTES), false);
@@ -14,4 +24,14 @@ test("videos larger than 50 GiB are rejected", () => {
     () => assertVideoFileSizeAllowed(MAX_VIDEO_FILE_SIZE_BYTES + 1),
     /Maximum size is 50 GiB/,
   );
+});
+
+test("client and server switch to multipart above 256 MiB", () => {
+  const threshold = 256 * SERVER_MEBIBYTE;
+
+  assert.equal(CLIENT_MEBIBYTE, SERVER_MEBIBYTE);
+  assert.equal(CLIENT_SINGLE_PUT_MAX_BYTES, threshold);
+  assert.equal(SERVER_SINGLE_PUT_MAX_BYTES, threshold);
+  assert.equal(usesMultipartUpload(threshold), false);
+  assert.equal(usesMultipartUpload(threshold + 1), true);
 });

--- a/src/lib/uploadLimits.test.ts
+++ b/src/lib/uploadLimits.test.ts
@@ -1,10 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  GIBIBYTE as SERVER_GIBIBYTE,
+  LEGACY_SINGLE_PUT_MAX_BYTES,
   MAX_VIDEO_FILE_SIZE_BYTES,
   MEBIBYTE as SERVER_MEBIBYTE,
   SINGLE_PUT_MAX_BYTES as SERVER_SINGLE_PUT_MAX_BYTES,
   assertVideoFileSizeAllowed,
+  isAboveLegacySinglePutMaxBytes,
   usesMultipartUpload,
 } from "@convex/uploadLimits";
 import {
@@ -34,4 +37,13 @@ test("client and server switch to multipart above 256 MiB", () => {
   assert.equal(SERVER_SINGLE_PUT_MAX_BYTES, threshold);
   assert.equal(usesMultipartUpload(threshold), false);
   assert.equal(usesMultipartUpload(threshold + 1), true);
+});
+
+test("legacy already-uploaded compatibility only applies above the old 5 GiB ceiling", () => {
+  const oldThreshold = 5 * SERVER_GIBIBYTE;
+
+  assert.equal(LEGACY_SINGLE_PUT_MAX_BYTES, oldThreshold);
+  assert.equal(isAboveLegacySinglePutMaxBytes(SERVER_SINGLE_PUT_MAX_BYTES + 1), false);
+  assert.equal(isAboveLegacySinglePutMaxBytes(oldThreshold), false);
+  assert.equal(isAboveLegacySinglePutMaxBytes(oldThreshold + 1), true);
 });

--- a/src/lib/uploadLimits.ts
+++ b/src/lib/uploadLimits.ts
@@ -2,7 +2,7 @@ export const GIBIBYTE = 1024 ** 3;
 export const MEBIBYTE = 1024 ** 2;
 
 export const MAX_VIDEO_FILE_SIZE_BYTES = 50 * GIBIBYTE;
-export const SINGLE_PUT_MAX_BYTES = 5 * GIBIBYTE;
+export const SINGLE_PUT_MAX_BYTES = 256 * MEBIBYTE;
 export const MULTIPART_PART_SIZE_BYTES = 64 * MEBIBYTE;
 export const MULTIPART_UPLOAD_CONCURRENCY = 4;
 export const MAX_SIGN_PARTS_BATCH = 20;


### PR DESCRIPTION
## Summary
- route uploads above 256 MiB through the existing multipart upload path instead of single PUT
- keep max upload size, part size, and concurrency unchanged
- add coverage for client/server threshold parity and exact multipart boundary behavior

## Why
Multipart can improve throughput when one browser upload stream underuses the available uplink, and it improves reliability for editor-sized videos by retrying/resuming 64 MiB parts instead of restarting the whole object.

## Validation
- bun test src/lib/uploadLimits.test.ts
- bun run check
- git diff --check

## Reviews
- correctness review: no findings
- design review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the single-file upload threshold to 256 MiB, so larger files now switch to multipart upload sooner.
  * Aligned upload size behavior across the app to ensure the same cutoff is used consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Lower multipart upload threshold from 5 GiB to 256 MiB
> - Reduces `SINGLE_PUT_MAX_BYTES` from 5 GiB to 256 MiB in both [convex/uploadLimits.ts](https://github.com/pingdotgg/lawn/pull/52/files#diff-f0ea52a82866335b38d5c8d6be79585a5c90eb46e2129239402754739c838b56) and [src/lib/uploadLimits.ts](https://github.com/pingdotgg/lawn/pull/52/files#diff-e29ca7a3c206c0c2f92f7b9792a40a62d49357199da66a129e20448fbfa5d15a), so `usesMultipartUpload()` now returns true for files larger than 256 MiB.
> - Adds `LEGACY_SINGLE_PUT_MAX_BYTES` (5 GiB) and `isAboveLegacySinglePutMaxBytes()` to preserve the old threshold for cases where it is still needed.
> - Guards the single-PUT reconciliation path in `initiateVideoUpload` with `isAboveLegacySinglePutMaxBytes`, so that path is skipped for files between 256 MiB and 5 GiB that previously used single PUT.
> - Behavioral Change: files between 256 MiB and 5 GiB now use multipart upload instead of a single PUT request.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c740a8d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->