### PR TITLE
feat: allow guest comments on review links

### DIFF
--- a/app/routes/-share.tsx
+++ b/app/routes/-share.tsx
@@ -13,6 +13,7 @@ import { formatDuration, formatTimestamp, formatRelativeTime } from "@/lib/utils
 import { useVideoPresence } from "@/lib/useVideoPresence";
 import { VideoWatchers } from "@/components/presence/VideoWatchers";
 import { CommentText } from "@/components/comments/CommentText";
+import { MAX_GUEST_NAME_LENGTH, readStoredGuestName, writeStoredGuestName } from "@/lib/guestName";
 import { Lock, Video, AlertCircle, MessageSquare, Clock, Download } from "lucide-react";
 import { useShareData } from "./-share.data";
 
@@ -39,11 +40,16 @@ export default function SharePage() {
   const [playbackError, setPlaybackError] = useState<string | null>(null);
   const [currentTime, setCurrentTime] = useState(0);
   const [commentText, setCommentText] = useState("");
+  const [guestName, setGuestName] = useState("");
   const [isSubmittingComment, setIsSubmittingComment] = useState(false);
   const [commentError, setCommentError] = useState<string | null>(null);
   const [isDownloading, setIsDownloading] = useState(false);
   const [downloadError, setDownloadError] = useState<string | null>(null);
   const playerRef = useRef<VideoPlayerHandle | null>(null);
+
+  useEffect(() => {
+    setGuestName(readStoredGuestName());
+  }, []);
 
   useEffect(() => {
     setIsDownloading(false);
@@ -147,17 +153,32 @@ export default function SharePage() {
     return markers;
   }, [comments]);
 
+  const isSignedIn = Boolean(user);
+  const allowGuestComments = videoData?.allowGuestComments === true;
+  const canComment = isSignedIn || allowGuestComments;
+  const guestNameReady = guestName.trim().length > 0;
+  const canSubmitComment =
+    Boolean(grantToken) &&
+    Boolean(commentText.trim()) &&
+    !isSubmittingComment &&
+    (isSignedIn || guestNameReady);
+
   const handleSubmitComment = async (event: React.FormEvent) => {
     event.preventDefault();
-    if (!grantToken || !commentText.trim() || isSubmittingComment) return;
+    if (!grantToken || !canSubmitComment) return;
 
     setIsSubmittingComment(true);
     setCommentError(null);
     try {
+      const trimmedGuestName = guestName.trim();
+      if (!isSignedIn) {
+        writeStoredGuestName(trimmedGuestName);
+      }
       await createComment({
         grantToken,
         text: commentText.trim(),
         timestampSeconds: currentTime,
+        guestName: isSignedIn ? undefined : trimmedGuestName,
       });
       setCommentText("");
     } catch {
@@ -365,12 +386,24 @@ export default function SharePage() {
             <span className="font-mono text-xs text-[#888]">{formatTimestamp(currentTime)}</span>
           </div>
 
-          {isUserLoaded && user ? (
+          {!isUserLoaded ? null : canComment ? (
             <form onSubmit={handleSubmitComment} className="space-y-2">
               <div className="flex items-center gap-2 text-xs text-[#666]">
                 <Clock className="h-3.5 w-3.5" />
                 Comment at {formatTimestamp(currentTime)}
               </div>
+              {!isSignedIn ? (
+                <Input
+                  value={guestName}
+                  onChange={(event) =>
+                    setGuestName(event.target.value.slice(0, MAX_GUEST_NAME_LENGTH))
+                  }
+                  placeholder="Your name"
+                  maxLength={MAX_GUEST_NAME_LENGTH}
+                  autoComplete="nickname"
+                  aria-label="Your name"
+                />
+              ) : null}
               <Textarea
                 value={commentText}
                 onChange={(event) => setCommentText(event.target.value)}
@@ -378,7 +411,7 @@ export default function SharePage() {
                 className="min-h-[90px]"
               />
               {commentError ? <p className="text-xs text-[#dc2626]">{commentError}</p> : null}
-              <Button type="submit" disabled={!commentText.trim() || isSubmittingComment}>
+              <Button type="submit" disabled={!canSubmitComment}>
                 <MessageSquare className="mr-1.5 h-4 w-4" />
                 {isSubmittingComment ? "Posting..." : "Post comment"}
               </Button>

--- a/app/routes/-watch.tsx
+++ b/app/routes/-watch.tsx
@@ -17,7 +17,9 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { CommentText } from "@/components/comments/CommentText";
+import { Input } from "@/components/ui/input";
 import { triggerDownload } from "@/lib/download";
+import { MAX_GUEST_NAME_LENGTH, readStoredGuestName, writeStoredGuestName } from "@/lib/guestName";
 import { watchPath } from "@/lib/routes";
 import { cn, formatDuration, formatTimestamp, formatRelativeTime } from "@/lib/utils";
 import {
@@ -52,6 +54,7 @@ export default function WatchPage() {
   const [playbackError, setPlaybackError] = useState<string | null>(null);
   const [currentTime, setCurrentTime] = useState(0);
   const [commentText, setCommentText] = useState("");
+  const [guestName, setGuestName] = useState("");
   const [isSubmittingComment, setIsSubmittingComment] = useState(false);
   const [commentError, setCommentError] = useState<string | null>(null);
   const [isDownloading, setIsDownloading] = useState(false);
@@ -59,6 +62,10 @@ export default function WatchPage() {
   const [mobileCommentsOpen, setMobileCommentsOpen] = useState(false);
   const [sidebarCollapsed, toggleSidebarCollapsed] = useSidebarCollapsed();
   const playerRef = useRef<VideoPlayerHandle | null>(null);
+
+  useEffect(() => {
+    setGuestName(readStoredGuestName());
+  }, []);
 
   useEffect(() => {
     if (!videoData?.video?.muxPlaybackId) {
@@ -115,17 +122,31 @@ export default function WatchPage() {
     return markers;
   }, [comments]);
 
+  const isSignedIn = Boolean(user);
+  const allowGuestComments = videoData?.allowGuestComments === true;
+  const canComment = isSignedIn || allowGuestComments;
+  const guestNameReady = guestName.trim().length > 0;
+  const canSubmitComment =
+    Boolean(commentText.trim()) &&
+    !isSubmittingComment &&
+    (isSignedIn || guestNameReady);
+
   const handleSubmitComment = async (event: React.FormEvent) => {
     event.preventDefault();
-    if (!commentText.trim() || isSubmittingComment) return;
+    if (!canSubmitComment) return;
 
     setIsSubmittingComment(true);
     setCommentError(null);
     try {
+      const trimmedGuestName = guestName.trim();
+      if (!isSignedIn) {
+        writeStoredGuestName(trimmedGuestName);
+      }
       await createComment({
         publicId,
         text: commentText.trim(),
         timestampSeconds: currentTime,
+        guestName: isSignedIn ? undefined : trimmedGuestName,
       });
       setCommentText("");
     } catch {
@@ -134,6 +155,49 @@ export default function WatchPage() {
       setIsSubmittingComment(false);
     }
   };
+
+  const commentForm = (
+    <form onSubmit={handleSubmitComment} className="space-y-2">
+      <div className="flex items-center gap-2 text-xs text-[#666]">
+        <Clock className="h-3.5 w-3.5" />
+        Comment at {formatTimestamp(currentTime)}
+      </div>
+      {!isSignedIn ? (
+        <Input
+          value={guestName}
+          onChange={(event) => setGuestName(event.target.value.slice(0, MAX_GUEST_NAME_LENGTH))}
+          placeholder="Your name"
+          maxLength={MAX_GUEST_NAME_LENGTH}
+          autoComplete="nickname"
+          aria-label="Your name"
+          className="text-sm"
+        />
+      ) : null}
+      <Textarea
+        value={commentText}
+        onChange={(event) => setCommentText(event.target.value)}
+        placeholder="Leave a comment..."
+        className="min-h-[90px] text-sm"
+      />
+      {commentError ? <p className="text-xs text-[#dc2626]">{commentError}</p> : null}
+      <Button type="submit" size="sm" disabled={!canSubmitComment} className="w-full">
+        <MessageSquare className="mr-1.5 h-4 w-4" />
+        {isSubmittingComment ? "Posting..." : "Post comment"}
+      </Button>
+    </form>
+  );
+
+  const signInToComment = (
+    <a
+      href={`/sign-in?redirect_url=${encodeURIComponent(`/watch/${publicId}`)}`}
+      className="block"
+    >
+      <Button className="w-full">
+        <MessageSquare className="mr-1.5 h-4 w-4" />
+        Sign in to comment
+      </Button>
+    </a>
+  );
 
   const handleDownload = useCallback(async () => {
     if (isDownloading) return;
@@ -425,40 +489,7 @@ export default function WatchPage() {
           </div>
 
           <div className="flex-shrink-0 border-t-2 border-[#1a1a1a] bg-[#f0f0e8] p-4">
-            {isUserLoaded && user ? (
-              <form onSubmit={handleSubmitComment} className="space-y-2">
-                <div className="flex items-center gap-2 text-xs text-[#666]">
-                  <Clock className="h-3.5 w-3.5" />
-                  Comment at {formatTimestamp(currentTime)}
-                </div>
-                <Textarea
-                  value={commentText}
-                  onChange={(event) => setCommentText(event.target.value)}
-                  placeholder="Leave a comment..."
-                  className="min-h-[90px] text-sm"
-                />
-                {commentError ? <p className="text-xs text-[#dc2626]">{commentError}</p> : null}
-                <Button
-                  type="submit"
-                  size="sm"
-                  disabled={!commentText.trim() || isSubmittingComment}
-                  className="w-full"
-                >
-                  <MessageSquare className="mr-1.5 h-4 w-4" />
-                  {isSubmittingComment ? "Posting..." : "Post comment"}
-                </Button>
-              </form>
-            ) : (
-              <a
-                href={`/sign-in?redirect_url=${encodeURIComponent(`/watch/${publicId}`)}`}
-                className="block"
-              >
-                <Button className="w-full">
-                  <MessageSquare className="mr-1.5 h-4 w-4" />
-                  Sign in to comment
-                </Button>
-              </a>
-            )}
+            {!isUserLoaded ? null : canComment ? commentForm : signInToComment}
           </div>
         </aside>
       </div>
@@ -545,40 +576,7 @@ export default function WatchPage() {
           </div>
 
           <div className="pb-safe flex-shrink-0 border-t-2 border-[#1a1a1a] bg-[#f0f0e8] p-4">
-            {isUserLoaded && user ? (
-              <form onSubmit={handleSubmitComment} className="space-y-2">
-                <div className="flex items-center gap-2 text-xs text-[#666]">
-                  <Clock className="h-3.5 w-3.5" />
-                  Comment at {formatTimestamp(currentTime)}
-                </div>
-                <Textarea
-                  value={commentText}
-                  onChange={(event) => setCommentText(event.target.value)}
-                  placeholder="Leave a comment..."
-                  className="min-h-[90px] text-sm"
-                />
-                {commentError ? <p className="text-xs text-[#dc2626]">{commentError}</p> : null}
-                <Button
-                  type="submit"
-                  size="sm"
-                  disabled={!commentText.trim() || isSubmittingComment}
-                  className="w-full"
-                >
-                  <MessageSquare className="mr-1.5 h-4 w-4" />
-                  {isSubmittingComment ? "Posting..." : "Post comment"}
-                </Button>
-              </form>
-            ) : (
-              <a
-                href={`/sign-in?redirect_url=${encodeURIComponent(`/watch/${publicId}`)}`}
-                className="block"
-              >
-                <Button className="w-full">
-                  <MessageSquare className="mr-1.5 h-4 w-4" />
-                  Sign in to comment
-                </Button>
-              </a>
-            )}
+            {!isUserLoaded ? null : canComment ? commentForm : signInToComment}
           </div>
         </div>
       )}

--- a/convex/comments.ts
+++ b/convex/comments.ts
@@ -1,8 +1,27 @@
+import { MINUTE, RateLimiter } from "@convex-dev/rate-limiter";
 import { v } from "convex/values";
+import { components } from "./_generated/api";
 import { mutation, query, MutationCtx, QueryCtx } from "./_generated/server";
-import { identityAvatarUrl, identityName, requireVideoAccess, requireUser } from "./auth";
+import { getUser, identityAvatarUrl, identityName, requireVideoAccess, requireUser } from "./auth";
 import { resolveActiveShareGrant } from "./shareAccess";
-import { resolvePublicVideo } from "./videos";
+import { guestCommentsEnabled, resolvePublicVideo } from "./videos";
+
+const MAX_COMMENT_TEXT_LENGTH = 5000;
+const MAX_GUEST_NAME_LENGTH = 40;
+
+const guestCommentRateLimiter = new RateLimiter(components.rateLimiter, {
+  guestCommentGlobal: {
+    kind: "fixed window",
+    rate: 300,
+    period: MINUTE,
+    shards: 8,
+  },
+  guestCommentByVideo: {
+    kind: "fixed window",
+    rate: 30,
+    period: MINUTE,
+  },
+});
 
 function toThreadedComments<
   T extends { _id: string; parentId?: string; timestampSeconds: number; _creationTime: number },
@@ -47,6 +66,42 @@ async function getPublicVideoByPublicId(ctx: QueryCtx | MutationCtx, publicId: s
   return await resolvePublicVideo(ctx, publicId);
 }
 
+function normalizeCommentText(text: string) {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    throw new Error("Comment cannot be empty");
+  }
+  if (trimmed.length > MAX_COMMENT_TEXT_LENGTH) {
+    throw new Error("Comment is too long");
+  }
+  return trimmed;
+}
+
+function normalizeGuestName(guestName: string | undefined) {
+  const trimmed = guestName?.trim() ?? "";
+  if (!trimmed) {
+    throw new Error("Guest name is required");
+  }
+  if (trimmed.length > MAX_GUEST_NAME_LENGTH) {
+    throw new Error("Guest name is too long");
+  }
+  return trimmed;
+}
+
+async function assertGuestCommentRateLimit(ctx: MutationCtx, videoId: string) {
+  const globalLimit = await guestCommentRateLimiter.limit(ctx, "guestCommentGlobal");
+  if (!globalLimit.ok) {
+    throw new Error("Too many comments. Please try again shortly.");
+  }
+
+  const videoLimit = await guestCommentRateLimiter.limit(ctx, "guestCommentByVideo", {
+    key: videoId,
+  });
+  if (!videoLimit.ok) {
+    throw new Error("Too many comments on this video. Please try again shortly.");
+  }
+}
+
 export const list = query({
   args: { videoId: v.id("videos") },
   handler: async (ctx, args) => {
@@ -70,6 +125,7 @@ export const create = mutation({
   },
   handler: async (ctx, args) => {
     const { user } = await requireVideoAccess(ctx, args.videoId, "viewer");
+    const text = normalizeCommentText(args.text);
 
     if (args.parentId) {
       const parent = await ctx.db.get(args.parentId);
@@ -83,7 +139,7 @@ export const create = mutation({
       userClerkId: user.subject,
       userName: identityName(user),
       userAvatarUrl: identityAvatarUrl(user),
-      text: args.text,
+      text,
       timestampSeconds: args.timestampSeconds,
       parentId: args.parentId,
       resolved: false,
@@ -97,15 +153,15 @@ export const createForPublic = mutation({
     text: v.string(),
     timestampSeconds: v.number(),
     parentId: v.optional(v.id("comments")),
+    guestName: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const user = await requireUser(ctx);
     const video = await getPublicVideoByPublicId(ctx, args.publicId);
-
     if (!video) {
       throw new Error("Video not found");
     }
 
+    const text = normalizeCommentText(args.text);
     if (args.parentId) {
       const parent = await ctx.db.get(args.parentId);
       if (!parent || parent.videoId !== video._id) {
@@ -113,12 +169,31 @@ export const createForPublic = mutation({
       }
     }
 
+    const user = await getUser(ctx);
+    if (user) {
+      return await ctx.db.insert("comments", {
+        videoId: video._id,
+        userClerkId: user.subject,
+        userName: identityName(user),
+        userAvatarUrl: identityAvatarUrl(user),
+        text,
+        timestampSeconds: args.timestampSeconds,
+        parentId: args.parentId,
+        resolved: false,
+      });
+    }
+
+    if (!guestCommentsEnabled(video)) {
+      throw new Error("Guest comments are not allowed on this video");
+    }
+
+    const guestName = normalizeGuestName(args.guestName);
+    await assertGuestCommentRateLimit(ctx, video._id);
+
     return await ctx.db.insert("comments", {
       videoId: video._id,
-      userClerkId: user.subject,
-      userName: identityName(user),
-      userAvatarUrl: identityAvatarUrl(user),
-      text: args.text,
+      userName: guestName,
+      text,
       timestampSeconds: args.timestampSeconds,
       parentId: args.parentId,
       resolved: false,
@@ -132,11 +207,10 @@ export const createForShareGrant = mutation({
     text: v.string(),
     timestampSeconds: v.number(),
     parentId: v.optional(v.id("comments")),
+    guestName: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const user = await requireUser(ctx);
     const resolved = await resolveActiveShareGrant(ctx, args.grantToken);
-
     if (!resolved) {
       throw new Error("Invalid share grant");
     }
@@ -146,6 +220,7 @@ export const createForShareGrant = mutation({
       throw new Error("Video not found");
     }
 
+    const text = normalizeCommentText(args.text);
     if (args.parentId) {
       const parent = await ctx.db.get(args.parentId);
       if (!parent || parent.videoId !== video._id) {
@@ -153,12 +228,31 @@ export const createForShareGrant = mutation({
       }
     }
 
+    const user = await getUser(ctx);
+    if (user) {
+      return await ctx.db.insert("comments", {
+        videoId: video._id,
+        userClerkId: user.subject,
+        userName: identityName(user),
+        userAvatarUrl: identityAvatarUrl(user),
+        text,
+        timestampSeconds: args.timestampSeconds,
+        parentId: args.parentId,
+        resolved: false,
+      });
+    }
+
+    if (!guestCommentsEnabled(video)) {
+      throw new Error("Guest comments are not allowed on this video");
+    }
+
+    const guestName = normalizeGuestName(args.guestName);
+    await assertGuestCommentRateLimit(ctx, video._id);
+
     return await ctx.db.insert("comments", {
       videoId: video._id,
-      userClerkId: user.subject,
-      userName: identityName(user),
-      userAvatarUrl: identityAvatarUrl(user),
-      text: args.text,
+      userName: guestName,
+      text,
       timestampSeconds: args.timestampSeconds,
       parentId: args.parentId,
       resolved: false,
@@ -177,11 +271,11 @@ export const update = mutation({
     const comment = await ctx.db.get(args.commentId);
     if (!comment) throw new Error("Comment not found");
 
-    if (comment.userClerkId !== user.subject) {
+    if (!comment.userClerkId || comment.userClerkId !== user.subject) {
       throw new Error("You can only edit your own comments");
     }
 
-    await ctx.db.patch(args.commentId, { text: args.text });
+    await ctx.db.patch(args.commentId, { text: normalizeCommentText(args.text) });
   },
 });
 
@@ -193,7 +287,7 @@ export const remove = mutation({
     const comment = await ctx.db.get(args.commentId);
     if (!comment) throw new Error("Comment not found");
 
-    if (comment.userClerkId !== user.subject) {
+    if (!comment.userClerkId || comment.userClerkId !== user.subject) {
       await requireVideoAccess(ctx, comment.videoId, "admin");
     }
 

--- a/convex/guestComments.vitest.ts
+++ b/convex/guestComments.vitest.ts
@@ -1,0 +1,163 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
+import { expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+import type { Id } from "./_generated/dataModel";
+
+const modules = import.meta.glob("./**/*.ts");
+
+async function seedPublicVideo(opts?: { allowGuestComments?: boolean }) {
+  const t = convexTest(schema, modules);
+  registerRateLimiter(t);
+  const seeded = await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "user_1",
+      plan: "basic",
+    });
+    await ctx.db.insert("teamMembers", {
+      teamId,
+      userClerkId: "user_1",
+      userEmail: "owner@example.com",
+      userName: "Owner",
+      role: "admin",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      teamId,
+      name: "Campaign",
+    });
+    const videoId = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "user_1",
+      uploaderName: "Owner",
+      title: "First cut",
+      visibility: "public",
+      publicId: "watch-guest-1",
+      status: "ready",
+      muxPlaybackId: "playback-guest-1",
+      workflowStatus: "review",
+      allowGuestComments: opts?.allowGuestComments,
+    });
+    return { teamId, projectId, videoId };
+  });
+
+  return { t, ...seeded };
+}
+
+test("public watch payload exposes allowGuestComments", async () => {
+  const { t, videoId } = await seedPublicVideo({ allowGuestComments: true });
+
+  const result = await t.query(api.videos.getByPublicId, { publicId: "watch-guest-1" });
+  expect(result?.allowGuestComments).toBe(true);
+
+  await t.withIdentity({ subject: "user_1" }).mutation(api.videos.setAllowGuestComments, {
+    videoId: videoId as Id<"videos">,
+    enabled: false,
+  });
+
+  const disabled = await t.query(api.videos.getByPublicId, { publicId: "watch-guest-1" });
+  expect(disabled?.allowGuestComments).toBe(false);
+});
+
+test("rejects guest comments when allowGuestComments is off", async () => {
+  const { t } = await seedPublicVideo();
+
+  await expect(
+    t.mutation(api.comments.createForPublic, {
+      publicId: "watch-guest-1",
+      text: "Looks good",
+      timestampSeconds: 12,
+      guestName: "Alex",
+    }),
+  ).rejects.toThrow(/Guest comments are not allowed/);
+});
+
+test("allows guest comments when allowGuestComments is on", async () => {
+  const { t, videoId } = await seedPublicVideo({ allowGuestComments: true });
+
+  const commentId = await t.mutation(api.comments.createForPublic, {
+    publicId: "watch-guest-1",
+    text: "Looks good at the open",
+    timestampSeconds: 3.5,
+    guestName: "  Client Name  ",
+  });
+
+  const stored = await t.run((ctx) => ctx.db.get(commentId));
+  expect(stored).toMatchObject({
+    videoId,
+    text: "Looks good at the open",
+    timestampSeconds: 3.5,
+    userName: "Client Name",
+    resolved: false,
+  });
+  expect(stored?.userClerkId).toBeUndefined();
+
+  const threaded = await t.query(api.comments.getThreadedForPublic, {
+    publicId: "watch-guest-1",
+  });
+  expect(threaded).toHaveLength(1);
+  expect(threaded[0]?.userName).toBe("Client Name");
+});
+
+test("signed-in users can still comment without guest name", async () => {
+  const { t } = await seedPublicVideo();
+
+  const commentId = await t
+    .withIdentity({ subject: "user_reviewer", name: "Reviewer" })
+    .mutation(api.comments.createForPublic, {
+      publicId: "watch-guest-1",
+      text: "Signed-in note",
+      timestampSeconds: 1,
+    });
+
+  const stored = await t.run((ctx) => ctx.db.get(commentId));
+  expect(stored).toMatchObject({
+    userClerkId: "user_reviewer",
+    userName: "Reviewer",
+    text: "Signed-in note",
+  });
+});
+
+test("setAllowGuestComments applies across a version stack", async () => {
+  const { t, videoId } = await seedPublicVideo();
+
+  const v2 = await t.run(async (ctx) => {
+    await ctx.db.patch(videoId as Id<"videos">, {
+      versionStackId: videoId as Id<"videos">,
+      versionNumber: 1,
+    });
+    return await ctx.db.insert("videos", {
+      projectId: (await ctx.db.get(videoId as Id<"videos">))!.projectId,
+      uploadedByClerkId: "user_1",
+      uploaderName: "Owner",
+      title: "First cut",
+      visibility: "public",
+      publicId: "watch-guest-2",
+      status: "ready",
+      muxPlaybackId: "playback-guest-2",
+      workflowStatus: "review",
+      versionStackId: videoId as Id<"videos">,
+      versionNumber: 2,
+    });
+  });
+
+  await t.run(async (ctx) => {
+    await ctx.db.patch(videoId as Id<"videos">, { supersededByVideoId: v2 });
+  });
+
+  await t.withIdentity({ subject: "user_1" }).mutation(api.videos.setAllowGuestComments, {
+    videoId: v2 as Id<"videos">,
+    enabled: true,
+  });
+
+  const flags = await t.run(async (ctx) => ({
+    v1: (await ctx.db.get(videoId as Id<"videos">))?.allowGuestComments,
+    v2: (await ctx.db.get(v2))?.allowGuestComments,
+  }));
+
+  expect(flags).toEqual({ v1: true, v2: true });
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -70,6 +70,10 @@ export default defineSchema({
     // version switcher is hidden. Unset/true means viewers can browse versions.
     // Kept consistent across every version in a stack (see setPublicVersionBrowsing).
     allowPublicVersionBrowsing: v.optional(v.boolean()),
+    // When true, anyone with the public or restricted share link can leave a
+    // comment without signing in. Unset/false means signed-in only.
+    // Kept consistent across every version in a stack (see setAllowGuestComments).
+    allowGuestComments: v.optional(v.boolean()),
     // Mux video references
     muxUploadId: v.optional(v.string()),
     muxAssetId: v.optional(v.string()),
@@ -128,7 +132,9 @@ export default defineSchema({
 
   comments: defineTable({
     videoId: v.id("videos"),
-    userClerkId: v.string(),
+    // Missing for guest comments left via public/share links when
+    // allowGuestComments is enabled on the video.
+    userClerkId: v.optional(v.string()),
     userName: v.string(),
     userAvatarUrl: v.optional(v.string()),
     text: v.string(),

--- a/convex/videos.ts
+++ b/convex/videos.ts
@@ -425,6 +425,8 @@ async function insertVersionRecord(
     description: latest.description,
     visibility: latest.visibility,
     publicId: args.publicId,
+    allowPublicVersionBrowsing: latest.allowPublicVersionBrowsing,
+    allowGuestComments: latest.allowGuestComments,
     fileSize: args.fileSize,
     contentType: args.contentType,
     status: "uploading",
@@ -638,6 +640,11 @@ function publicVersionBrowsingEnabled(video: Doc<"videos">) {
   return video.allowPublicVersionBrowsing !== false;
 }
 
+// Guest comments are off unless explicitly enabled (opt-in).
+export function guestCommentsEnabled(video: Pick<Doc<"videos">, "allowGuestComments">) {
+  return video.allowGuestComments === true;
+}
+
 function isPublicReadyVersion(video: Doc<"videos">) {
   return video.visibility === "public" && video.status === "ready";
 }
@@ -762,6 +769,7 @@ export const getByPublicId = query({
       processing: false as const,
       title: video.title,
       allowVersionBrowsing: resolution.allowVersionBrowsing,
+      allowGuestComments: guestCommentsEnabled(video),
       video: {
         _id: video._id,
         publicId: video.publicId,
@@ -875,6 +883,7 @@ export const getByShareGrant = query({
         contentType: video.contentType,
         s3Key: video.s3Key,
       },
+      allowGuestComments: guestCommentsEnabled(video),
       grantExpiresAt: resolved.grant.expiresAt,
     };
   },
@@ -993,6 +1002,27 @@ export const setPublicVersionBrowsing = mutation({
       versions.map((version) =>
         publicVersionBrowsingEnabled(version) !== args.enabled
           ? ctx.db.patch(version._id, { allowPublicVersionBrowsing: args.enabled })
+          : Promise.resolve(),
+      ),
+    );
+  },
+});
+
+export const setAllowGuestComments = mutation({
+  args: {
+    videoId: v.id("videos"),
+    enabled: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const { video } = await requireVideoAccess(ctx, args.videoId, "member");
+
+    // Guest commenting is a property of the whole video. Keep it consistent
+    // across every version in the stack.
+    const versions = await readStackVersionsForUpdate(ctx, video);
+    await Promise.all(
+      versions.map((version) =>
+        guestCommentsEnabled(version) !== args.enabled
+          ? ctx.db.patch(version._id, { allowGuestComments: args.enabled })
           : Promise.resolve(),
       ),
     );

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -40,10 +40,12 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
   const deleteShareLink = useMutation(api.shareLinks.remove);
   const setVisibility = useMutation(api.videos.setVisibility);
   const setVersionBrowsing = useMutation(api.videos.setPublicVersionBrowsing);
+  const setAllowGuestComments = useMutation(api.videos.setAllowGuestComments);
 
   const [isCreating, setIsCreating] = useState(false);
   const [isUpdatingVisibility, setIsUpdatingVisibility] = useState(false);
   const [isUpdatingVersionBrowsing, setIsUpdatingVersionBrowsing] = useState(false);
+  const [isUpdatingGuestComments, setIsUpdatingGuestComments] = useState(false);
   const [deletingLinkId, setDeletingLinkId] = useState<Id<"shareLinks"> | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [copyStatus, setCopyStatus] = useState<{
@@ -82,6 +84,7 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
     setIsCreating(false);
     setIsUpdatingVisibility(false);
     setIsUpdatingVersionBrowsing(false);
+    setIsUpdatingGuestComments(false);
     setDeletingLinkId(null);
     setMutationError(null);
     setNewLinkOptions({ expiresInDays: undefined, password: undefined });
@@ -168,6 +171,7 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
   };
 
   const versionBrowsingEnabled = video?.allowPublicVersionBrowsing !== false;
+  const guestCommentsEnabled = video?.allowGuestComments === true;
 
   const handleSetVersionBrowsing = async (enabled: boolean) => {
     if (
@@ -189,6 +193,30 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
     } finally {
       if (isMutationCurrent(contextEpoch, requestVideoId)) {
         setIsUpdatingVersionBrowsing(false);
+      }
+    }
+  };
+
+  const handleSetGuestComments = async (enabled: boolean) => {
+    if (
+      !video ||
+      !canManageSharing ||
+      isUpdatingGuestComments ||
+      guestCommentsEnabled === enabled
+    )
+      return;
+    const contextEpoch = mutationContextEpochRef.current.current();
+    const requestVideoId = videoId;
+    setIsUpdatingGuestComments(true);
+    setMutationError(null);
+    try {
+      await setAllowGuestComments({ videoId, enabled });
+    } catch {
+      if (!isMutationCurrent(contextEpoch, requestVideoId)) return;
+      setMutationError("Could not update guest comments. Please try again.");
+    } finally {
+      if (isMutationCurrent(contextEpoch, requestVideoId)) {
+        setIsUpdatingGuestComments(false);
       }
     }
   };
@@ -263,7 +291,8 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
         <DialogHeader>
           <DialogTitle>Share video</DialogTitle>
           <DialogDescription>
-            Public videos can be viewed by anyone with the URL. Only signed-in users can comment.
+            Public videos can be viewed by anyone with the URL. Enable guest comments to let
+            reviewers leave feedback without signing in.
           </DialogDescription>
         </DialogHeader>
 
@@ -330,6 +359,45 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
           <p className="text-xs text-[#888]">
             Private disables the public URL. Restricted share links still work.
           </p>
+        </div>
+
+        {/* Guest comments */}
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h3 className="text-sm font-bold text-[#1a1a1a]">Allow guest comments</h3>
+            <p className="text-xs text-[#888]">
+              Anyone with the public or restricted link can comment without signing in.
+            </p>
+          </div>
+          <div className="flex shrink-0 items-center gap-2.5">
+            <span
+              className={cn(
+                "text-xs font-bold tracking-wide uppercase",
+                guestCommentsEnabled ? "text-[#2d5a2d]" : "text-[#888]",
+              )}
+            >
+              {guestCommentsEnabled ? "On" : "Off"}
+            </span>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={guestCommentsEnabled}
+              aria-label="Allow guest comments"
+              disabled={!canManageSharing || isUpdatingGuestComments}
+              onClick={() => void handleSetGuestComments(!guestCommentsEnabled)}
+              className={cn(
+                "relative h-7 w-12 shrink-0 border-2 border-[#1a1a1a] transition-colors disabled:opacity-50",
+                guestCommentsEnabled ? "bg-[#2d5a2d]" : "bg-[#ccc]",
+              )}
+            >
+              <span
+                className={cn(
+                  "absolute top-1 h-4 w-4 border-2 border-[#1a1a1a] bg-[#f0f0e8] transition-all",
+                  guestCommentsEnabled ? "left-[26px]" : "left-0.5",
+                )}
+              />
+            </button>
+          </div>
         </div>
 
         {/* Public URL + version browsing */}

--- a/src/lib/guestName.ts
+++ b/src/lib/guestName.ts
@@ -1,0 +1,25 @@
+const STORAGE_KEY = "lawn.guest_name";
+export const MAX_GUEST_NAME_LENGTH = 40;
+
+export function readStoredGuestName(): string {
+  if (typeof window === "undefined") return "";
+  try {
+    return window.localStorage.getItem(STORAGE_KEY)?.trim() ?? "";
+  } catch {
+    return "";
+  }
+}
+
+export function writeStoredGuestName(name: string) {
+  if (typeof window === "undefined") return;
+  const trimmed = name.trim().slice(0, MAX_GUEST_NAME_LENGTH);
+  try {
+    if (trimmed) {
+      window.localStorage.setItem(STORAGE_KEY, trimmed);
+    } else {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  } catch {
+    // Ignore quota / private mode failures.
+  }
+}


### PR DESCRIPTION
## Summary
- Closes https://github.com/pingdotgg/lawn/issues/12
- Adds a per-video **Allow guest comments** toggle in the share dialog (opt-in, applies across the whole version stack)
- When enabled, anyone with the public `/watch` link or a restricted `/share` link can leave a comment without signing in (guest name required, stored in localStorage)
- Signed-in reviewers still comment as themselves; guest posts are rate-limited

## Test plan
- [x] Open share dialog on a video → toggle **Allow guest comments** on/off and confirm state persists
- [x] With toggle **off**, open public and restricted links while signed out → still see “Sign in to comment”
- [ ] With toggle **on**, open public link signed out → enter guest name + comment → comment appears with that name
- [x] Same flow on a restricted share link
- [ ] Signed-in comment still works without guest name
- [ ] Dashboard discussion still lists guest comments; team admin can delete them
- [ ] `bunx vitest run convex/guestComments.vitest.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands who can write comments on link-accessible videos (abuse/spam mitigated by rate limits and opt-in); schema change makes `userClerkId` optional on comments.
> 
> **Overview**
> Adds an **opt-in per-video** `allowGuestComments` setting (toggled in the share dialog, synced across the version stack) so reviewers with a public `/watch` or restricted `/share` link can post timestamped comments **without signing in** when it is enabled.
> 
> **Watch and share pages** show the comment form when the viewer is signed in or guest comments are on; unsigned guests enter a name (persisted in `localStorage` via `guestName.ts`) and submit with `guestName` on the mutation. Otherwise the UI still prompts sign-in.
> 
> **Backend:** `comments.userClerkId` is optional for guest posts. `createForPublic` and `createForShareGrant` use optional auth (`getUser`); signed-in users behave as before, guests require the flag plus normalized name/text and **global + per-video rate limits**. Edit/delete rules treat missing `userClerkId` as non-owner (admins can still delete). Public/share payloads expose `allowGuestComments`. Vitests cover the new behavior in `guestComments.vitest.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8472c4df30286794bb7fbdbeac125eebc29449d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow guest comments on public watch and review share links
> - Adds a per-video `allowGuestComments` toggle in the share dialog; team members can enable/disable it and the setting propagates across all versions in the video stack.
> - Unauthenticated viewers on public watch and share-grant pages can post comments when the flag is enabled; they must provide a non-empty display name (persisted to `localStorage` via [`src/lib/guestName.ts`](https://github.com/pingdotgg/lawn/pull/56/files#diff-06a8c6c8cbbb642720dfe3a98e9ff5d3668bba65f0791df96d1275a974741f38)).
> - Guest comments are stored without a `userClerkId` in the comments table; the schema change makes that field optional ([`convex/schema.ts`](https://github.com/pingdotgg/lawn/pull/56/files#diff-00e6e27e65e72a0fd4a73f6942f41e1cf3f476a59f263513f3f47fdf801a0eb1)).
> - Guest comment creation is rate-limited via two buckets: 300/min globally and 30/min per video; text and name inputs are validated and length-capped server-side.
> - Risk: guest comments cannot be edited by anyone; deleting them requires admin video access rather than ownership.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d8472c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional guest commenting for public and shared videos.
  * Guests can enter a display name, which is remembered for future comments.
  * Video owners can enable or disable guest comments from the sharing settings.
  * Added comment text and guest-name validation with rate limiting.

* **Bug Fixes**
  * Tightened comment editing and deletion permissions.
  * Improved comment text normalization and guest-name handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->