### PR TITLE
feat: DaVinci Resolve-compatible comment export

### DIFF
--- a/app/routes/dashboard/-video.tsx
+++ b/app/routes/dashboard/-video.tsx
@@ -19,6 +19,10 @@ import {
 } from "@/components/videos/VideoWorkflowStatusControl";
 import { cn, formatDuration } from "@/lib/utils";
 import { buildCommentsCsv, buildCommentsCsvFilename } from "@/lib/commentCsv";
+import {
+  buildResolveMarkersCsv,
+  buildResolveMarkersFilename,
+} from "@/lib/commentResolveExport";
 import { triggerTextDownload } from "@/lib/download";
 import { useVideoPresence } from "@/lib/useVideoPresence";
 import { useSidebarCollapsed } from "@/lib/useSidebarCollapsed";
@@ -632,6 +636,16 @@ export default function VideoPage() {
     if (!video || !commentsThreaded?.length) return;
 
     triggerTextDownload(buildCommentsCsv(commentsThreaded), buildCommentsCsvFilename(video.title));
+  }, [commentsThreaded, video]);
+
+  const handleExportResolveMarkers = useCallback(() => {
+    if (!video || !commentsThreaded?.length) return;
+
+    // Default 24fps (editorial). Match this to the Resolve timeline fps on import.
+    triggerTextDownload(
+      buildResolveMarkersCsv(commentsThreaded),
+      buildResolveMarkersFilename(video.title),
+    );
   }, [commentsThreaded, video]);
 
   const handleSaveTitle = async () => {
@@ -1250,9 +1264,21 @@ export default function VideoPage() {
                 className="h-7 px-2 text-[10px]"
                 onClick={handleExportComments}
                 disabled={!commentsThreaded?.length}
+                title="Download comments as spreadsheet CSV"
               >
                 <Download className="h-3.5 w-3.5" />
                 Export CSV
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-[10px]"
+                onClick={handleExportResolveMarkers}
+                disabled={!commentsThreaded?.length}
+                title="Download DaVinci Resolve timeline markers (24fps)"
+              >
+                <Download className="h-3.5 w-3.5" />
+                Export for Resolve
               </Button>
             </div>
           </div>
@@ -1297,9 +1323,21 @@ export default function VideoPage() {
                 className="h-8 px-2 text-[10px]"
                 onClick={handleExportComments}
                 disabled={!commentsThreaded?.length}
+                title="Download comments as spreadsheet CSV"
               >
                 <Download className="h-3.5 w-3.5" />
-                Export CSV
+                CSV
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 px-2 text-[10px]"
+                onClick={handleExportResolveMarkers}
+                disabled={!commentsThreaded?.length}
+                title="Download DaVinci Resolve timeline markers (24fps)"
+              >
+                <Download className="h-3.5 w-3.5" />
+                Resolve
               </Button>
               <Button
                 variant="ghost"

--- a/src/lib/commentResolveExport.test.ts
+++ b/src/lib/commentResolveExport.test.ts
@@ -1,0 +1,126 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_RESOLVE_FPS,
+  buildResolveMarkersCsv,
+  buildResolveMarkersFilename,
+  secondsToTimecode,
+} from "@/lib/commentResolveExport";
+
+test("secondsToTimecode formats HH:MM:SS:FF at 24fps", () => {
+  assert.equal(secondsToTimecode(0, 24), "00:00:00:00");
+  assert.equal(secondsToTimecode(1, 24), "00:00:01:00");
+  assert.equal(secondsToTimecode(65, 24), "00:01:05:00");
+  // 1 frame at 24fps ≈ 0.04166s
+  assert.equal(secondsToTimecode(1 / 24, 24), "00:00:00:01");
+  // 2 hours + 3 min + 4 sec + 5 frames
+  assert.equal(secondsToTimecode(2 * 3600 + 3 * 60 + 4 + 5 / 24, 24), "02:03:04:05");
+});
+
+test("secondsToTimecode respects alternate fps", () => {
+  assert.equal(secondsToTimecode(1, 30), "00:00:01:00");
+  assert.equal(secondsToTimecode(1 / 30, 30), "00:00:00:01");
+  assert.equal(secondsToTimecode(10 + 15 / 25, 25), "00:00:10:15");
+});
+
+test("secondsToTimecode clamps invalid inputs", () => {
+  assert.equal(secondsToTimecode(-5, 24), "00:00:00:00");
+  assert.equal(secondsToTimecode(Number.NaN, 24), "00:00:00:00");
+  assert.equal(secondsToTimecode(1, 0), secondsToTimecode(1, DEFAULT_RESOLVE_FPS));
+});
+
+test("exports Resolve markers with author, text, resolved state, and replies", () => {
+  const csv = buildResolveMarkersCsv(
+    [
+      {
+        text: "Fix the pop",
+        timestampSeconds: 65,
+        userName: "Alice",
+        resolved: false,
+        replies: [
+          {
+            text: "On it",
+            timestampSeconds: 65,
+            userName: "Bob",
+            resolved: false,
+          },
+        ],
+      },
+      {
+        text: "Color grade looks good",
+        timestampSeconds: 125,
+        userName: "Carol",
+        resolved: true,
+        replies: [],
+      },
+    ],
+    { fps: 24 },
+  );
+
+  const lines = csv.split("\r\n");
+  assert.equal(lines[0], "No.,Name,Start,End,Duration,Color,Notes");
+  assert.equal(lines.length, 4);
+
+  // Row 1: top-level open comment at 00:01:05:00
+  assert.match(lines[1]!, /^1,"Alice: Fix the pop","00:01:05:00","00:01:05:01","00:00:00:01","Blue",/);
+  assert.match(lines[1]!, /\[Comment\] Alice · Open/);
+  assert.match(lines[1]!, /Fix the pop/);
+
+  // Row 2: reply, indented name
+  assert.match(lines[2]!, /^2,"↳ Bob: On it","00:01:05:00"/);
+  assert.match(lines[2]!, /\[Reply\] Bob · Open/);
+
+  // Row 3: resolved → green
+  assert.match(
+    lines[3]!,
+    /^3,"✓ Carol: Color grade looks good","00:02:05:00","00:02:05:01","00:00:00:01","Green",/,
+  );
+  assert.match(lines[3]!, /\[Comment\] Carol · Resolved/);
+});
+
+test("escapes CSV quotes/newlines; formula text is nested under safe prefixes", () => {
+  const csv = buildResolveMarkersCsv([
+    {
+      text: 'Comma, quote "and"\nnewline',
+      timestampSeconds: 0,
+      userName: "Ed",
+      resolved: false,
+      replies: [],
+    },
+    {
+      text: '=HYPERLINK("https://example.com")',
+      timestampSeconds: 1,
+      userName: "Evil",
+      resolved: false,
+      replies: [],
+    },
+  ]);
+
+  // Quotes doubled inside cells
+  assert.match(csv, /""and""/);
+  // Name is author-prefixed so the cell value does not start with =
+  assert.match(csv, /"Evil: =HYPERLINK/);
+  // Notes open with [Comment]/[Reply], not a spreadsheet formula
+  assert.match(csv, /"\[Comment\] Evil · Open\n=HYPERLINK/);
+});
+
+test("defaults to 24fps when fps omitted", () => {
+  const csv = buildResolveMarkersCsv([
+    {
+      text: "Beat",
+      timestampSeconds: 1,
+      userName: "A",
+      resolved: false,
+      replies: [],
+    },
+  ]);
+  assert.match(csv, /"00:00:01:00"/);
+});
+
+test("builds a stable filesystem-safe Resolve markers filename", () => {
+  assert.equal(
+    buildResolveMarkersFilename('  Launch / Review: "Final"  '),
+    "launch-review-final-resolve-markers.csv",
+  );
+  assert.equal(buildResolveMarkersFilename("你好"), "video-resolve-markers.csv");
+});

--- a/src/lib/commentResolveExport.ts
+++ b/src/lib/commentResolveExport.ts
@@ -1,0 +1,151 @@
+/**
+ * DaVinci Resolve timeline markers export.
+ *
+ * Produces a markers CSV matching the common Resolve export/import shape:
+ *   No.,Name,Start,End,Duration,Color,Notes
+ * with non-drop timecodes as HH:MM:SS:FF.
+ *
+ * Import (Resolve 18+): open the timeline → right-click the timeline ruler
+ * (or Index → Markers) → Import Markers… / File → Import → Timeline… and
+ * select this CSV. Timeline frame rate should match the export fps.
+ */
+
+/** Editorial default; override when the cut is 23.976 / 25 / 29.97 / 30. */
+export const DEFAULT_RESOLVE_FPS = 24;
+
+/** One-frame marker duration in frames (Resolve point markers). */
+const MARKER_DURATION_FRAMES = 1;
+
+interface ResolveComment {
+  text: string;
+  timestampSeconds: number;
+  userName?: string;
+  resolved?: boolean;
+}
+
+interface ResolveCommentThread extends ResolveComment {
+  replies: ResolveComment[];
+}
+
+export interface BuildResolveMarkersOptions {
+  /** Timeline frame rate. Defaults to {@link DEFAULT_RESOLVE_FPS}. */
+  fps?: number;
+}
+
+function escapeCsvCell(value: string) {
+  const spreadsheetSafeValue = /^\s*[=+\-@]/.test(value) ? `'${value}` : value;
+  return `"${spreadsheetSafeValue.replaceAll('"', '""')}"`;
+}
+
+/**
+ * Convert media seconds to non-drop timecode HH:MM:SS:FF.
+ * Uses rounded nominal fps for the frame field (24 for 23.976, 30 for 29.97).
+ */
+export function secondsToTimecode(
+  totalSeconds: number,
+  fps: number = DEFAULT_RESOLVE_FPS,
+): string {
+  const rate = Number.isFinite(fps) && fps > 0 ? fps : DEFAULT_RESOLVE_FPS;
+  const seconds = Number.isFinite(totalSeconds) && totalSeconds > 0 ? totalSeconds : 0;
+  const nominalFps = Math.max(1, Math.round(rate));
+  const totalFrames = Math.round(seconds * rate);
+
+  const ff = ((totalFrames % nominalFps) + nominalFps) % nominalFps;
+  const totalWholeSeconds = Math.floor(totalFrames / nominalFps);
+  const ss = totalWholeSeconds % 60;
+  const totalMinutes = Math.floor(totalWholeSeconds / 60);
+  const mm = totalMinutes % 60;
+  const hh = Math.floor(totalMinutes / 60);
+
+  return [hh, mm, ss, ff].map((n) => String(n).padStart(2, "0")).join(":");
+}
+
+function framesToTimecode(totalFrames: number, nominalFps: number): string {
+  const frames = Math.max(0, Math.floor(totalFrames));
+  const fps = Math.max(1, nominalFps);
+  const ff = frames % fps;
+  const totalWholeSeconds = Math.floor(frames / fps);
+  const ss = totalWholeSeconds % 60;
+  const totalMinutes = Math.floor(totalWholeSeconds / 60);
+  const mm = totalMinutes % 60;
+  const hh = Math.floor(totalMinutes / 60);
+  return [hh, mm, ss, ff].map((n) => String(n).padStart(2, "0")).join(":");
+}
+
+function markerColor(resolved: boolean | undefined): string {
+  return resolved ? "Green" : "Blue";
+}
+
+function markerName(comment: ResolveComment, isReply: boolean): string {
+  const author = comment.userName?.trim() || "Comment";
+  const status = comment.resolved ? "✓ " : "";
+  const prefix = isReply ? "↳ " : "";
+  // Keep name short so it fits the Resolve marker lane.
+  const snippet = comment.text.replace(/\s+/g, " ").trim().slice(0, 48);
+  const label = snippet ? `${author}: ${snippet}` : author;
+  return `${prefix}${status}${label}`.slice(0, 80);
+}
+
+function markerNotes(comment: ResolveComment, isReply: boolean): string {
+  const author = comment.userName?.trim() || "Unknown";
+  const status = comment.resolved ? "Resolved" : "Open";
+  const kind = isReply ? "Reply" : "Comment";
+  return [`[${kind}] ${author} · ${status}`, comment.text.trim()].filter(Boolean).join("\n");
+}
+
+type FlatMarker = ResolveComment & { isReply: boolean };
+
+function flattenComments(comments: ResolveCommentThread[]): FlatMarker[] {
+  return comments.flatMap((comment) => [
+    { ...comment, isReply: false },
+    ...comment.replies.map((reply) => ({ ...reply, isReply: true })),
+  ]);
+}
+
+/**
+ * Build a DaVinci Resolve markers CSV from threaded comments.
+ * Top-level comments keep timeline order; replies follow their parent.
+ */
+export function buildResolveMarkersCsv(
+  comments: ResolveCommentThread[],
+  options: BuildResolveMarkersOptions = {},
+): string {
+  const fps = options.fps ?? DEFAULT_RESOLVE_FPS;
+  const nominalFps = Math.max(1, Math.round(fps > 0 ? fps : DEFAULT_RESOLVE_FPS));
+  const durationTc = framesToTimecode(MARKER_DURATION_FRAMES, nominalFps);
+  const rows = flattenComments(comments);
+
+  const header = "No.,Name,Start,End,Duration,Color,Notes";
+  const body = rows.map((comment, index) => {
+    const start = secondsToTimecode(comment.timestampSeconds, fps);
+    // Point marker: End = Start + 1 frame for importers that require a range.
+    const startFrames = Math.round(
+      Math.max(0, Number.isFinite(comment.timestampSeconds) ? comment.timestampSeconds : 0) * fps,
+    );
+    const end = framesToTimecode(startFrames + MARKER_DURATION_FRAMES, nominalFps);
+
+    return [
+      String(index + 1),
+      escapeCsvCell(markerName(comment, comment.isReply)),
+      escapeCsvCell(start),
+      escapeCsvCell(end),
+      escapeCsvCell(durationTc),
+      escapeCsvCell(markerColor(comment.resolved)),
+      escapeCsvCell(markerNotes(comment, comment.isReply)),
+    ].join(",");
+  });
+
+  return [header, ...body].join("\r\n");
+}
+
+export function buildResolveMarkersFilename(videoTitle: string) {
+  const slug = videoTitle
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80)
+    .replace(/-+$/g, "");
+
+  return `${slug || "video"}-resolve-markers.csv`;
+}


### PR DESCRIPTION
Closes https://github.com/pingdotgg/lawn/issues/31

## Summary
Adds a **DaVinci Resolve markers CSV** export next to the existing spreadsheet CSV download on the dashboard video discussion panel (desktop + mobile).

### Format choice
**Resolve markers CSV** (`No.,Name,Start,End,Duration,Color,Notes`) with non-drop `HH:MM:SS:FF` timecodes.

Why this over EDL/XML:
- Imports as timeline markers without rebuilding a sequence
- Carries author, notes, and color (open → Blue, resolved → Green)
- Keeps replies in thread order with a `↳` name prefix and `[Reply]` notes
- Client-side only from the already-authorized comments query (same trust model as PR #41) — no new public export endpoint

Default fps is **24** (editorial standard). Match your Resolve timeline frame rate on import; the builder accepts an `fps` option for future UI if needed.

Filename: `<video-title>-resolve-markers.csv`

## Import into DaVinci Resolve
1. Open the target timeline in Resolve.
2. Confirm the timeline frame rate matches the export (**24 fps** by default).
3. Import markers from the CSV:
   - **Resolve 18+:** right-click the timeline ruler → **Import Markers…** (wording varies slightly by version), *or*
   - Use **File → Import → Timeline…** if your version surfaces marker import there, *or*
   - **Index → Markers** panel → import/load markers from file when available.
4. Markers land at each comment’s timecode with name + notes (author, open/resolved, full text). Replies follow their parent at the same time.

If import rejects the file, open the CSV in a text editor and confirm columns match: `No.,Name,Start,End,Duration,Color,Notes` and that Start/End look like `00:01:05:00`.

## Files
- `src/lib/commentResolveExport.ts` — timecode conversion + CSV builder
- `src/lib/commentResolveExport.test.ts` — unit tests for TC + export content
- `app/routes/dashboard/-video.tsx` — **Export for Resolve** buttons (desktop + mobile)

## Test plan
- [x] Unit tests for `secondsToTimecode` and marker CSV content
- [ ] Click **Export for Resolve** on a video with threaded comments; file downloads
- [ ] Import CSV into a 24fps Resolve timeline and confirm marker positions/notes
- [ ] Confirm **Export CSV** still works unchanged
- [ ] Confirm export buttons stay disabled when there are no comments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only export from already-loaded comments; no API or auth changes, with behavior covered by unit tests.
> 
> **Overview**
> Adds a **client-side DaVinci Resolve markers CSV** export alongside the existing spreadsheet comment download on the dashboard video discussion panel (desktop and mobile).
> 
> New `commentResolveExport` builds Resolve’s `No.,Name,Start,End,Duration,Color,Notes` format with `HH:MM:SS:FF` timecodes (default **24 fps**), one-frame point markers, **Blue/Green** for open vs resolved, threaded replies in order with `↳` / `[Reply]` labeling, and CSV escaping consistent with the spreadsheet export. The video page wires **Export for Resolve** (and short **Resolve** on mobile) through the same `triggerTextDownload` path as **Export CSV**, disabled when there are no threaded comments.
> 
> Unit tests cover timecode conversion, marker content, formula-safe cells, and filename slugging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35b9dd412ac77cfba015339d177bfa00f69947ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add DaVinci Resolve-compatible marker CSV export to the video page
> - Adds [`commentResolveExport.ts`](https://github.com/pingdotgg/lawn/pull/59/files#diff-7c11c8dad6091dde4a1b2bfdfc97e18bde4db928e730a65b549b8f60d0b684b0) with three utilities: `secondsToTimecode` (seconds → `HH:MM:SS:FF`), `buildResolveMarkersCsv` (flattens threaded comments into a Resolve-compatible CSV with Blue/Green color coding and safe CSV escaping), and `buildResolveMarkersFilename` (generates a slugified filename).
> - Adds "Export for Resolve" and "Resolve" buttons (desktop and mobile) to the video page header that trigger a CSV download derived from threaded comments.
> - Shortens the existing mobile CSV export button label from "Export CSV" to "CSV" and adds `title` tooltip attributes to all CSV export buttons.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35b9dd4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->