### PR TITLE
feat: add comment tags for discussion triage

### DIFF
--- a/app/routes/dashboard/-video.tsx
+++ b/app/routes/dashboard/-video.tsx
@@ -1263,6 +1263,7 @@ export default function VideoPage() {
               onTimestampClick={handleTimestampClick}
               highlightedCommentId={highlightedCommentId}
               canResolve={canEdit}
+              canTag={canEdit}
             />
           </div>
           {canComment && (
@@ -1321,6 +1322,7 @@ export default function VideoPage() {
               }}
               highlightedCommentId={highlightedCommentId}
               canResolve={canEdit}
+              canTag={canEdit}
             />
           </div>
           {canComment && (

--- a/convex/commentTags.vitest.ts
+++ b/convex/commentTags.vitest.ts
@@ -1,0 +1,136 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+import { MAX_COMMENT_TAGS, MAX_TAG_LENGTH, normalizeCommentTags } from "./comments";
+
+const modules = import.meta.glob("./**/*.ts");
+
+test("normalizeCommentTags trims, dedupes, and enforces limits", () => {
+  expect(normalizeCommentTags(undefined)).toEqual([]);
+  expect(normalizeCommentTags(["  In-Out  ", "in-out", "Audio"])).toEqual(["In-Out", "Audio"]);
+  expect(() => normalizeCommentTags(["x".repeat(MAX_TAG_LENGTH + 1)])).toThrow(/characters/);
+  expect(() =>
+    normalizeCommentTags(Array.from({ length: MAX_COMMENT_TAGS + 1 }, (_, i) => `t${i}`)),
+  ).toThrow(/at most/);
+});
+
+async function seedTeam() {
+  const t = convexTest(schema, modules);
+  const seeded = await t.run(async (ctx) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: "Garden",
+      slug: "garden",
+      ownerClerkId: "owner",
+      plan: "basic",
+    });
+    await ctx.db.insert("teamMembers", {
+      teamId,
+      userClerkId: "owner",
+      userEmail: "owner@example.com",
+      userName: "Owner",
+      role: "owner",
+    });
+    await ctx.db.insert("teamMembers", {
+      teamId,
+      userClerkId: "member",
+      userEmail: "member@example.com",
+      userName: "Member",
+      role: "member",
+    });
+    await ctx.db.insert("teamMembers", {
+      teamId,
+      userClerkId: "viewer",
+      userEmail: "viewer@example.com",
+      userName: "Viewer",
+      role: "viewer",
+    });
+    const projectId = await ctx.db.insert("projects", { teamId, name: "Campaign" });
+    const videoId = await ctx.db.insert("videos", {
+      projectId,
+      uploadedByClerkId: "owner",
+      uploaderName: "Owner",
+      title: "Cut 1",
+      visibility: "private",
+      publicId: "vid-tags",
+      status: "ready",
+      workflowStatus: "review",
+    });
+    return { videoId };
+  });
+  return { t, ...seeded };
+}
+
+test("members can set tags; viewers cannot", async () => {
+  const { t, videoId } = await seedTeam();
+
+  const commentId = await t.withIdentity({ subject: "owner" }).mutation(api.comments.create, {
+    videoId,
+    text: "Trim the intro",
+    timestampSeconds: 12,
+  });
+
+  await t.withIdentity({ subject: "member" }).mutation(api.comments.setTags, {
+    commentId,
+    tags: ["In-Out", "  in-out ", "Audio"],
+  });
+
+  const threaded = await t.withIdentity({ subject: "owner" }).query(api.comments.getThreaded, {
+    videoId,
+  });
+  expect(threaded).toHaveLength(1);
+  expect(threaded[0]?.tags).toEqual(["In-Out", "Audio"]);
+
+  await expect(
+    t.withIdentity({ subject: "viewer" }).mutation(api.comments.setTags, {
+      commentId,
+      tags: ["Nope"],
+    }),
+  ).rejects.toThrow();
+});
+
+test("create accepts tags only for member+ roles", async () => {
+  const { t, videoId } = await seedTeam();
+
+  const memberCommentId = await t.withIdentity({ subject: "member" }).mutation(api.comments.create, {
+    videoId,
+    text: "Color grade sky",
+    timestampSeconds: 30,
+    tags: ["Color"],
+  });
+
+  const memberDoc = await t.run((ctx) => ctx.db.get(memberCommentId));
+  expect(memberDoc?.tags).toEqual(["Color"]);
+
+  // Viewers can comment but tags are ignored.
+  const viewerCommentId = await t.withIdentity({ subject: "viewer" }).mutation(api.comments.create, {
+    videoId,
+    text: "Looks good",
+    timestampSeconds: 40,
+    tags: ["ShouldIgnore"],
+  });
+  const viewerDoc = await t.run((ctx) => ctx.db.get(viewerCommentId));
+  expect(viewerDoc?.tags).toBeUndefined();
+});
+
+test("public threaded payload includes tags", async () => {
+  const { t, videoId } = await seedTeam();
+
+  await t.run(async (ctx) => {
+    await ctx.db.patch(videoId, { visibility: "public" });
+  });
+
+  await t.withIdentity({ subject: "owner" }).mutation(api.comments.create, {
+    videoId,
+    text: "Public note",
+    timestampSeconds: 5,
+    tags: ["Note"],
+  });
+
+  const publicThreaded = await t.query(api.comments.getThreadedForPublic, {
+    publicId: "vid-tags",
+  });
+  expect(publicThreaded[0]?.tags).toEqual(["Note"]);
+});

--- a/convex/comments.ts
+++ b/convex/comments.ts
@@ -4,6 +4,41 @@ import { identityAvatarUrl, identityName, requireVideoAccess, requireUser } from
 import { resolveActiveShareGrant } from "./shareAccess";
 import { resolvePublicVideo } from "./videos";
 
+/** Max tags on a single comment. */
+export const MAX_COMMENT_TAGS = 8;
+/** Max characters per tag after trim. */
+export const MAX_TAG_LENGTH = 32;
+
+/**
+ * Normalize free-form comment tags for storage.
+ * Trims, collapses internal whitespace, enforces length/count, and dedupes
+ * case-insensitively while preserving the first-seen casing.
+ */
+export function normalizeCommentTags(tags: string[] | undefined): string[] {
+  if (!tags || tags.length === 0) return [];
+
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const raw of tags) {
+    if (typeof raw !== "string") continue;
+    const tag = raw.trim().replace(/\s+/g, " ");
+    if (!tag) continue;
+    if (tag.length > MAX_TAG_LENGTH) {
+      throw new Error(`Tag must be ${MAX_TAG_LENGTH} characters or fewer`);
+    }
+    const key = tag.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(tag);
+    if (result.length > MAX_COMMENT_TAGS) {
+      throw new Error(`Comments can have at most ${MAX_COMMENT_TAGS} tags`);
+    }
+  }
+
+  return result;
+}
+
 function toThreadedComments<
   T extends { _id: string; parentId?: string; timestampSeconds: number; _creationTime: number },
 >(comments: T[]) {
@@ -28,6 +63,7 @@ function toPublicCommentPayload(comment: {
   resolved: boolean;
   userName: string;
   userAvatarUrl?: string;
+  tags?: string[];
 }) {
   return {
     _id: comment._id,
@@ -38,6 +74,7 @@ function toPublicCommentPayload(comment: {
     resolved: comment.resolved,
     userName: comment.userName,
     userAvatarUrl: comment.userAvatarUrl,
+    tags: comment.tags,
   };
 }
 
@@ -67,9 +104,11 @@ export const create = mutation({
     text: v.string(),
     timestampSeconds: v.number(),
     parentId: v.optional(v.id("comments")),
+    // Only applied when the caller has member+ access; viewers cannot tag.
+    tags: v.optional(v.array(v.string())),
   },
   handler: async (ctx, args) => {
-    const { user } = await requireVideoAccess(ctx, args.videoId, "viewer");
+    const { user, membership } = await requireVideoAccess(ctx, args.videoId, "viewer");
 
     if (args.parentId) {
       const parent = await ctx.db.get(args.parentId);
@@ -77,6 +116,13 @@ export const create = mutation({
         throw new Error("Invalid parent comment");
       }
     }
+
+    const canTag =
+      membership.role === "owner" ||
+      membership.role === "admin" ||
+      membership.role === "member";
+    const tags =
+      canTag && args.tags && args.tags.length > 0 ? normalizeCommentTags(args.tags) : undefined;
 
     return await ctx.db.insert("comments", {
       videoId: args.videoId,
@@ -87,6 +133,7 @@ export const create = mutation({
       timestampSeconds: args.timestampSeconds,
       parentId: args.parentId,
       resolved: false,
+      ...(tags && tags.length > 0 ? { tags } : {}),
     });
   },
 });
@@ -219,6 +266,26 @@ export const toggleResolved = mutation({
     await requireVideoAccess(ctx, comment.videoId, "member");
 
     await ctx.db.patch(args.commentId, { resolved: !comment.resolved });
+  },
+});
+
+/**
+ * Replace the tag list on a comment. Project owners and team members only
+ * (viewer role cannot manage tags).
+ */
+export const setTags = mutation({
+  args: {
+    commentId: v.id("comments"),
+    tags: v.array(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const comment = await ctx.db.get(args.commentId);
+    if (!comment) throw new Error("Comment not found");
+
+    await requireVideoAccess(ctx, comment.videoId, "member");
+
+    const tags = normalizeCommentTags(args.tags);
+    await ctx.db.patch(args.commentId, { tags });
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -135,6 +135,8 @@ export default defineSchema({
     timestampSeconds: v.number(),
     parentId: v.optional(v.id("comments")),
     resolved: v.boolean(),
+    // Free-form labels for triage. Optional so existing rows need no backfill.
+    tags: v.optional(v.array(v.string())),
   })
     .index("by_video", ["videoId"])
     .index("by_video_and_timestamp", ["videoId", "timestampSeconds"])

--- a/src/components/comments/CommentItem.tsx
+++ b/src/components/comments/CommentItem.tsx
@@ -7,7 +7,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { formatTimestamp, formatRelativeTime, getInitials, cn } from "@/lib/utils";
-import { Check, MoreVertical, Trash2, Reply } from "lucide-react";
+import { Check, MoreVertical, Tag, Trash2, Reply, X } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -28,6 +28,7 @@ interface Comment {
   userName: string;
   userAvatarUrl?: string;
   _creationTime: number;
+  tags?: string[];
 }
 
 interface CommentItemProps {
@@ -36,6 +37,7 @@ interface CommentItemProps {
   isHighlighted?: boolean;
   isReply?: boolean;
   canResolve?: boolean;
+  canTag?: boolean;
 }
 
 export function CommentItem({
@@ -44,10 +46,17 @@ export function CommentItem({
   isHighlighted = false,
   isReply = false,
   canResolve = false,
+  canTag = false,
 }: CommentItemProps) {
   const [isReplying, setIsReplying] = useState(false);
+  const [isAddingTag, setIsAddingTag] = useState(false);
+  const [newTag, setNewTag] = useState("");
+  const [tagError, setTagError] = useState<string | null>(null);
   const toggleResolved = useMutation(api.comments.toggleResolved);
   const deleteComment = useMutation(api.comments.remove);
+  const setTags = useMutation(api.comments.setTags);
+
+  const tags = comment.tags ?? [];
 
   const handleToggleResolved = async () => {
     try {
@@ -64,6 +73,35 @@ export function CommentItem({
     } catch (error) {
       console.error("Failed to delete comment:", error);
     }
+  };
+
+  const persistTags = async (next: string[]) => {
+    setTagError(null);
+    try {
+      await setTags({ commentId: comment._id, tags: next });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to update tags";
+      setTagError(message);
+      console.error("Failed to update tags:", error);
+    }
+  };
+
+  const handleAddTag = async () => {
+    const trimmed = newTag.trim();
+    if (!trimmed) return;
+    const exists = tags.some((t) => t.toLowerCase() === trimmed.toLowerCase());
+    if (exists) {
+      setNewTag("");
+      setIsAddingTag(false);
+      return;
+    }
+    await persistTags([...tags, trimmed]);
+    setNewTag("");
+    setIsAddingTag(false);
+  };
+
+  const handleRemoveTag = async (tag: string) => {
+    await persistTags(tags.filter((t) => t.toLowerCase() !== tag.toLowerCase()));
   };
 
   return (
@@ -115,6 +153,17 @@ export function CommentItem({
                     {comment.resolved ? "Unresolve" : "Resolve"}
                   </DropdownMenuItem>
                 )}
+                {canTag && (
+                  <DropdownMenuItem
+                    onClick={() => {
+                      setIsAddingTag(true);
+                      setTagError(null);
+                    }}
+                  >
+                    <Tag className="mr-2 h-4 w-4" />
+                    Add tag
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuItem
                   className="text-[#dc2626] focus:text-[#dc2626]"
                   onClick={handleDelete}
@@ -128,6 +177,63 @@ export function CommentItem({
           <p className="mt-1 text-sm break-words whitespace-pre-wrap text-[#1a1a1a]">
             <CommentText text={comment.text} />
           </p>
+          {(tags.length > 0 || isAddingTag) && (
+            <div className="mt-2 flex flex-wrap items-center gap-1.5">
+              {tags.map((tag) => (
+                <span
+                  key={tag.toLowerCase()}
+                  className="inline-flex items-center gap-1 border border-[#1a1a1a]/30 bg-[#e8e8e0] px-1.5 py-0.5 text-[10px] font-bold tracking-wider text-[#1a1a1a] uppercase"
+                >
+                  {tag}
+                  {canTag && (
+                    <button
+                      type="button"
+                      onClick={() => void handleRemoveTag(tag)}
+                      className="inline-flex h-3 w-3 items-center justify-center text-[#888] hover:text-[#dc2626]"
+                      aria-label={`Remove tag ${tag}`}
+                    >
+                      <X className="h-2.5 w-2.5" />
+                    </button>
+                  )}
+                </span>
+              ))}
+              {isAddingTag && (
+                <form
+                  className="flex items-center gap-1"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    void handleAddTag();
+                  }}
+                >
+                  <input
+                    autoFocus
+                    value={newTag}
+                    onChange={(event) => setNewTag(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Escape") {
+                        setIsAddingTag(false);
+                        setNewTag("");
+                        setTagError(null);
+                      }
+                    }}
+                    onBlur={() => {
+                      if (!newTag.trim()) {
+                        setIsAddingTag(false);
+                        setTagError(null);
+                      }
+                    }}
+                    placeholder="tag name"
+                    maxLength={32}
+                    className="h-6 w-24 border border-[#1a1a1a] bg-[#f0f0e8] px-1.5 font-mono text-[10px] text-[#1a1a1a] outline-none placeholder:text-[#888]"
+                  />
+                  <Button type="submit" size="sm" variant="ghost" className="h-6 px-1.5 text-[10px]">
+                    Add
+                  </Button>
+                </form>
+              )}
+            </div>
+          )}
+          {tagError ? <p className="mt-1 text-[11px] text-[#dc2626]">{tagError}</p> : null}
           <p className="mt-1 text-[11px] text-[#888]">
             {formatRelativeTime(comment._creationTime)}
           </p>

--- a/src/components/comments/CommentList.tsx
+++ b/src/components/comments/CommentList.tsx
@@ -1,11 +1,20 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import { useQuery } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import { Id } from "../../../convex/_generated/dataModel";
 import { FunctionReturnType } from "convex/server";
 import { CommentItem } from "./CommentItem";
+import { CommentTagFilter } from "./CommentTagFilter";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  collectUniqueTags,
+  commentMatchesTagFilter,
+  exclusiveSelectTag,
+  toggleTagFilter,
+  type ActiveTagFilter,
+} from "@/lib/commentTags";
 
 type ThreadedComments = FunctionReturnType<typeof api.comments.getThreaded>;
 
@@ -15,6 +24,7 @@ interface CommentListProps {
   onTimestampClick: (seconds: number) => void;
   highlightedCommentId?: Id<"comments">;
   canResolve?: boolean;
+  canTag?: boolean;
 }
 
 export function CommentList({
@@ -23,9 +33,22 @@ export function CommentList({
   onTimestampClick,
   highlightedCommentId,
   canResolve = false,
+  canTag = false,
 }: CommentListProps) {
   const queriedComments = useQuery(api.comments.getThreaded, { videoId });
   const comments = providedComments ?? queriedComments;
+  const [activeFilter, setActiveFilter] = useState<ActiveTagFilter>(null);
+
+  const availableTags = useMemo(
+    () => (comments ? collectUniqueTags(comments) : []),
+    [comments],
+  );
+
+  const filteredComments = useMemo(() => {
+    if (!comments) return comments;
+    if (activeFilter === null) return comments;
+    return comments.filter((comment) => commentMatchesTagFilter(comment, activeFilter));
+  }, [comments, activeFilter]);
 
   if (comments === undefined) {
     return <div className="p-4 text-center text-[#888]">Loading...</div>;
@@ -44,34 +67,61 @@ export function CommentList({
   }
 
   return (
-    <ScrollArea className="h-full">
-      <div className="flex flex-col divide-y divide-[#1a1a1a]/10 dark:divide-white/10">
-        {comments.map((comment) => (
-          <div key={comment._id} className="relative">
-            <CommentItem
-              comment={comment}
-              onTimestampClick={onTimestampClick}
-              isHighlighted={highlightedCommentId === comment._id}
-              canResolve={canResolve}
-            />
-            {comment.replies.length > 0 && (
-              <div className="relative space-y-4 pr-4 pb-4 pl-14">
-                <div className="absolute top-0 bottom-6 left-[1.35rem] w-px bg-[#1a1a1a]/10 dark:bg-white/10" />
-                {comment.replies.map((reply) => (
-                  <CommentItem
-                    key={reply._id}
-                    comment={reply}
-                    onTimestampClick={onTimestampClick}
-                    isHighlighted={highlightedCommentId === reply._id}
-                    isReply
-                    canResolve={canResolve}
-                  />
-                ))}
-              </div>
-            )}
+    <div className="flex h-full min-h-0 flex-col">
+      <CommentTagFilter
+        tags={availableTags}
+        activeFilter={activeFilter}
+        onExclusiveSelect={(tag) => setActiveFilter(exclusiveSelectTag(activeFilter, tag))}
+        onToggle={(tag) => setActiveFilter(toggleTagFilter(activeFilter, tag, availableTags))}
+        onShowAll={() => setActiveFilter(null)}
+      />
+      <ScrollArea className="min-h-0 flex-1">
+        {filteredComments && filteredComments.length === 0 ? (
+          <div className="flex items-center justify-center p-6">
+            <p className="text-center text-sm text-[#888]">
+              No comments match the selected tags.
+              <br />
+              <button
+                type="button"
+                className="mt-1 font-bold text-[#2d5a2d] underline underline-offset-2"
+                onClick={() => setActiveFilter(null)}
+              >
+                Show all
+              </button>
+            </p>
           </div>
-        ))}
-      </div>
-    </ScrollArea>
+        ) : (
+          <div className="flex flex-col divide-y divide-[#1a1a1a]/10 dark:divide-white/10">
+            {filteredComments?.map((comment) => (
+              <div key={comment._id} className="relative">
+                <CommentItem
+                  comment={comment}
+                  onTimestampClick={onTimestampClick}
+                  isHighlighted={highlightedCommentId === comment._id}
+                  canResolve={canResolve}
+                  canTag={canTag}
+                />
+                {comment.replies.length > 0 && (
+                  <div className="relative space-y-4 pr-4 pb-4 pl-14">
+                    <div className="absolute top-0 bottom-6 left-[1.35rem] w-px bg-[#1a1a1a]/10 dark:bg-white/10" />
+                    {comment.replies.map((reply) => (
+                      <CommentItem
+                        key={reply._id}
+                        comment={reply}
+                        onTimestampClick={onTimestampClick}
+                        isHighlighted={highlightedCommentId === reply._id}
+                        isReply
+                        canResolve={canResolve}
+                        canTag={canTag}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </ScrollArea>
+    </div>
   );
 }

--- a/src/components/comments/CommentTagFilter.tsx
+++ b/src/components/comments/CommentTagFilter.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { isTagActive, type ActiveTagFilter } from "@/lib/commentTags";
+
+interface CommentTagFilterProps {
+  tags: string[];
+  activeFilter: ActiveTagFilter;
+  onExclusiveSelect: (tag: string) => void;
+  onToggle: (tag: string) => void;
+  onShowAll?: () => void;
+}
+
+/**
+ * Badge row at the top of the discussion panel.
+ * Left-click: exclusive filter on that tag.
+ * Right-click: toggle that tag without resetting the rest.
+ */
+export function CommentTagFilter({
+  tags,
+  activeFilter,
+  onExclusiveSelect,
+  onToggle,
+  onShowAll,
+}: CommentTagFilterProps) {
+  if (tags.length === 0) return null;
+
+  const allActive = activeFilter === null;
+  const showShowAll = !allActive;
+
+  return (
+    <div
+      className="flex flex-shrink-0 flex-wrap items-center gap-1.5 border-b border-[#1a1a1a]/10 px-4 py-2.5 dark:border-white/10"
+      role="toolbar"
+      aria-label="Filter comments by tag"
+    >
+      {tags.map((tag) => {
+        const active = isTagActive(activeFilter, tag);
+        return (
+          <button
+            key={tag.toLowerCase()}
+            type="button"
+            onClick={() => onExclusiveSelect(tag)}
+            onContextMenu={(event) => {
+              event.preventDefault();
+              onToggle(tag);
+            }}
+            title={
+              active
+                ? "Left-click: show only this tag. Right-click: hide this tag."
+                : "Left-click: show only this tag. Right-click: include this tag."
+            }
+            aria-pressed={active}
+            className={cn(
+              "inline-flex items-center border-2 px-2 py-0.5 text-[10px] font-bold tracking-wider uppercase transition-colors",
+              active
+                ? "border-[#1a1a1a] bg-[#2d5a2d] text-[#f0f0e8]"
+                : "border-[#1a1a1a]/40 bg-transparent text-[#888] opacity-60 hover:opacity-100",
+            )}
+          >
+            {tag}
+          </button>
+        );
+      })}
+      {showShowAll && onShowAll ? (
+        <button
+          type="button"
+          onClick={onShowAll}
+          className="ml-1 text-[10px] font-bold tracking-wider text-[#2d5a2d] uppercase underline underline-offset-2 hover:text-[#1a1a1a]"
+        >
+          Show all
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/commentTags.test.ts
+++ b/src/lib/commentTags.test.ts
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  collectUniqueTags,
+  commentMatchesTagFilter,
+  exclusiveSelectTag,
+  isTagActive,
+  toggleTagFilter,
+} from "./commentTags";
+
+test("collectUniqueTags dedupes case-insensitively and preserves first casing", () => {
+  assert.deepEqual(
+    collectUniqueTags([
+      { tags: ["In-Out", "Audio"] },
+      { tags: ["in-out", "Color"] },
+      { tags: undefined },
+    ]),
+    ["In-Out", "Audio", "Color"],
+  );
+});
+
+test("exclusiveSelectTag leaves only the clicked tag active", () => {
+  const next = exclusiveSelectTag(null, "Audio");
+  assert.deepEqual(next, new Set(["Audio"]));
+  assert.equal(isTagActive(next, "Audio"), true);
+  assert.equal(isTagActive(next, "Color"), false);
+});
+
+test("toggleTagFilter right-click from all-active turns that tag off", () => {
+  const all = ["In-Out", "Audio", "Color"];
+  const next = toggleTagFilter(null, "Audio", all);
+  assert.equal(isTagActive(next, "In-Out"), true);
+  assert.equal(isTagActive(next, "Audio"), false);
+  assert.equal(isTagActive(next, "Color"), true);
+});
+
+test("toggleTagFilter right-click re-enables a previously off tag", () => {
+  const all = ["In-Out", "Audio", "Color"];
+  const partial = new Set(["In-Out", "Color"]);
+  const next = toggleTagFilter(partial, "Audio", all);
+  // All tags active again → collapsed to null
+  assert.equal(next, null);
+});
+
+test("toggleTagFilter toggling the last active tag leaves an empty set", () => {
+  const all = ["In-Out", "Audio", "Color"];
+  const only = new Set(["Audio"]);
+  const next = toggleTagFilter(only, "Audio", all);
+  assert.deepEqual(next, new Set());
+});
+
+test("commentMatchesTagFilter null shows everything including untagged", () => {
+  assert.equal(commentMatchesTagFilter({ tags: ["Audio"] }, null), true);
+  assert.equal(commentMatchesTagFilter({ tags: [] }, null), true);
+  assert.equal(commentMatchesTagFilter({}, null), true);
+});
+
+test("commentMatchesTagFilter subset requires at least one matching tag", () => {
+  const filter = new Set(["Audio"]);
+  assert.equal(commentMatchesTagFilter({ tags: ["Audio", "Color"] }, filter), true);
+  assert.equal(commentMatchesTagFilter({ tags: ["Color"] }, filter), false);
+  assert.equal(commentMatchesTagFilter({ tags: [] }, filter), false);
+});
+
+test("commentMatchesTagFilter empty filter shows nothing", () => {
+  assert.equal(commentMatchesTagFilter({ tags: ["Audio"] }, new Set()), false);
+});

--- a/src/lib/commentTags.ts
+++ b/src/lib/commentTags.ts
@@ -1,0 +1,87 @@
+/**
+ * Helpers for comment-tag filtering in the discussion panel.
+ *
+ * Filter state:
+ * - `null` means every tag is active (default) — show all comments, including untagged.
+ * - a `Set` means only comments that include at least one of those tags are shown.
+ */
+
+export type ActiveTagFilter = Set<string> | null;
+
+/** Collect unique tags from threads, preserving first-seen order and casing. */
+export function collectUniqueTags(comments: Array<{ tags?: string[] }>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const comment of comments) {
+    for (const tag of comment.tags ?? []) {
+      const key = tag.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      result.push(tag);
+    }
+  }
+  return result;
+}
+
+/** Left-click: exclusive filter on a single tag. */
+export function exclusiveSelectTag(_current: ActiveTagFilter, tag: string): ActiveTagFilter {
+  return new Set([tag]);
+}
+
+/**
+ * Right-click: toggle one tag without resetting the rest.
+ * When currently showing all (`null`), toggling off means "all except this one".
+ * When the result is every known tag, collapse back to `null` (show all).
+ */
+export function toggleTagFilter(
+  current: ActiveTagFilter,
+  tag: string,
+  allTags: string[],
+): ActiveTagFilter {
+  const allKeys = allTags.map((t) => t.toLowerCase());
+  const tagKey = tag.toLowerCase();
+
+  if (current === null) {
+    // All active → turn this one off.
+    const remaining = allTags.filter((t) => t.toLowerCase() !== tagKey);
+    if (remaining.length === 0) return new Set();
+    return new Set(remaining);
+  }
+
+  const next = new Set(current);
+  // Match by case-insensitive key but store display casing from allTags when adding.
+  const existing = [...next].find((t) => t.toLowerCase() === tagKey);
+  if (existing) {
+    next.delete(existing);
+  } else {
+    const display = allTags.find((t) => t.toLowerCase() === tagKey) ?? tag;
+    next.add(display);
+  }
+
+  if (next.size === 0) return next;
+
+  if (allKeys.length > 0 && allKeys.every((k) => [...next].some((t) => t.toLowerCase() === k))) {
+    return null;
+  }
+
+  return next;
+}
+
+export function isTagActive(filter: ActiveTagFilter, tag: string): boolean {
+  if (filter === null) return true;
+  const key = tag.toLowerCase();
+  return [...filter].some((t) => t.toLowerCase() === key);
+}
+
+/** Whether a comment should be visible under the current filter. */
+export function commentMatchesTagFilter(
+  comment: { tags?: string[] },
+  filter: ActiveTagFilter,
+): boolean {
+  if (filter === null) return true;
+  if (filter.size === 0) return false;
+  const tags = comment.tags ?? [];
+  if (tags.length === 0) return false;
+  const activeKeys = new Set([...filter].map((t) => t.toLowerCase()));
+  return tags.some((t) => activeKeys.has(t.toLowerCase()));
+}


### PR DESCRIPTION
## Summary

Closes https://github.com/pingdotgg/lawn/issues/15

Adds free-form **tags** on comments so editors can triage feedback on the fly without drowning in an unfiltered discussion thread.

### Behavior
- **Who can tag**: project owners and team members (`member` role and above). Viewers cannot manage tags.
- **Filter bar**: unique tags for the video appear as small badges at the top of the discussion panel
  - All tags active by default (show everything, including untagged)
  - **Left-click** a tag → exclusive filter (only that tag)
  - **Right-click** a tag → toggle that tag only without resetting the rest
  - **Show all** control when a subset filter is active
- Tags on each comment shown as chips; members can add/remove via the comment menu

### Implementation
- Schema: optional `tags: string[]` on `comments` (no backfill)
- `comments.setTags` mutation + optional tags on `comments.create` (member+)
- Public/share threaded payloads include tags for display
- Client filter helpers + unit tests; Convex vitest coverage for auth and normalization

## Test plan

- [ ] As a team member, open a video discussion → add a tag via comment ⋮ menu
- [ ] Tag badge appears at top of panel; all tags look active by default
- [ ] Left-click one tag → only comments with that tag remain
- [ ] Right-click another tag → multi-select filter updates without exclusive reset
- [ ] Click **Show all** → full list returns
- [ ] As a viewer, confirm “Add tag” is not available
- [ ] `bun test src/lib/commentTags.test.ts`
- [ ] `bunx vitest run convex/commentTags.vitest.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped comment feature with role checks on mutations; optional schema field needs no migration. Filter is client-only and does not change auth beyond existing video access rules.
> 
> **Overview**
> Adds **optional free-form tags** on video comments so teams can label and filter feedback in the discussion panel.
> 
> **Backend:** Comments gain optional `tags: string[]` (no backfill). `normalizeCommentTags` enforces trim, dedupe, and limits (8 tags, 32 chars). `comments.setTags` and optional tags on `comments.create` are allowed for **member+** roles; viewers’ tag input on create is ignored. Public threaded payloads include tags for display.
> 
> **UI:** Editors (`canTag` tied to `canEdit` on the video page) add/remove tags from the comment menu and see tag chips on each comment. A **tag filter bar** lists unique tags—left-click exclusive filter, right-click multi-toggle, plus **Show all**. Client logic lives in `commentTags` helpers with unit and Convex vitest coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4681067b242db767b3a3cf33b82d427f94314e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add comment tags with filtering and role-gated management UI
> - Adds an optional `tags` array to the comments schema in [convex/schema.ts](https://github.com/pingdotgg/lawn/pull/57/files#diff-00e6e27e65e72a0fd4a73f6942f41e1cf3f476a59f263513f3f47fdf801a0eb1) and exposes tags in public comment payloads.
> - Adds `comments.setTags` mutation and tag support in `comments.create`; tags are normalized (trimmed, deduplicated case-insensitively, length/count capped) via `normalizeCommentTags`. Only members, admins, and owners can set tags; viewers' tags are silently ignored.
> - Adds tag badge UI to [CommentItem.tsx](https://github.com/pingdotgg/lawn/pull/57/files#diff-b5918b745d876a582a1d0fb65657690baf7bce17ab649e0037aedd03461579ed) for adding/removing tags, with inline input, error feedback, and a dropdown action gated on the new `canTag` prop.
> - Adds a [CommentTagFilter.tsx](https://github.com/pingdotgg/lawn/pull/57/files#diff-91998e0d341e3b52aae47a273b3b6e4eda9f14903bdf0d30cf184bc622d131bd) toolbar to [CommentList.tsx](https://github.com/pingdotgg/lawn/pull/57/files#diff-d2076decc108172cb4f6b910851b7c9153675cd301cbbd961d342fc9f7f493d5) supporting exclusive (left-click) and toggle (right-click) tag filtering, with an empty-state message when no comments match.
> - Risk: tags field is optional with no backfill, so existing comment documents without the field are treated as untagged throughout the filtering logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d468106.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tags to video comments for easier triage and organization.
  - Authorized editors can add, remove, and manage comment tags.
  - Added tag-based filtering, including single- and multi-tag selection.
  - Tags are visible in public comment threads when available.

- **Bug Fixes**
  - Tag input is automatically trimmed, deduplicated, and limited to supported sizes.
  - Users without editing access cannot add or change tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->