### PR TITLE
feat: per-team branded share subdomains on lawn.video

### DIFF
--- a/app/routes/-share.data.ts
+++ b/app/routes/-share.data.ts
@@ -1,33 +1,47 @@
 import { useQuery, type ConvexReactClient } from "convex/react";
 import { api } from "@convex/_generated/api";
 import { makeRouteQuerySpec, prewarmSpecs } from "@/lib/convexRouteData";
+import { getBrowserHostname } from "@/lib/shareHost";
 
-export function getShareEssentialSpecs(params: { token: string }) {
+export function getShareEssentialSpecs(params: { token: string; shareHost?: string | null }) {
   return [
     makeRouteQuerySpec(api.shareLinks.getByToken, {
       token: params.token,
+      shareHost: params.shareHost ?? undefined,
     }),
   ];
 }
 
 export function useShareData(params: { token: string; grantToken?: string | null }) {
+  const shareHost = getBrowserHostname() ?? undefined;
+
   const shareInfo = useQuery(api.shareLinks.getByToken, {
     token: params.token,
+    shareHost,
   });
 
   const videoData = useQuery(
     api.videos.getByShareGrant,
-    params.grantToken ? { grantToken: params.grantToken } : "skip",
+    params.grantToken ? { grantToken: params.grantToken, shareHost } : "skip",
   );
 
   const comments = useQuery(
     api.comments.getThreadedForShareGrant,
-    params.grantToken ? { grantToken: params.grantToken } : "skip",
+    params.grantToken ? { grantToken: params.grantToken, shareHost } : "skip",
   );
 
-  return { shareInfo, videoData, comments };
+  return { shareInfo, videoData, comments, shareHost };
 }
 
-export async function prewarmShare(convex: ConvexReactClient, params: { token: string }) {
-  prewarmSpecs(convex, getShareEssentialSpecs(params));
+export async function prewarmShare(
+  convex: ConvexReactClient,
+  params: { token: string; shareHost?: string | null },
+) {
+  prewarmSpecs(
+    convex,
+    getShareEssentialSpecs({
+      token: params.token,
+      shareHost: params.shareHost ?? getBrowserHostname(),
+    }),
+  );
 }

--- a/app/routes/-share.tsx
+++ b/app/routes/-share.tsx
@@ -50,7 +50,7 @@ export default function SharePage() {
     setDownloadError(null);
   }, [token]);
 
-  const { shareInfo, videoData, comments } = useShareData({ token, grantToken });
+  const { shareInfo, videoData, comments, shareHost } = useShareData({ token, grantToken });
   const canTrackPresence = Boolean(playbackSession?.url && videoData?.video?._id);
   const { watchers } = useVideoPresence({
     videoId: videoData?.video?._id,
@@ -70,7 +70,7 @@ export default function SharePage() {
       setPasswordError(false);
 
       try {
-        const result = await issueAccessGrant({ token, password });
+        const result = await issueAccessGrant({ token, password, shareHost });
         if (result.ok && result.grantToken) {
           setGrantToken(result.grantToken);
           return true;
@@ -85,7 +85,7 @@ export default function SharePage() {
         setIsRequestingGrant(false);
       }
     },
-    [isRequestingGrant, issueAccessGrant, token],
+    [isRequestingGrant, issueAccessGrant, shareHost, token],
   );
 
   useEffect(() => {
@@ -107,7 +107,7 @@ export default function SharePage() {
     setIsLoadingPlayback(true);
     setPlaybackError(null);
 
-    void getPlaybackSession({ grantToken })
+    void getPlaybackSession({ grantToken, shareHost })
       .then((session) => {
         if (cancelled) return;
         setPlaybackSession(session);
@@ -124,7 +124,7 @@ export default function SharePage() {
     return () => {
       cancelled = true;
     };
-  }, [getPlaybackSession, grantToken]);
+  }, [getPlaybackSession, grantToken, shareHost]);
 
   const flattenedComments = useMemo(() => {
     if (!comments) return [] as Array<{ _id: string; timestampSeconds: number; resolved: boolean }>;
@@ -158,6 +158,7 @@ export default function SharePage() {
         grantToken,
         text: commentText.trim(),
         timestampSeconds: currentTime,
+        shareHost,
       });
       setCommentText("");
     } catch {
@@ -173,7 +174,7 @@ export default function SharePage() {
     setDownloadError(null);
     setIsDownloading(true);
     try {
-      const result = await getDownloadUrl({ grantToken });
+      const result = await getDownloadUrl({ grantToken, shareHost });
       triggerDownload(result.url, result.filename);
     } catch (error) {
       console.error("Failed to prepare shared download:", error);
@@ -183,7 +184,7 @@ export default function SharePage() {
     } finally {
       setIsDownloading(false);
     }
-  }, [getDownloadUrl, grantToken, isDownloading]);
+  }, [getDownloadUrl, grantToken, isDownloading, shareHost]);
 
   const isBootstrappingShare =
     shareInfo === undefined ||

--- a/app/routes/-watch.data.ts
+++ b/app/routes/-watch.data.ts
@@ -1,37 +1,56 @@
 import { useQuery, type ConvexReactClient } from "convex/react";
 import { api } from "@convex/_generated/api";
 import { makeRouteQuerySpec, prewarmSpecs } from "@/lib/convexRouteData";
+import { getBrowserHostname } from "@/lib/shareHost";
 
-export function getWatchEssentialSpecs(params: { publicId: string }) {
+export function getWatchEssentialSpecs(params: { publicId: string; shareHost?: string | null }) {
+  const shareHost = params.shareHost ?? undefined;
   return [
     makeRouteQuerySpec(api.videos.getByPublicId, {
       publicId: params.publicId,
+      shareHost,
     }),
     makeRouteQuerySpec(api.videos.listPublicVersions, {
       publicId: params.publicId,
+      shareHost,
     }),
     makeRouteQuerySpec(api.comments.getThreadedForPublic, {
       publicId: params.publicId,
+      shareHost,
     }),
   ];
 }
 
 export function useWatchData(params: { publicId: string }) {
+  const shareHost = getBrowserHostname() ?? undefined;
+
   const videoData = useQuery(api.videos.getByPublicId, {
     publicId: params.publicId,
+    shareHost,
   });
 
   const versions = useQuery(api.videos.listPublicVersions, {
     publicId: params.publicId,
+    shareHost,
   });
 
   const comments = useQuery(api.comments.getThreadedForPublic, {
     publicId: params.publicId,
+    shareHost,
   });
 
-  return { videoData, versions, comments };
+  return { videoData, versions, comments, shareHost };
 }
 
-export async function prewarmWatch(convex: ConvexReactClient, params: { publicId: string }) {
-  prewarmSpecs(convex, getWatchEssentialSpecs(params));
+export async function prewarmWatch(
+  convex: ConvexReactClient,
+  params: { publicId: string; shareHost?: string | null },
+) {
+  prewarmSpecs(
+    convex,
+    getWatchEssentialSpecs({
+      publicId: params.publicId,
+      shareHost: params.shareHost ?? getBrowserHostname(),
+    }),
+  );
 }

--- a/app/routes/-watch.tsx
+++ b/app/routes/-watch.tsx
@@ -43,7 +43,7 @@ export default function WatchPage() {
   const getPlaybackSession = useAction(api.videoActions.getPublicPlaybackSession);
   const getDownloadUrl = useAction(api.videoActions.getPublicDownloadUrl);
 
-  const { videoData, versions, comments } = useWatchData({ publicId });
+  const { videoData, versions, comments, shareHost } = useWatchData({ publicId });
   const [playbackSession, setPlaybackSession] = useState<{
     url: string;
     posterUrl: string;
@@ -70,7 +70,7 @@ export default function WatchPage() {
     setIsLoadingPlayback(true);
     setPlaybackError(null);
 
-    void getPlaybackSession({ publicId })
+    void getPlaybackSession({ publicId, shareHost })
       .then((session) => {
         if (cancelled) return;
         setPlaybackSession(session);
@@ -87,7 +87,7 @@ export default function WatchPage() {
     return () => {
       cancelled = true;
     };
-  }, [getPlaybackSession, publicId, videoData?.video?.muxPlaybackId]);
+  }, [getPlaybackSession, publicId, shareHost, videoData?.video?.muxPlaybackId]);
 
   useEffect(() => {
     setIsDownloading(false);
@@ -126,6 +126,7 @@ export default function WatchPage() {
         publicId,
         text: commentText.trim(),
         timestampSeconds: currentTime,
+        shareHost,
       });
       setCommentText("");
     } catch {
@@ -141,7 +142,7 @@ export default function WatchPage() {
     setDownloadError(null);
     setIsDownloading(true);
     try {
-      const result = await getDownloadUrl({ publicId });
+      const result = await getDownloadUrl({ publicId, shareHost });
       triggerDownload(result.url, result.filename);
     } catch (error) {
       console.error("Failed to prepare public download:", error);
@@ -151,7 +152,7 @@ export default function WatchPage() {
     } finally {
       setIsDownloading(false);
     }
-  }, [getDownloadUrl, isDownloading, publicId]);
+  }, [getDownloadUrl, isDownloading, publicId, shareHost]);
 
   if (videoData === undefined) {
     return (

--- a/app/routes/dashboard/-project.tsx
+++ b/app/routes/dashboard/-project.tsx
@@ -38,8 +38,9 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Id } from "@convex/_generated/dataModel";
 import { cn } from "@/lib/utils";
-import { projectPath, teamHomePath, videoPath, watchPath } from "@/lib/routes";
+import { projectPath, teamHomePath, videoPath } from "@/lib/routes";
 import { copyTextToClipboard } from "@/lib/clipboard";
+import { publicWatchUrl } from "@/lib/shareHost";
 import { ProjectCard } from "@/components/projects/ProjectCard";
 import { MoveProjectDialog } from "@/components/projects/MoveProjectDialog";
 import { MoveVideoDialog } from "@/components/videos/MoveVideoDialog";
@@ -338,11 +339,13 @@ export default function ProjectPage({
       setSharePending(true);
       setShareToast(null);
       const requestEpoch = shareRequestEpochRef.current.next();
-      const publicWatchPath =
-        video.visibility === "public" && video.publicId ? watchPath(video.publicId) : null;
-      const path = publicWatchPath ?? videoPath(resolvedTeamSlug, projectId, video._id);
+      const publicUrl =
+        video.visibility === "public" && video.publicId
+          ? publicWatchUrl(resolvedTeamSlug, video.publicId)
+          : null;
+      const privatePath = videoPath(resolvedTeamSlug, projectId, video._id);
       const origin = typeof window !== "undefined" ? window.location.origin : "";
-      const url = `${origin}${path}`;
+      const url = publicUrl ?? `${origin}${privatePath}`;
 
       try {
         const copied = await copyTextToClipboard(url);
@@ -356,7 +359,7 @@ export default function ProjectPage({
         showShareToast(
           {
             tone: "success",
-            message: publicWatchPath ? "Share link copied" : "Private dashboard link copied",
+            message: publicUrl ? "Share link copied" : "Private dashboard link copied",
           },
           true,
         );

--- a/convex/comments.ts
+++ b/convex/comments.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import { mutation, query, MutationCtx, QueryCtx } from "./_generated/server";
 import { identityAvatarUrl, identityName, requireVideoAccess, requireUser } from "./auth";
 import { resolveActiveShareGrant } from "./shareAccess";
+import { videoMatchesShareHost } from "./shareHost";
 import { resolvePublicVideo } from "./videos";
 
 function toThreadedComments<
@@ -97,12 +98,17 @@ export const createForPublic = mutation({
     text: v.string(),
     timestampSeconds: v.number(),
     parentId: v.optional(v.id("comments")),
+    shareHost: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const user = await requireUser(ctx);
     const video = await getPublicVideoByPublicId(ctx, args.publicId);
 
     if (!video) {
+      throw new Error("Video not found");
+    }
+
+    if (!(await videoMatchesShareHost(ctx, video._id, args.shareHost))) {
       throw new Error("Video not found");
     }
 
@@ -132,6 +138,7 @@ export const createForShareGrant = mutation({
     text: v.string(),
     timestampSeconds: v.number(),
     parentId: v.optional(v.id("comments")),
+    shareHost: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const user = await requireUser(ctx);
@@ -143,6 +150,10 @@ export const createForShareGrant = mutation({
 
     const video = await ctx.db.get(resolved.shareLink.videoId);
     if (!video || video.status !== "ready") {
+      throw new Error("Video not found");
+    }
+
+    if (!(await videoMatchesShareHost(ctx, video._id, args.shareHost))) {
       throw new Error("Video not found");
     }
 
@@ -237,10 +248,17 @@ export const getThreaded = query({
 });
 
 export const getThreadedForPublic = query({
-  args: { publicId: v.string() },
+  args: {
+    publicId: v.string(),
+    shareHost: v.optional(v.string()),
+  },
   handler: async (ctx, args) => {
     const video = await getPublicVideoByPublicId(ctx, args.publicId);
     if (!video) {
+      return [];
+    }
+
+    if (!(await videoMatchesShareHost(ctx, video._id, args.shareHost))) {
       return [];
     }
 
@@ -254,7 +272,10 @@ export const getThreadedForPublic = query({
 });
 
 export const getThreadedForShareGrant = query({
-  args: { grantToken: v.string() },
+  args: {
+    grantToken: v.string(),
+    shareHost: v.optional(v.string()),
+  },
   handler: async (ctx, args) => {
     const resolved = await resolveActiveShareGrant(ctx, args.grantToken);
     if (!resolved) {
@@ -263,6 +284,10 @@ export const getThreadedForShareGrant = query({
 
     const video = await ctx.db.get(resolved.shareLink.videoId);
     if (!video || video.status !== "ready") {
+      return [];
+    }
+
+    if (!(await videoMatchesShareHost(ctx, video._id, args.shareHost))) {
       return [];
     }
 

--- a/convex/shareHost.ts
+++ b/convex/shareHost.ts
@@ -1,0 +1,104 @@
+import type { Id } from "./_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "./_generated/server";
+
+/** Apex domain used for branded team share hosts. Keep in sync with src/lib/shareHost.ts. */
+export const SHARE_ROOT_DOMAIN = "lawn.video";
+
+/**
+ * Subdomains reserved for app infrastructure. Keep in sync with src/lib/shareHost.ts.
+ */
+export const RESERVED_SHARE_SUBDOMAINS = new Set([
+  "www",
+  "app",
+  "api",
+  "clerk",
+  "cdn",
+  "static",
+  "assets",
+  "mail",
+  "email",
+  "admin",
+  "dashboard",
+  "status",
+  "docs",
+  "help",
+  "support",
+  "blog",
+  "dev",
+  "staging",
+  "preview",
+  "test",
+  "beta",
+  "alpha",
+  "m",
+  "stream",
+  "image",
+  "media",
+  "upload",
+  "uploads",
+  "auth",
+  "accounts",
+  "billing",
+  "webhook",
+  "webhooks",
+  "convex",
+]);
+
+function normalizeHostname(hostname: string): string {
+  return hostname.trim().toLowerCase().split(":")[0] ?? "";
+}
+
+/**
+ * Extract the team share subdomain from a request host.
+ * Returns null for apex lawn.video, non-lawn hosts, multi-level subs, or reserved names.
+ * When null, host isolation is not applied (legacy apex / local / preview links).
+ */
+export function parseTeamShareSubdomain(hostname: string | null | undefined): string | null {
+  if (!hostname) return null;
+  const host = normalizeHostname(hostname);
+  if (host === SHARE_ROOT_DOMAIN) return null;
+
+  const suffix = `.${SHARE_ROOT_DOMAIN}`;
+  if (!host.endsWith(suffix)) return null;
+
+  const sub = host.slice(0, -suffix.length);
+  if (!sub || sub.includes(".")) return null;
+  if (RESERVED_SHARE_SUBDOMAINS.has(sub)) return null;
+  return sub;
+}
+
+export function isReservedShareSubdomain(slug: string): boolean {
+  return RESERVED_SHARE_SUBDOMAINS.has(slug.trim().toLowerCase());
+}
+
+type DbCtx = Pick<QueryCtx, "db"> | Pick<MutationCtx, "db">;
+
+/** Resolve the owning team's slug for a video, or null if the chain is broken. */
+export async function getTeamSlugForVideo(
+  ctx: DbCtx,
+  videoId: Id<"videos">,
+): Promise<string | null> {
+  const video = await ctx.db.get(videoId);
+  if (!video) return null;
+  const project = await ctx.db.get(video.projectId);
+  if (!project) return null;
+  const team = await ctx.db.get(project.teamId);
+  return team?.slug ?? null;
+}
+
+/**
+ * When the request host is a team share subdomain, require the video's team
+ * slug to match. Apex / non-lawn hosts skip isolation so existing links keep
+ * working.
+ */
+export async function videoMatchesShareHost(
+  ctx: DbCtx,
+  videoId: Id<"videos">,
+  shareHost: string | null | undefined,
+): Promise<boolean> {
+  const expectedSlug = parseTeamShareSubdomain(shareHost);
+  if (!expectedSlug) return true;
+
+  const teamSlug = await getTeamSlugForVideo(ctx, videoId);
+  return teamSlug === expectedSlug;
+}

--- a/convex/shareHost.vitest.ts
+++ b/convex/shareHost.vitest.ts
@@ -1,0 +1,134 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { expect, test } from "vitest";
+import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
+import { api } from "./_generated/api";
+import schema from "./schema";
+import { parseTeamShareSubdomain } from "./shareHost";
+
+const modules = import.meta.glob("./**/*.ts");
+
+async function seedTeams() {
+  const t = convexTest(schema, modules);
+  registerRateLimiter(t);
+  const seeded = await t.run(async (ctx) => {
+    const acmeId = await ctx.db.insert("teams", {
+      name: "Acme",
+      slug: "acme",
+      ownerClerkId: "user_acme",
+      plan: "basic",
+    });
+    const otherId = await ctx.db.insert("teams", {
+      name: "Other Corp",
+      slug: "othercorp",
+      ownerClerkId: "user_other",
+      plan: "basic",
+    });
+    await ctx.db.insert("teamMembers", {
+      teamId: acmeId,
+      userClerkId: "user_acme",
+      userEmail: "acme@example.com",
+      userName: "Acme Owner",
+      role: "owner",
+    });
+    const acmeProject = await ctx.db.insert("projects", {
+      teamId: acmeId,
+      name: "Acme Project",
+    });
+    await ctx.db.insert("projects", {
+      teamId: otherId,
+      name: "Other Project",
+    });
+    const acmeVideo = await ctx.db.insert("videos", {
+      projectId: acmeProject,
+      uploadedByClerkId: "user_acme",
+      uploaderName: "Acme Owner",
+      title: "Acme Cut",
+      visibility: "public",
+      publicId: "acme-public",
+      status: "ready",
+      muxPlaybackId: "playback-acme",
+      workflowStatus: "review",
+    });
+    await ctx.db.insert("shareLinks", {
+      videoId: acmeVideo,
+      token: "acme-share-token",
+      createdByClerkId: "user_acme",
+      createdByName: "Acme Owner",
+      allowDownload: false,
+      viewCount: 0,
+    });
+    return { acmeId, otherId, acmeVideo };
+  });
+  return { t, ...seeded };
+}
+
+test("parseTeamShareSubdomain only accepts single-level team hosts", () => {
+  expect(parseTeamShareSubdomain("acme.lawn.video")).toBe("acme");
+  expect(parseTeamShareSubdomain("lawn.video")).toBeNull();
+  expect(parseTeamShareSubdomain("www.lawn.video")).toBeNull();
+  expect(parseTeamShareSubdomain("localhost")).toBeNull();
+});
+
+test("public watch rejects mismatched team subdomains", async () => {
+  const { t } = await seedTeams();
+
+  const onAcme = await t.query(api.videos.getByPublicId, {
+    publicId: "acme-public",
+    shareHost: "acme.lawn.video",
+  });
+  expect(onAcme?.video?.publicId).toBe("acme-public");
+
+  const onWrong = await t.query(api.videos.getByPublicId, {
+    publicId: "acme-public",
+    shareHost: "othercorp.lawn.video",
+  });
+  expect(onWrong).toBeNull();
+
+  // Apex keeps working for legacy links.
+  const onApex = await t.query(api.videos.getByPublicId, {
+    publicId: "acme-public",
+    shareHost: "lawn.video",
+  });
+  expect(onApex?.video?.publicId).toBe("acme-public");
+});
+
+test("restricted share rejects mismatched team subdomains", async () => {
+  const { t } = await seedTeams();
+
+  const ok = await t.query(api.shareLinks.getByToken, {
+    token: "acme-share-token",
+    shareHost: "acme.lawn.video",
+  });
+  expect(ok.status).toBe("ok");
+
+  const wrong = await t.query(api.shareLinks.getByToken, {
+    token: "acme-share-token",
+    shareHost: "othercorp.lawn.video",
+  });
+  expect(wrong.status).toBe("missing");
+
+  const apex = await t.query(api.shareLinks.getByToken, {
+    token: "acme-share-token",
+    shareHost: "lawn.video",
+  });
+  expect(apex.status).toBe("ok");
+});
+
+test("issueAccessGrant fails on wrong team host", async () => {
+  const { t } = await seedTeams();
+
+  const wrong = await t.mutation(api.shareLinks.issueAccessGrant, {
+    token: "acme-share-token",
+    shareHost: "othercorp.lawn.video",
+  });
+  expect(wrong).toEqual({ ok: false, grantToken: null });
+
+  const ok = await t.mutation(api.shareLinks.issueAccessGrant, {
+    token: "acme-share-token",
+    shareHost: "acme.lawn.video",
+  });
+  expect(ok.ok).toBe(true);
+  expect(ok.grantToken).toBeTruthy();
+});

--- a/convex/shareLinks.ts
+++ b/convex/shareLinks.ts
@@ -6,6 +6,7 @@ import { mutation, query, MutationCtx } from "./_generated/server";
 import { identityName, requireVideoAccess } from "./auth";
 import { generateUniqueToken, hashPassword, verifyPassword } from "./security";
 import { findShareLinkByToken, issueShareAccessGrant } from "./shareAccess";
+import { videoMatchesShareHost } from "./shareHost";
 
 const shareLinkStatusValidator = v.union(
   v.literal("missing"),
@@ -196,7 +197,11 @@ export const update = mutation({
 });
 
 export const getByToken = query({
-  args: { token: v.string() },
+  args: {
+    token: v.string(),
+    /** Request hostname for team subdomain isolation (optional). */
+    shareHost: v.optional(v.string()),
+  },
   returns: v.object({
     status: shareLinkStatusValidator,
   }),
@@ -216,6 +221,10 @@ export const getByToken = query({
       return { status: "missing" as const };
     }
 
+    if (!(await videoMatchesShareHost(ctx, link.videoId, args.shareHost))) {
+      return { status: "missing" as const };
+    }
+
     if (hasPasswordProtection(link)) {
       return { status: "requiresPassword" as const };
     }
@@ -228,6 +237,7 @@ export const issueAccessGrant = mutation({
   args: {
     token: v.string(),
     password: v.optional(v.string()),
+    shareHost: v.optional(v.string()),
   },
   returns: v.object({
     ok: v.boolean(),
@@ -260,6 +270,10 @@ export const issueAccessGrant = mutation({
 
     const video = await ctx.db.get(link.videoId);
     if (!video || video.status !== "ready") {
+      return { ok: false, grantToken: null };
+    }
+
+    if (!(await videoMatchesShareHost(ctx, link.videoId, args.shareHost))) {
       return { ok: false, grantToken: null };
     }
 

--- a/convex/teams.ts
+++ b/convex/teams.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { internalMutation, mutation, query } from "./_generated/server";
+import { internalMutation, mutation, query, type MutationCtx } from "./_generated/server";
 import {
   getUser,
   identityAvatarUrl,
@@ -9,6 +9,7 @@ import {
   requireTeamAccess,
 } from "./auth";
 import { getTeamSubscriptionState } from "./billingHelpers";
+import { isReservedShareSubdomain } from "./shareHost";
 import { deleteVideoAndDependents } from "./videos";
 
 function normalizedEmail(value: string) {
@@ -32,6 +33,27 @@ function generateToken(): string {
   return result;
 }
 
+/** Team slugs double as share subdomains; keep them unique and non-reserved. */
+async function allocateUniqueTeamSlug(ctx: MutationCtx, baseName: string): Promise<string> {
+  const base = generateSlug(baseName) || "team";
+  let slug = base;
+  let counter = 1;
+
+  while (true) {
+    if (!isReservedShareSubdomain(slug)) {
+      const existingWithSlug = await ctx.db
+        .query("teams")
+        .withIndex("by_slug", (q) => q.eq("slug", slug))
+        .unique();
+      if (!existingWithSlug) {
+        return slug;
+      }
+    }
+    slug = `${base}-${counter}`;
+    counter++;
+  }
+}
+
 export const create = mutation({
   args: {
     name: v.string(),
@@ -39,21 +61,7 @@ export const create = mutation({
   handler: async (ctx, args) => {
     const user = await requireUser(ctx);
 
-    let slug = generateSlug(args.name);
-    let existingWithSlug = await ctx.db
-      .query("teams")
-      .withIndex("by_slug", (q) => q.eq("slug", slug))
-      .unique();
-
-    let counter = 1;
-    while (existingWithSlug) {
-      slug = `${generateSlug(args.name)}-${counter}`;
-      existingWithSlug = await ctx.db
-        .query("teams")
-        .withIndex("by_slug", (q) => q.eq("slug", slug))
-        .unique();
-      counter++;
-    }
+    const slug = await allocateUniqueTeamSlug(ctx, args.name);
 
     const teamId = await ctx.db.insert("teams", {
       name: args.name,

--- a/convex/videoActions.ts
+++ b/convex/videoActions.ts
@@ -1114,7 +1114,10 @@ export const getOriginalPlaybackUrl = action({
 });
 
 export const getPublicPlaybackSession = action({
-  args: { publicId: v.string() },
+  args: {
+    publicId: v.string(),
+    shareHost: v.optional(v.string()),
+  },
   returns: v.object({
     url: v.string(),
     posterUrl: v.string(),
@@ -1122,6 +1125,7 @@ export const getPublicPlaybackSession = action({
   handler: async (ctx, args): Promise<{ url: string; posterUrl: string }> => {
     const result = await ctx.runQuery(api.videos.getByPublicId, {
       publicId: args.publicId,
+      shareHost: args.shareHost,
     });
 
     if (!result?.video?.muxPlaybackId) {
@@ -1138,7 +1142,10 @@ export const getPublicPlaybackSession = action({
 });
 
 export const getSharedPlaybackSession = action({
-  args: { grantToken: v.string() },
+  args: {
+    grantToken: v.string(),
+    shareHost: v.optional(v.string()),
+  },
   returns: v.object({
     url: v.string(),
     posterUrl: v.string(),
@@ -1146,6 +1153,7 @@ export const getSharedPlaybackSession = action({
   handler: async (ctx, args): Promise<{ url: string; posterUrl: string }> => {
     const result = await ctx.runQuery(api.videos.getByShareGrant, {
       grantToken: args.grantToken,
+      shareHost: args.shareHost,
     });
 
     if (!result?.video?.muxPlaybackId) {
@@ -1193,7 +1201,10 @@ export const getDownloadUrl = action({
 });
 
 export const getPublicDownloadUrl = action({
-  args: { publicId: v.string() },
+  args: {
+    publicId: v.string(),
+    shareHost: v.optional(v.string()),
+  },
   returns: v.object({
     url: v.string(),
     filename: v.string(),
@@ -1201,6 +1212,7 @@ export const getPublicDownloadUrl = action({
   handler: async (ctx, args): Promise<{ url: string; filename: string }> => {
     const result = await ctx.runQuery(api.videos.getByPublicIdForDownload, {
       publicId: args.publicId,
+      shareHost: args.shareHost,
     });
 
     if (!result?.video) {
@@ -1224,7 +1236,10 @@ export const getPublicDownloadUrl = action({
 });
 
 export const getSharedDownloadUrl = action({
-  args: { grantToken: v.string() },
+  args: {
+    grantToken: v.string(),
+    shareHost: v.optional(v.string()),
+  },
   returns: v.object({
     url: v.string(),
     filename: v.string(),
@@ -1232,6 +1247,7 @@ export const getSharedDownloadUrl = action({
   handler: async (ctx, args): Promise<{ url: string; filename: string }> => {
     const result = await ctx.runQuery(api.videos.getByShareGrantForDownload, {
       grantToken: args.grantToken,
+      shareHost: args.shareHost,
     });
 
     if (!result?.video) {

--- a/convex/videos.ts
+++ b/convex/videos.ts
@@ -13,6 +13,7 @@ import { identityName, requireProjectAccess, requireVideoAccess } from "./auth";
 import { Doc, Id } from "./_generated/dataModel";
 import { generateUniqueToken } from "./security";
 import { resolveActiveShareGrant } from "./shareAccess";
+import { videoMatchesShareHost } from "./shareHost";
 import { assertTeamCanStoreBytes, assertTeamHasActiveSubscription } from "./billingHelpers";
 import { assertVideoFileSizeAllowed } from "./uploadLimits";
 
@@ -595,7 +596,8 @@ export const list = query({
 export const get = query({
   args: { videoId: v.id("videos") },
   handler: async (ctx, args) => {
-    const { video, membership } = await requireVideoAccess(ctx, args.videoId);
+    const { video, membership, project } = await requireVideoAccess(ctx, args.videoId);
+    const team = await ctx.db.get(project.teamId);
     return {
       ...video,
       uploaderName: video.uploaderName ?? "Unknown",
@@ -603,6 +605,8 @@ export const get = query({
       versionNumber: normalizeVersionNumber(video),
       isLatestVersion: video.supersededByVideoId === undefined,
       role: membership.role,
+      // Share/watch URLs use the team slug as the branded lawn.video subdomain.
+      teamSlug: team?.slug ?? null,
     };
   },
 });
@@ -629,7 +633,7 @@ export const listVersions = query({
 
 type PublicWatchResolution =
   | { state: "ready"; video: Doc<"videos">; allowVersionBrowsing: boolean }
-  | { state: "processing"; title: string }
+  | { state: "processing"; title: string; videoId: Id<"videos"> }
   | { state: "unavailable" };
 
 // Version browsing is on unless explicitly disabled, so existing public videos
@@ -725,7 +729,7 @@ async function resolvePublicWatch(
       (candidate.status === "uploading" || candidate.status === "processing"),
   );
   if (hasInflightVersion) {
-    return { state: "processing", title: matched.title };
+    return { state: "processing", title: matched.title, videoId: matched._id };
   }
 
   return { state: "unavailable" };
@@ -745,7 +749,11 @@ export async function resolvePublicVideo(
 }
 
 export const getByPublicId = query({
-  args: { publicId: v.string() },
+  args: {
+    publicId: v.string(),
+    /** Request hostname for team subdomain isolation (optional). */
+    shareHost: v.optional(v.string()),
+  },
   handler: async (ctx, args) => {
     const resolution = await resolvePublicWatch(ctx, args.publicId);
 
@@ -754,10 +762,17 @@ export const getByPublicId = query({
     }
 
     if (resolution.state === "processing") {
+      if (!(await videoMatchesShareHost(ctx, resolution.videoId, args.shareHost))) {
+        return null;
+      }
       return { processing: true as const, title: resolution.title, video: null };
     }
 
     const video = resolution.video;
+    if (!(await videoMatchesShareHost(ctx, video._id, args.shareHost))) {
+      return null;
+    }
+
     return {
       processing: false as const,
       title: video.title,
@@ -785,7 +800,10 @@ export const getByPublicId = query({
  * list when the video is private or the owner disabled version browsing.
  */
 export const listPublicVersions = query({
-  args: { publicId: v.string() },
+  args: {
+    publicId: v.string(),
+    shareHost: v.optional(v.string()),
+  },
   returns: v.array(
     v.object({
       publicId: v.string(),
@@ -803,6 +821,10 @@ export const listPublicVersions = query({
       return [];
     }
 
+    if (!(await videoMatchesShareHost(ctx, matched._id, args.shareHost))) {
+      return [];
+    }
+
     const stackVersions = await readStackVersions(ctx, matched);
     return stackVersions.filter(isPublicReadyVersion).map((version) => ({
       publicId: version.publicId,
@@ -813,10 +835,17 @@ export const listPublicVersions = query({
 });
 
 export const getByPublicIdForDownload = query({
-  args: { publicId: v.string() },
+  args: {
+    publicId: v.string(),
+    shareHost: v.optional(v.string()),
+  },
   handler: async (ctx, args) => {
     const video = await resolvePublicVideo(ctx, args.publicId);
     if (!video) {
+      return null;
+    }
+
+    if (!(await videoMatchesShareHost(ctx, video._id, args.shareHost))) {
       return null;
     }
 
@@ -851,7 +880,10 @@ export const getPublicIdByVideoId = query({
 });
 
 export const getByShareGrant = query({
-  args: { grantToken: v.string() },
+  args: {
+    grantToken: v.string(),
+    shareHost: v.optional(v.string()),
+  },
   handler: async (ctx, args) => {
     const resolved = await resolveActiveShareGrant(ctx, args.grantToken);
     if (!resolved) {
@@ -860,6 +892,10 @@ export const getByShareGrant = query({
 
     const video = await ctx.db.get(resolved.shareLink.videoId);
     if (!video || video.status !== "ready") {
+      return null;
+    }
+
+    if (!(await videoMatchesShareHost(ctx, video._id, args.shareHost))) {
       return null;
     }
 
@@ -881,7 +917,10 @@ export const getByShareGrant = query({
 });
 
 export const getByShareGrantForDownload = query({
-  args: { grantToken: v.string() },
+  args: {
+    grantToken: v.string(),
+    shareHost: v.optional(v.string()),
+  },
   handler: async (ctx, args) => {
     const resolved = await resolveActiveShareGrant(ctx, args.grantToken);
     if (!resolved) {
@@ -890,6 +929,10 @@ export const getByShareGrantForDownload = query({
 
     const video = await ctx.db.get(resolved.shareLink.videoId);
     if (!video) {
+      return null;
+    }
+
+    if (!(await videoMatchesShareHost(ctx, video._id, args.shareHost))) {
       return null;
     }
 

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -24,7 +24,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { cn, formatRelativeTime } from "@/lib/utils";
 import { copyTextToClipboard } from "@/lib/clipboard";
-import { watchPath } from "@/lib/routes";
+import { displayShareUrl, publicWatchUrl, restrictedShareUrl } from "@/lib/shareHost";
 import { createRequestEpoch } from "@/lib/requestEpoch";
 
 interface ShareDialogProps {
@@ -193,7 +193,9 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
     }
   };
 
-  const copyLink = async (id: string, path: string) => {
+  const teamSlug = video?.teamSlug ?? null;
+
+  const copyAbsoluteUrl = async (id: string, url: string) => {
     const requestId = copySequenceRef.current + 1;
     copySequenceRef.current = requestId;
     if (copyTimeoutRef.current !== null) {
@@ -203,7 +205,6 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
     setCopiedId(null);
     setCopyStatus(null);
     setCopyFailureUrl(null);
-    const url = `${window.location.origin}${path}`;
     const copied = await copyTextToClipboard(url);
     if (requestId !== copySequenceRef.current || activeVideoIdRef.current !== videoId || !open) {
       return;
@@ -228,12 +229,12 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
   };
 
   const handleCopyLink = async (token: string) => {
-    await copyLink(token, `/share/${token}`);
+    await copyAbsoluteUrl(token, restrictedShareUrl(teamSlug, token));
   };
 
   const handleCopyPublicLink = async () => {
     if (!video?.publicId) return;
-    await copyLink("public", watchPath(video.publicId));
+    await copyAbsoluteUrl("public", publicWatchUrl(teamSlug, video.publicId));
   };
 
   const handleDeleteLink = async (linkId: Id<"shareLinks">) => {
@@ -255,7 +256,10 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
     }
   };
 
-  const publicWatchPath = video?.publicId ? watchPath(video.publicId) : null;
+  const publicWatchAbsoluteUrl = video?.publicId ? publicWatchUrl(teamSlug, video.publicId) : null;
+  const publicWatchDisplay = publicWatchAbsoluteUrl
+    ? displayShareUrl(publicWatchAbsoluteUrl)
+    : null;
 
   return (
     <Dialog open={open} onOpenChange={handleDialogOpenChange}>
@@ -335,10 +339,10 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
         {/* Public URL + version browsing */}
         {video?.visibility === "public" ? (
           <div className="space-y-3">
-            {publicWatchPath ? (
+            {publicWatchAbsoluteUrl && publicWatchDisplay ? (
               <div className="flex items-center gap-2">
                 <code className="min-w-0 flex-1 truncate border-2 border-[#1a1a1a] bg-[#e8e8e0] px-3 py-2 font-mono text-sm">
-                  {publicWatchPath}
+                  {publicWatchDisplay}
                 </code>
                 <Button
                   variant="outline"
@@ -355,7 +359,7 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
                 <Button
                   variant="outline"
                   size="icon"
-                  onClick={() => window.open(publicWatchPath, "_blank")}
+                  onClick={() => window.open(publicWatchAbsoluteUrl, "_blank")}
                   aria-label="Open public URL"
                 >
                   <ExternalLink className="h-4 w-4" />
@@ -474,67 +478,70 @@ export function ShareDialog({ videoId, open, onOpenChange }: ShareDialogProps) {
             <p className="text-sm text-[#888]">No share links yet</p>
           ) : (
             <div className="max-h-64 divide-y-2 divide-[#1a1a1a] overflow-y-auto border-2 border-[#1a1a1a]">
-              {shareLinks.map((link) => (
-                <div key={link._id} className="flex items-center justify-between gap-2 p-3">
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <code className="max-w-[200px] truncate bg-[#e8e8e0] px-2 py-0.5 font-mono text-sm">
-                        /share/{link.token}
-                      </code>
-                      {link.isExpired ? <Badge variant="destructive">Expired</Badge> : null}
-                    </div>
-                    <div className="mt-1 flex items-center gap-3 text-xs text-[#888]">
-                      <span className="flex items-center gap-1">
-                        <Eye className="h-3 w-3" />
-                        {link.viewCount} views
-                      </span>
-                      {link.hasPassword ? (
+              {shareLinks.map((link) => {
+                const linkUrl = restrictedShareUrl(teamSlug, link.token);
+                return (
+                  <div key={link._id} className="flex items-center justify-between gap-2 p-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <code className="max-w-[200px] truncate bg-[#e8e8e0] px-2 py-0.5 font-mono text-sm">
+                          {displayShareUrl(linkUrl)}
+                        </code>
+                        {link.isExpired ? <Badge variant="destructive">Expired</Badge> : null}
+                      </div>
+                      <div className="mt-1 flex items-center gap-3 text-xs text-[#888]">
                         <span className="flex items-center gap-1">
-                          <Lock className="h-3 w-3" />
-                          Protected
+                          <Eye className="h-3 w-3" />
+                          {link.viewCount} views
                         </span>
-                      ) : null}
-                      {link.expiresAt ? (
-                        <span>Expires {formatRelativeTime(link.expiresAt)}</span>
-                      ) : null}
+                        {link.hasPassword ? (
+                          <span className="flex items-center gap-1">
+                            <Lock className="h-3 w-3" />
+                            Protected
+                          </span>
+                        ) : null}
+                        {link.expiresAt ? (
+                          <span>Expires {formatRelativeTime(link.expiresAt)}</span>
+                        ) : null}
+                      </div>
                     </div>
-                  </div>
-                  <div className="flex shrink-0 items-center gap-1">
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => void handleCopyLink(link.token)}
-                      aria-label="Copy restricted link"
-                    >
-                      {copiedId === link.token ? (
-                        <Check className="h-4 w-4 text-[#2d5a2d]" />
-                      ) : (
-                        <Copy className="h-4 w-4" />
-                      )}
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => window.open(`/share/${link.token}`, "_blank")}
-                      aria-label="Open restricted link"
-                    >
-                      <ExternalLink className="h-4 w-4" />
-                    </Button>
-                    {canManageSharing ? (
+                    <div className="flex shrink-0 items-center gap-1">
                       <Button
                         variant="ghost"
                         size="icon"
-                        className="text-[#dc2626] hover:text-[#dc2626]"
-                        disabled={deletingLinkId !== null}
-                        onClick={() => void handleDeleteLink(link._id)}
-                        aria-label="Delete restricted link"
+                        onClick={() => void handleCopyLink(link.token)}
+                        aria-label="Copy restricted link"
                       >
-                        <Trash2 className="h-4 w-4" />
+                        {copiedId === link.token ? (
+                          <Check className="h-4 w-4 text-[#2d5a2d]" />
+                        ) : (
+                          <Copy className="h-4 w-4" />
+                        )}
                       </Button>
-                    ) : null}
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => window.open(linkUrl, "_blank")}
+                        aria-label="Open restricted link"
+                      >
+                        <ExternalLink className="h-4 w-4" />
+                      </Button>
+                      {canManageSharing ? (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="text-[#dc2626] hover:text-[#dc2626]"
+                          disabled={deletingLinkId !== null}
+                          onClick={() => void handleDeleteLink(link._id)}
+                          aria-label="Delete restricted link"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      ) : null}
+                    </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           )}
         </div>

--- a/src/lib/shareHost.test.ts
+++ b/src/lib/shareHost.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import {
+  displayShareUrl,
+  getTeamShareBaseUrl,
+  isReservedShareSubdomain,
+  isShareRootHost,
+  parseTeamShareSubdomain,
+  publicWatchUrl,
+  restrictedShareUrl,
+  teamShareOrigin,
+} from "./shareHost";
+
+describe("parseTeamShareSubdomain", () => {
+  test("extracts team subdomain from branded host", () => {
+    expect(parseTeamShareSubdomain("acme.lawn.video")).toBe("acme");
+    expect(parseTeamShareSubdomain("ACME.lawn.video")).toBe("acme");
+  });
+
+  test("returns null for apex and non-lawn hosts", () => {
+    expect(parseTeamShareSubdomain("lawn.video")).toBeNull();
+    expect(parseTeamShareSubdomain("localhost")).toBeNull();
+    expect(parseTeamShareSubdomain("lawn.video.evil.com")).toBeNull();
+    expect(parseTeamShareSubdomain("preview.vercel.app")).toBeNull();
+  });
+
+  test("rejects reserved and multi-level subdomains", () => {
+    expect(parseTeamShareSubdomain("www.lawn.video")).toBeNull();
+    expect(parseTeamShareSubdomain("clerk.lawn.video")).toBeNull();
+    expect(parseTeamShareSubdomain("a.b.lawn.video")).toBeNull();
+  });
+});
+
+describe("share URL generation", () => {
+  test("builds branded team origins", () => {
+    expect(teamShareOrigin("acme")).toBe("https://acme.lawn.video");
+  });
+
+  test("uses team subdomain on lawn.video hosts", () => {
+    expect(getTeamShareBaseUrl("acme", "https://lawn.video")).toBe("https://acme.lawn.video");
+    expect(getTeamShareBaseUrl("acme", "https://other.lawn.video")).toBe("https://acme.lawn.video");
+    expect(publicWatchUrl("acme", "vid123", "https://lawn.video")).toBe(
+      "https://acme.lawn.video/watch/vid123",
+    );
+    expect(restrictedShareUrl("acme", "tok", "https://lawn.video")).toBe(
+      "https://acme.lawn.video/share/tok",
+    );
+  });
+
+  test("falls back to current origin outside production", () => {
+    expect(getTeamShareBaseUrl("acme", "http://localhost:5296")).toBe("http://localhost:5296");
+    expect(publicWatchUrl("acme", "vid123", "http://localhost:5296")).toBe(
+      "http://localhost:5296/watch/vid123",
+    );
+  });
+
+  test("falls back when team slug is missing", () => {
+    expect(getTeamShareBaseUrl(null, "https://lawn.video")).toBe("https://lawn.video");
+  });
+
+  test("displayShareUrl strips protocol", () => {
+    expect(displayShareUrl("https://acme.lawn.video/watch/abc")).toBe("acme.lawn.video/watch/abc");
+  });
+});
+
+describe("reserved share subdomains", () => {
+  test("blocks infrastructure names", () => {
+    expect(isReservedShareSubdomain("www")).toBe(true);
+    expect(isReservedShareSubdomain("clerk")).toBe(true);
+    expect(isReservedShareSubdomain("acme")).toBe(false);
+  });
+
+  test("isShareRootHost recognizes lawn hosts", () => {
+    expect(isShareRootHost("lawn.video")).toBe(true);
+    expect(isShareRootHost("acme.lawn.video")).toBe(true);
+    expect(isShareRootHost("localhost")).toBe(false);
+  });
+});

--- a/src/lib/shareHost.ts
+++ b/src/lib/shareHost.ts
@@ -1,0 +1,146 @@
+/** Apex domain used for branded team share hosts. */
+export const SHARE_ROOT_DOMAIN = "lawn.video";
+
+/**
+ * Subdomains reserved for app infrastructure. Teams cannot claim these as
+ * share hosts (or as team slugs, which double as share subdomains).
+ */
+export const RESERVED_SHARE_SUBDOMAINS = new Set([
+  "www",
+  "app",
+  "api",
+  "clerk",
+  "cdn",
+  "static",
+  "assets",
+  "mail",
+  "email",
+  "admin",
+  "dashboard",
+  "status",
+  "docs",
+  "help",
+  "support",
+  "blog",
+  "dev",
+  "staging",
+  "preview",
+  "test",
+  "beta",
+  "alpha",
+  "m",
+  "stream",
+  "image",
+  "media",
+  "upload",
+  "uploads",
+  "auth",
+  "accounts",
+  "billing",
+  "webhook",
+  "webhooks",
+  "convex",
+]);
+
+function normalizeHostname(hostname: string): string {
+  return hostname.trim().toLowerCase().split(":")[0] ?? "";
+}
+
+/** True when the host is lawn.video or any *.lawn.video subdomain. */
+export function isShareRootHost(hostname: string | null | undefined): boolean {
+  if (!hostname) return false;
+  const host = normalizeHostname(hostname);
+  return host === SHARE_ROOT_DOMAIN || host.endsWith(`.${SHARE_ROOT_DOMAIN}`);
+}
+
+/**
+ * Extract the team share subdomain from a hostname.
+ * Returns null for apex, non-lawn hosts, multi-level subs, or reserved names.
+ */
+export function parseTeamShareSubdomain(hostname: string | null | undefined): string | null {
+  if (!hostname) return null;
+  const host = normalizeHostname(hostname);
+  if (host === SHARE_ROOT_DOMAIN) return null;
+
+  const suffix = `.${SHARE_ROOT_DOMAIN}`;
+  if (!host.endsWith(suffix)) return null;
+
+  const sub = host.slice(0, -suffix.length);
+  // Reject empty or multi-level (e.g. a.b.lawn.video).
+  if (!sub || sub.includes(".")) return null;
+  if (RESERVED_SHARE_SUBDOMAINS.has(sub)) return null;
+  return sub;
+}
+
+export function isReservedShareSubdomain(slug: string): boolean {
+  return RESERVED_SHARE_SUBDOMAINS.has(slug.trim().toLowerCase());
+}
+
+/** Canonical origin for a team's branded share host. */
+export function teamShareOrigin(teamSlug: string): string {
+  return `https://${teamSlug}.${SHARE_ROOT_DOMAIN}`;
+}
+
+/**
+ * Base URL for public watch / restricted share links.
+ *
+ * On lawn.video production hosts, always use the team subdomain so copied
+ * links are branded. On local/preview origins, fall back to the current
+ * origin so the share flow keeps working without wildcard DNS.
+ */
+export function getTeamShareBaseUrl(
+  teamSlug: string | null | undefined,
+  currentOrigin?: string,
+): string {
+  const origin =
+    currentOrigin ??
+    (typeof window !== "undefined" ? window.location.origin : `https://${SHARE_ROOT_DOMAIN}`);
+
+  if (!teamSlug) return origin;
+
+  try {
+    const url = new URL(origin);
+    if (isShareRootHost(url.hostname)) {
+      return teamShareOrigin(teamSlug);
+    }
+    return url.origin;
+  } catch {
+    return teamShareOrigin(teamSlug);
+  }
+}
+
+export function publicWatchUrl(
+  teamSlug: string | null | undefined,
+  publicId: string,
+  currentOrigin?: string,
+): string {
+  return `${getTeamShareBaseUrl(teamSlug, currentOrigin)}/watch/${publicId}`;
+}
+
+export function restrictedShareUrl(
+  teamSlug: string | null | undefined,
+  token: string,
+  currentOrigin?: string,
+): string {
+  return `${getTeamShareBaseUrl(teamSlug, currentOrigin)}/share/${token}`;
+}
+
+/** Display-friendly host+path for share UI (no protocol). */
+export function displayShareUrl(absoluteUrl: string): string {
+  try {
+    const url = new URL(absoluteUrl);
+    return `${url.host}${url.pathname}${url.search}`;
+  } catch {
+    return absoluteUrl;
+  }
+}
+
+export function getBrowserHostname(): string | null {
+  if (typeof window === "undefined") return null;
+  return window.location.hostname;
+}
+
+export function getBrowserOrigin(): string | null {
+  if (typeof window === "undefined") return null;
+  return window.location.origin;
+}


### PR DESCRIPTION
## Summary

Implements [#32](https://github.com/pingdotgg/lawn/issues/32): per-team branded share hosts on `lawn.video`.

- Each team’s **slug** is its share subdomain (already unique; reserved infra names blocked at team creation)
- Copied public watch + restricted share links use `https://{teamSlug}.lawn.video/...` on production
- Local/preview keeps using the current origin so the share flow still works without wildcard DNS
- Incoming share/watch traffic on a team subdomain is host-isolated: wrong team host → missing/denied
- Apex `lawn.video` links still work for backward compatibility
- Existing share protections (expiry, password, download flags) are unchanged

### Notable files
- `src/lib/shareHost.ts` / `convex/shareHost.ts` — URL generation + host parsing/isolation
- `ShareDialog` + project share copy — branded URL generation
- Public share/watch queries & actions accept optional `shareHost`

### Ops note
Production needs a wildcard `*.lawn.video` DNS/Vercel domain so team subdomains resolve to the same app deployment.

## Test plan
- [x] Unit tests for host parsing + branded URL generation
- [x] Convex tests for host isolation on public watch / share grant
- [x] Existing public watch tests still pass
- [ ] On production with `*.lawn.video`: copy a public watch link → `https://{slug}.lawn.video/watch/...`
- [ ] Open that URL → video loads; open same path on another team’s subdomain → unavailable
- [ ] Restricted share link with password still works on the correct team host
- [ ] Locally: copied links still use localhost origin

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all public share/watch access paths and enforces host–team binding; misconfiguration of wildcard DNS or host parsing could break or over-expose links, though apex bypass limits blast radius for legacy URLs.
> 
> **Overview**
> Adds **per-team branded share hosts** on `lawn.video`, where each team’s slug becomes `{slug}.lawn.video` for copied public watch and restricted share URLs (with localhost/preview still using the current origin).
> 
> **Share/watch flows** now send the browser hostname as optional `shareHost` on Convex queries, mutations, and playback/download actions. Server-side `videoMatchesShareHost` enforces that on a team subdomain, the video’s owning team slug must match; apex and non-`lawn.video` hosts skip isolation so legacy links keep working.
> 
> **Dashboard UX**: `ShareDialog` and project quick-share copy full branded URLs via `publicWatchUrl` / `restrictedShareUrl`; `videos.get` exposes `teamSlug` for link building. **Team creation** allocates slugs that avoid reserved infrastructure subdomains.
> 
> New `shareHost` helpers (client + Convex), unit tests, and Convex isolation tests cover parsing, URL generation, and cross-team host rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b7c5d6a5c6dec41d676dce9a3cef0846e1a88c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-team branded share subdomains on lawn.video
> - Introduces a `shareHost` concept that scopes all share and watch page queries, mutations, and actions to the team's branded subdomain (e.g. `{team-slug}.lawn.video`).
> - Adds a new [convex/shareHost.ts](https://github.com/pingdotgg/lawn/pull/58/files#diff-6057617bdca0464f2b9c3aa23bf3a5fcbe4c41726fb98d32887ba28ba3b1a42d) backend module and [src/lib/shareHost.ts](https://github.com/pingdotgg/lawn/pull/58/files#diff-cf72a8a013ce365efd494061301bc4922642bf570f6020a0d19830e30c73fd56) frontend module providing subdomain parsing, URL construction, and host validation utilities.
> - Share link lookups, access grant issuance, playback sessions, downloads, and comment reads/writes now return empty or null results when the request host does not match the video's owning team.
> - The [ShareDialog](https://github.com/pingdotgg/lawn/pull/58/files#diff-2aa80443991b40a426d495eff17b90d6dc4977bc346bb9e4264fdc83e834a745) and project page copy-to-clipboard now produce absolute branded URLs instead of relative paths.
> - Team slug generation avoids reserved share subdomains to prevent routing collisions.
> - Risk: share and watch content silently returns null/empty for requests from mismatched hosts, which could surface as missing content if host propagation is incorrect.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b7c5d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->