### PR TITLE
Fix sign-up footer colors on auth pages

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -590,6 +590,41 @@ body {
 [class~="hover:text-[#2d5a2d]"]:hover {
   color: var(--accent) !important;
 }
+
+/* Auth pages always use the light cream palette */
+.auth-shell {
+  --background: #f0f0e8;
+  --foreground: #1a1a1a;
+  --foreground-muted: #888888;
+  --foreground-inverse: #f0f0e8;
+  --border: #1a1a1a;
+  --border-subtle: #cccccc;
+  --shadow-color: #1a1a1a;
+  --shadow-accent: rgba(45, 90, 45, 1);
+  --accent: #2d5a2d;
+  --accent-hover: #3a6a3a;
+  --accent-light: #7cb87c;
+  color-scheme: light;
+}
+
+.cl-footer {
+  display: none !important;
+}
+
+.auth-footer-text {
+  color: #888888;
+}
+
+.auth-footer-link {
+  color: #1a1a1a;
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.auth-footer-link:hover {
+  color: #2d5a2d;
+}
 [class~="group-hover:text-[#1a1a1a]"] {
   transition: color 150ms ease;
 }

--- a/app/app.css
+++ b/app/app.css
@@ -607,7 +607,7 @@ body {
   color-scheme: light;
 }
 
-.cl-footer {
+.auth-shell .cl-footer {
   display: none !important;
 }
 

--- a/app/routes/auth/-layout.tsx
+++ b/app/routes/auth/-layout.tsx
@@ -1,9 +1,28 @@
-import { Link } from "@tanstack/react-router";
+import { Link, useRouterState } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 
+function alternateAuthHref(pathname: "/sign-in" | "/sign-up", search: string) {
+  const redirectUrl = new URLSearchParams(search).get("redirect_url");
+  if (!redirectUrl) {
+    return pathname;
+  }
+  return `${pathname}?redirect_url=${encodeURIComponent(redirectUrl)}`;
+}
+
 export function AuthShell({ children }: { children: ReactNode }) {
+  const { pathname, searchStr } = useRouterState({
+    select: (state) => ({
+      pathname: state.location.pathname,
+      searchStr: state.location.searchStr,
+    }),
+  });
+  const isSignUp = pathname.startsWith("/sign-up");
+
   return (
-    <div className="relative flex min-h-screen items-center justify-center bg-[#f0f0e8]">
+    <div
+      data-theme="light"
+      className="auth-shell relative flex min-h-screen flex-col items-center justify-center bg-[#f0f0e8]"
+    >
       {/* Subtle grid pattern */}
       <div
         className="pointer-events-none absolute inset-0 opacity-[0.03]"
@@ -24,6 +43,23 @@ export function AuthShell({ children }: { children: ReactNode }) {
           <p className="mt-3 text-sm text-[#888]">Video collaboration, simplified</p>
         </div>
         {children}
+        <p className="auth-footer mt-6 text-center text-sm">
+          {isSignUp ? (
+            <>
+              <span className="auth-footer-text">Already have an account?</span>{" "}
+              <Link to={alternateAuthHref("/sign-in", searchStr)} className="auth-footer-link">
+                Sign in
+              </Link>
+            </>
+          ) : (
+            <>
+              <span className="auth-footer-text">Don&apos;t have an account?</span>{" "}
+              <Link to={alternateAuthHref("/sign-up", searchStr)} className="auth-footer-link">
+                Sign up
+              </Link>
+            </>
+          )}
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Hides Clerk's built-in auth footer (its internal styles were overriding `hidden`, leaving a mis-colored "Already have an account?" block)
- Adds a custom footer in `AuthShell` with the correct cream-palette colors and in-app links to `/sign-in` / `/sign-up`
- Pins the light theme on auth pages so dark-mode CSS variable remapping no longer distorts footer and form text

## Test plan

- [x] Visit `/sign-up` in light and dark mode — footer should show muted gray text with a near-black underlined "Sign in" link
- [x] Visit `/sign-in` — footer should show "Don't have an account? Sign up"
- [x] Confirm Clerk's duplicate footer is not visible
- [x] Confirm `redirect_url` is preserved when switching between sign-in and sign-up

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only auth layout and CSS; no changes to authentication logic or APIs.
> 
> **Overview**
> Fixes mis-colored auth footers in dark mode by **pinning the light cream palette** on auth routes: `AuthShell` now sets `data-theme="light"` and the `auth-shell` class, and **app.css** overrides theme CSS variables inside `.auth-shell` so global dark-mode remapping no longer distorts Clerk and footer text.
> 
> **Replaces Clerk’s footer** with an in-app footer: `.auth-shell .cl-footer` is hidden, and `AuthShell` renders contextual “Already have an account? / Don’t have an account?” links styled via `.auth-footer-text` and `.auth-footer-link`. **`alternateAuthHref`** keeps `redirect_url` when switching between `/sign-in` and `/sign-up`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dbbbf00bb897d01483aa815e58d2d2a0c6dbb4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sign-up footer colors and add contextual sign-in/sign-up links on auth pages
> - Adds an `.auth-shell` CSS scope in [app.css](https://github.com/pingdotgg/lawn/pull/55/files#diff-0c4ab16f2f7c1e3f4b5d0a6d4c1d939044081653e1e1e56c560170b0af384730) that applies a light cream color palette via CSS custom properties and hides Clerk's `.cl-footer` element
> - Adds `.auth-footer-text` and `.auth-footer-link` styles with underline, bold, and hover color for the custom auth footer
> - Updates [AuthShell](https://github.com/pingdotgg/lawn/pull/55/files#diff-a2c6d49ce26a60713bf5bc9879cd5e5e4d6a67615af5271da212642728f75f2e) to render a footer with a contextual "Sign in" or "Sign up" link based on the current path, preserving any `redirect_url` query parameter
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2dbbbf0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a consistent light theme styling for authentication pages.
  * Added contextual sign-in/sign-up navigation with automatic switching between the two flows.
  * Preserved `redirect_url` when moving between sign-in and sign-up.

* **Style**
  * Refined authentication footer text and link styling, including hover states.
  * Hid the default authentication footer for a cleaner authentication layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->