### PR TITLE
feat: collapsible discussion sidebar on video and watch pages

### DIFF
--- a/app/routes/-watch.tsx
+++ b/app/routes/-watch.tsx
@@ -19,8 +19,18 @@ import {
 import { CommentText } from "@/components/comments/CommentText";
 import { triggerDownload } from "@/lib/download";
 import { watchPath } from "@/lib/routes";
-import { formatDuration, formatTimestamp, formatRelativeTime } from "@/lib/utils";
-import { AlertCircle, Layers3, MessageSquare, Clock, Download, X } from "lucide-react";
+import { cn, formatDuration, formatTimestamp, formatRelativeTime } from "@/lib/utils";
+import {
+  AlertCircle,
+  Layers3,
+  MessageSquare,
+  Clock,
+  Download,
+  PanelRightClose,
+  PanelRightOpen,
+  X,
+} from "lucide-react";
+import { useSidebarCollapsed } from "@/lib/useSidebarCollapsed";
 import { useWatchData } from "./-watch.data";
 
 export default function WatchPage() {
@@ -47,6 +57,7 @@ export default function WatchPage() {
   const [isDownloading, setIsDownloading] = useState(false);
   const [downloadError, setDownloadError] = useState<string | null>(null);
   const [mobileCommentsOpen, setMobileCommentsOpen] = useState(false);
+  const [sidebarCollapsed, toggleSidebarCollapsed] = useSidebarCollapsed();
   const playerRef = useRef<VideoPlayerHandle | null>(null);
 
   useEffect(() => {
@@ -277,6 +288,19 @@ export default function WatchPage() {
               <span className="ml-1.5 text-xs">{comments.length}</span>
             )}
           </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="hidden h-8 lg:inline-flex"
+            onClick={toggleSidebarCollapsed}
+            aria-label={sidebarCollapsed ? "Show discussion sidebar" : "Hide discussion sidebar"}
+          >
+            {sidebarCollapsed ? (
+              <PanelRightOpen className="h-4 w-4" />
+            ) : (
+              <PanelRightClose className="h-4 w-4" />
+            )}
+          </Button>
         </div>
       </header>
 
@@ -319,7 +343,13 @@ export default function WatchPage() {
         </div>
 
         {/* Comments sidebar — desktop */}
-        <aside className="hidden w-80 flex-col border-l-2 border-[#1a1a1a] bg-[#f0f0e8] lg:flex xl:w-96">
+        <aside
+          className={cn(
+            "hidden w-80 flex-col border-l-2 border-[#1a1a1a] bg-[#f0f0e8] transition-[margin,transform] duration-300 lg:flex xl:w-96",
+            sidebarCollapsed && "pointer-events-none -mr-80 translate-x-full xl:-mr-96",
+          )}
+          aria-hidden={sidebarCollapsed}
+        >
           <div className="flex flex-shrink-0 items-center justify-between border-b border-[#1a1a1a]/10 px-5 py-4">
             <h2 className="flex items-center gap-2 text-sm font-semibold tracking-tight text-[#1a1a1a]">
               Discussion
@@ -369,7 +399,9 @@ export default function WatchPage() {
                                 type="button"
                                 className="font-mono text-xs text-[#2d5a2d] hover:text-[#1a1a1a]"
                                 onClick={() =>
-                                  playerRef.current?.seekTo(reply.timestampSeconds, { play: true })
+                                  playerRef.current?.seekTo(reply.timestampSeconds, {
+                                    play: true,
+                                  })
                                 }
                               >
                                 {formatTimestamp(reply.timestampSeconds)}

--- a/app/routes/-watch.tsx
+++ b/app/routes/-watch.tsx
@@ -294,11 +294,13 @@ export default function WatchPage() {
             className="hidden h-8 lg:inline-flex"
             onClick={toggleSidebarCollapsed}
             aria-label={sidebarCollapsed ? "Show discussion sidebar" : "Hide discussion sidebar"}
+            aria-controls="public-discussion-sidebar"
+            aria-expanded={!sidebarCollapsed}
           >
             {sidebarCollapsed ? (
-              <PanelRightOpen className="h-4 w-4" />
+              <PanelRightOpen className="h-4 w-4" aria-hidden="true" />
             ) : (
-              <PanelRightClose className="h-4 w-4" />
+              <PanelRightClose className="h-4 w-4" aria-hidden="true" />
             )}
           </Button>
         </div>
@@ -344,9 +346,10 @@ export default function WatchPage() {
 
         {/* Comments sidebar — desktop */}
         <aside
+          id="public-discussion-sidebar"
           className={cn(
-            "hidden w-80 flex-col border-l-2 border-[#1a1a1a] bg-[#f0f0e8] transition-[margin,transform] duration-300 lg:flex xl:w-96",
-            sidebarCollapsed && "pointer-events-none -mr-80 translate-x-full xl:-mr-96",
+            "hidden w-80 flex-col border-l-2 border-[#1a1a1a] bg-[#f0f0e8] transition-[margin] duration-300 motion-reduce:transition-none lg:flex xl:w-96",
+            sidebarCollapsed && "pointer-events-none -mr-80 xl:-mr-96",
           )}
           aria-hidden={sidebarCollapsed}
           inert={sidebarCollapsed}

--- a/app/routes/-watch.tsx
+++ b/app/routes/-watch.tsx
@@ -349,6 +349,7 @@ export default function WatchPage() {
             sidebarCollapsed && "pointer-events-none -mr-80 translate-x-full xl:-mr-96",
           )}
           aria-hidden={sidebarCollapsed}
+          inert={sidebarCollapsed}
         >
           <div className="flex flex-shrink-0 items-center justify-between border-b border-[#1a1a1a]/10 px-5 py-4">
             <h2 className="flex items-center gap-2 text-sm font-semibold tracking-tight text-[#1a1a1a]">

--- a/app/routes/dashboard/-video.tsx
+++ b/app/routes/dashboard/-video.tsx
@@ -21,6 +21,7 @@ import { cn, formatDuration } from "@/lib/utils";
 import { buildCommentsCsv, buildCommentsCsvFilename } from "@/lib/commentCsv";
 import { triggerTextDownload } from "@/lib/download";
 import { useVideoPresence } from "@/lib/useVideoPresence";
+import { useSidebarCollapsed } from "@/lib/useSidebarCollapsed";
 import { VideoWatchers } from "@/components/presence/VideoWatchers";
 import { DashboardHeader } from "@/components/DashboardHeader";
 import { UploadButton } from "@/components/upload/UploadButton";
@@ -33,6 +34,8 @@ import {
   MessageSquare,
   MoreVertical,
   Download,
+  PanelRightClose,
+  PanelRightOpen,
   Layers3,
   Upload,
   Trash2,
@@ -309,6 +312,7 @@ export default function VideoPage() {
   const [highlightedCommentId, setHighlightedCommentId] = useState<Id<"comments"> | undefined>();
   const [shareDialogOpen, setShareDialogOpen] = useState(false);
   const [mobileCommentsOpen, setMobileCommentsOpen] = useState(false);
+  const [sidebarCollapsed, toggleSidebarCollapsed] = useSidebarCollapsed();
   const [playbackSession, setPlaybackSession] = useState<{
     url: string;
     posterUrl: string;
@@ -987,6 +991,18 @@ export default function VideoPage() {
               )}
             </DropdownMenuContent>
           </DropdownMenu>
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={toggleSidebarCollapsed}
+            aria-label={sidebarCollapsed ? "Show discussion sidebar" : "Hide discussion sidebar"}
+          >
+            {sidebarCollapsed ? (
+              <PanelRightOpen className="h-4 w-4" />
+            ) : (
+              <PanelRightClose className="h-4 w-4" />
+            )}
+          </Button>
         </div>
 
         {/* Compact: workflow status + consolidated menu until large screens */}
@@ -1207,7 +1223,13 @@ export default function VideoPage() {
         </div>
 
         {/* Comments sidebar — desktop */}
-        <aside className="hidden w-80 flex-col border-l-2 border-[#1a1a1a] bg-[#f0f0e8] lg:flex xl:w-96">
+        <aside
+          className={cn(
+            "hidden w-80 flex-col border-l-2 border-[#1a1a1a] bg-[#f0f0e8] transition-[margin,transform] duration-300 lg:flex xl:w-96",
+            sidebarCollapsed && "pointer-events-none -mr-80 translate-x-full xl:-mr-96",
+          )}
+          aria-hidden={sidebarCollapsed}
+        >
           <div className="flex flex-shrink-0 items-center justify-between border-b border-[#1a1a1a]/10 px-5 py-4 dark:border-white/10">
             <h2 className="flex items-center gap-2 text-sm font-semibold tracking-tight text-[#1a1a1a] dark:text-[#f0f0e8]">
               Discussion

--- a/app/routes/dashboard/-video.tsx
+++ b/app/routes/dashboard/-video.tsx
@@ -1229,6 +1229,7 @@ export default function VideoPage() {
             sidebarCollapsed && "pointer-events-none -mr-80 translate-x-full xl:-mr-96",
           )}
           aria-hidden={sidebarCollapsed}
+          inert={sidebarCollapsed}
         >
           <div className="flex flex-shrink-0 items-center justify-between border-b border-[#1a1a1a]/10 px-5 py-4 dark:border-white/10">
             <h2 className="flex items-center gap-2 text-sm font-semibold tracking-tight text-[#1a1a1a] dark:text-[#f0f0e8]">

--- a/app/routes/dashboard/-video.tsx
+++ b/app/routes/dashboard/-video.tsx
@@ -996,11 +996,13 @@ export default function VideoPage() {
             size="icon"
             onClick={toggleSidebarCollapsed}
             aria-label={sidebarCollapsed ? "Show discussion sidebar" : "Hide discussion sidebar"}
+            aria-controls="dashboard-discussion-sidebar"
+            aria-expanded={!sidebarCollapsed}
           >
             {sidebarCollapsed ? (
-              <PanelRightOpen className="h-4 w-4" />
+              <PanelRightOpen className="h-4 w-4" aria-hidden="true" />
             ) : (
-              <PanelRightClose className="h-4 w-4" />
+              <PanelRightClose className="h-4 w-4" aria-hidden="true" />
             )}
           </Button>
         </div>
@@ -1224,9 +1226,10 @@ export default function VideoPage() {
 
         {/* Comments sidebar — desktop */}
         <aside
+          id="dashboard-discussion-sidebar"
           className={cn(
-            "hidden w-80 flex-col border-l-2 border-[#1a1a1a] bg-[#f0f0e8] transition-[margin,transform] duration-300 lg:flex xl:w-96",
-            sidebarCollapsed && "pointer-events-none -mr-80 translate-x-full xl:-mr-96",
+            "hidden w-80 flex-col border-l-2 border-[#1a1a1a] bg-[#f0f0e8] transition-[margin] duration-300 motion-reduce:transition-none lg:flex xl:w-96",
+            sidebarCollapsed && "pointer-events-none -mr-80 xl:-mr-96",
           )}
           aria-hidden={sidebarCollapsed}
           inert={sidebarCollapsed}

--- a/src/lib/useSidebarCollapsed.ts
+++ b/src/lib/useSidebarCollapsed.ts
@@ -1,29 +1,75 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 
 const STORAGE_KEY = "lawn:discussion-collapsed";
+const listeners = new Set<() => void>();
+
+let collapsed = false;
+let initialized = false;
+
+function initializeCollapsed() {
+  if (initialized || typeof window === "undefined") return;
+
+  initialized = true;
+  try {
+    collapsed = window.localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    // Keep using the in-memory value when storage is unavailable.
+  }
+}
+
+function getSnapshot() {
+  initializeCollapsed();
+  return collapsed;
+}
+
+function getServerSnapshot() {
+  return false;
+}
+
+function emitChange() {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function handleStorage(event: StorageEvent) {
+  if (event.key !== STORAGE_KEY && event.key !== null) return;
+
+  initialized = true;
+  collapsed = event.key === STORAGE_KEY && event.newValue === "1";
+  emitChange();
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  if (listeners.size === 1 && typeof window !== "undefined") {
+    window.addEventListener("storage", handleStorage);
+  }
+
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      initialized = false;
+      if (typeof window !== "undefined") {
+        window.removeEventListener("storage", handleStorage);
+      }
+    }
+  };
+}
 
 export function useSidebarCollapsed() {
-  const [collapsed, setCollapsed] = useState(false);
-
-  useEffect(() => {
-    try {
-      setCollapsed(window.localStorage.getItem(STORAGE_KEY) === "1");
-    } catch {
-      // ignore storage failures
-    }
-  }, []);
+  const sidebarCollapsed = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
   const toggle = useCallback(() => {
-    setCollapsed((prev) => {
-      const next = !prev;
-      try {
-        window.localStorage.setItem(STORAGE_KEY, next ? "1" : "0");
-      } catch {
-        // ignore storage failures
-      }
-      return next;
-    });
+    initializeCollapsed();
+    collapsed = !collapsed;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, collapsed ? "1" : "0");
+    } catch {
+      // The in-memory value remains usable when storage writes fail.
+    }
+    emitChange();
   }, []);
 
-  return [collapsed, toggle] as const;
+  return [sidebarCollapsed, toggle] as const;
 }

--- a/src/lib/useSidebarCollapsed.ts
+++ b/src/lib/useSidebarCollapsed.ts
@@ -1,0 +1,28 @@
+import { useCallback, useState } from "react";
+
+const STORAGE_KEY = "lawn:discussion-collapsed";
+
+export function useSidebarCollapsed() {
+  const [collapsed, setCollapsed] = useState(() => {
+    if (typeof window === "undefined") return false;
+    try {
+      return window.localStorage.getItem(STORAGE_KEY) === "1";
+    } catch {
+      return false;
+    }
+  });
+
+  const toggle = useCallback(() => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      try {
+        window.localStorage.setItem(STORAGE_KEY, next ? "1" : "0");
+      } catch {
+        // ignore storage failures
+      }
+      return next;
+    });
+  }, []);
+
+  return [collapsed, toggle] as const;
+}

--- a/src/lib/useSidebarCollapsed.ts
+++ b/src/lib/useSidebarCollapsed.ts
@@ -1,16 +1,17 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 const STORAGE_KEY = "lawn:discussion-collapsed";
 
 export function useSidebarCollapsed() {
-  const [collapsed, setCollapsed] = useState(() => {
-    if (typeof window === "undefined") return false;
+  const [collapsed, setCollapsed] = useState(false);
+
+  useEffect(() => {
     try {
-      return window.localStorage.getItem(STORAGE_KEY) === "1";
+      setCollapsed(window.localStorage.getItem(STORAGE_KEY) === "1");
     } catch {
-      return false;
+      // ignore storage failures
     }
-  });
+  }, []);
 
   const toggle = useCallback(() => {
     setCollapsed((prev) => {


### PR DESCRIPTION
## Summary
Adds a hide/show toggle for the discussion sidebar on both the dashboard video page and the public `/watch/<publicId>` viewer, so viewers can watch in a near-fullscreen width without entering fullscreen.

- Toggle button lives in the top bar (next to Download on `/watch`, in the desktop actions row on the dashboard video page), using `PanelRightClose`/`PanelRightOpen` icons.
- When hidden, the sidebar slides fully off to the right and disappears (`transition-[margin,transform]` + `-mr-80/-mr-96 translate-x-full`, `aria-hidden`, `pointer-events-none`); the video area expands edge-to-edge.
- State persists via a new `useSidebarCollapsed()` hook (`localStorage` key `lawn:discussion-collapsed`), shared by both pages.
- Desktop (`lg+`) only; the mobile comments overlay is unchanged.

Demo video (hide via top-bar icon → full-width video → show again → persists across reload): drag-and-drop the attached mp4 into this description on GitHub to embed it.


https://github.com/user-attachments/assets/f43568a3-683e-41a8-86d5-bd5644d314ad


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and client-side preference storage; no API, auth, or playback logic changes.
> 
> **Overview**
> Adds a **desktop-only** way to hide the discussion sidebar so the video can use nearly full width without fullscreen.
> 
> A new **`useSidebarCollapsed`** hook stores open/closed state in `localStorage` (`lawn:discussion-collapsed`) and is wired into both the public **watch** page and the dashboard **video** page. Each page gets a header toggle (`PanelRightOpen` / `PanelRightClose`) on `lg+`; mobile comments overlay behavior is unchanged.
> 
> When collapsed, the sidebar **slides off-screen** with a transition, the player area expands, and the panel is marked **`aria-hidden`** with **`inert`** and **`pointer-events-none`** so it is not focusable or interactive while hidden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 251e899d8f6aff30fc13f96b6c15941409d68642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add collapsible discussion sidebar to video and watch pages
> - Adds a toggle button to the header/toolbar on the watch page ([`-watch.tsx`](https://github.com/pingdotgg/lawn/pull/53/files#diff-2b2efe3a498fab946d47a922e4452d5ad03e3d9694febd564713cb76bfe0d056)) and dashboard video page ([`-video.tsx`](https://github.com/pingdotgg/lawn/pull/53/files#diff-833e2f5b1e2fafc1cc96eaad146f828e4462dfc59201a1f837cf780c7d11a442)) to collapse or expand the discussion sidebar on large screens.
> - When collapsed, the sidebar is moved off-screen and made non-interactive via `pointer-events-none`, `inert`, and `aria-hidden`.
> - Introduces [`useSidebarCollapsed`](https://github.com/pingdotgg/lawn/pull/53/files#diff-b9a83d1eaf4fc9fe998935f120b332eb26ce8328d645286fadaa59a3e4544178), a reusable hook that persists the collapsed state to `localStorage` under the key `lawn:discussion-collapsed`.
> - Behavioral Change: on first load, the sidebar state is read from `localStorage`, so users who previously had no stored value will default to expanded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 251e899.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a desktop header toggle to collapse/expand the discussion/comments sidebar on Watch and Dashboard video pages.
  * The collapsed layout preference now persists across visits and stays in sync across tabs.
* **Bug Fixes**
  * Improved accessibility and interaction handling when the sidebar is collapsed, including off-canvas behavior and updates to `aria-label`, `aria-hidden`, and `inert`.
  * Refined the “seek to timestamp” reply action formatting without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->