### PR TITLE
fix: send team invite emails via Resend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,8 @@ AUTUMN_SECRET_KEY=
 # chunkify
 CHUNKIFY_PROJECT_ACCESS_TOKEN=
 CHUNKIFY_WEBHOOK_SECRET=
+
+# team invite email (Resend). Optional — invites still work via shareable link.
+RESEND_API_KEY=
+RESEND_FROM_EMAIL=                  # optional; default "Lawn <invites@lawn.video>"
+SITE_URL=https://lawn.video         # public origin for invite links (or APP_URL)

--- a/convex/.env.example
+++ b/convex/.env.example
@@ -37,3 +37,12 @@ AUTUMN_SECRET_KEY=
 # chunkify
 CHUNKIFY_PROJECT_ACCESS_TOKEN=
 CHUNKIFY_WEBHOOK_SECRET=
+
+# team invite email (Resend). Optional — invites still work via shareable link.
+# RESEND_FROM_EMAIL defaults to "Lawn <invites@lawn.video>"; set your verified
+# sender if that domain is not verified in Resend.
+RESEND_API_KEY=
+RESEND_FROM_EMAIL=
+# Public app origin used in invite links (no trailing slash). SITE_URL preferred.
+SITE_URL=https://lawn.video
+# APP_URL=

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -14,6 +14,7 @@ import type * as billingHelpers from "../billingHelpers.js";
 import type * as comments from "../comments.js";
 import type * as crons from "../crons.js";
 import type * as http from "../http.js";
+import type * as inviteEmail from "../inviteEmail.js";
 import type * as mux from "../mux.js";
 import type * as muxActions from "../muxActions.js";
 import type * as projects from "../projects.js";
@@ -42,6 +43,7 @@ declare const fullApi: ApiFromModules<{
   comments: typeof comments;
   crons: typeof crons;
   http: typeof http;
+  inviteEmail: typeof inviteEmail;
   mux: typeof mux;
   muxActions: typeof muxActions;
   projects: typeof projects;

--- a/convex/inviteEmail.ts
+++ b/convex/inviteEmail.ts
@@ -1,0 +1,135 @@
+import { v } from "convex/values";
+import { internalAction } from "./_generated/server";
+
+const DEFAULT_SITE_URL = "https://lawn.video";
+const DEFAULT_FROM_EMAIL = "Lawn <invites@lawn.video>";
+
+export type InviteEmailContentInput = {
+  inviterName: string;
+  teamName: string;
+  inviteUrl: string;
+};
+
+/** Resolve the public site origin for invite links. */
+export function getSiteUrl(
+  env: { SITE_URL?: string | undefined; APP_URL?: string | undefined } = {
+    SITE_URL: process.env.SITE_URL,
+    APP_URL: process.env.APP_URL,
+  },
+): string {
+  const raw = env.SITE_URL?.trim() || env.APP_URL?.trim() || DEFAULT_SITE_URL;
+  return raw.replace(/\/+$/, "");
+}
+
+export function buildInviteUrl(token: string, siteUrl: string = getSiteUrl()): string {
+  return `${siteUrl}/invite/${token}`;
+}
+
+export function buildInviteEmailSubject(inviterName: string, teamName: string): string {
+  return `${inviterName} invited you to ${teamName} on Lawn`;
+}
+
+export function buildInviteEmailText(input: InviteEmailContentInput): string {
+  const { inviterName, teamName, inviteUrl } = input;
+  return [
+    `${inviterName} invited you to join ${teamName} on Lawn.`,
+    "",
+    "Accept the invite:",
+    inviteUrl,
+    "",
+    "This invite expires in 7 days.",
+    "",
+    "If you weren't expecting this, you can ignore this email.",
+  ].join("\n");
+}
+
+export function buildInviteEmailHtml(input: InviteEmailContentInput): string {
+  const { inviterName, teamName, inviteUrl } = input;
+  // Keep markup minimal and inline so it renders without external CSS.
+  const safeInviter = escapeHtml(inviterName);
+  const safeTeam = escapeHtml(teamName);
+  const safeUrl = escapeHtml(inviteUrl);
+  return [
+    `<!DOCTYPE html>`,
+    `<html><body style="font-family:system-ui,sans-serif;line-height:1.5;color:#1a1a1a;background:#f0f0e8;padding:24px;">`,
+    `<div style="max-width:480px;margin:0 auto;border:2px solid #1a1a1a;padding:24px;background:#f0f0e8;">`,
+    `<p style="margin:0 0 16px;font-size:16px;"><strong>${safeInviter}</strong> invited you to join <strong>${safeTeam}</strong> on Lawn.</p>`,
+    `<p style="margin:0 0 24px;">`,
+    `<a href="${safeUrl}" style="display:inline-block;background:#2d5a2d;color:#f0f0e8;text-decoration:none;font-weight:700;padding:12px 16px;border:2px solid #1a1a1a;">Accept invite</a>`,
+    `</p>`,
+    `<p style="margin:0 0 8px;font-size:14px;color:#888;">Or copy this link:</p>`,
+    `<p style="margin:0 0 16px;font-size:13px;word-break:break-all;"><a href="${safeUrl}" style="color:#2d5a2d;">${safeUrl}</a></p>`,
+    `<p style="margin:0;font-size:12px;color:#888;">This invite expires in 7 days. If you weren't expecting this, you can ignore this email.</p>`,
+    `</div></body></html>`,
+  ].join("");
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Best-effort invite email via Resend.
+ * Skips silently when RESEND_API_KEY is unset; never throws to callers of inviteMember.
+ */
+export const sendInviteEmail = internalAction({
+  args: {
+    toEmail: v.string(),
+    inviterName: v.string(),
+    teamName: v.string(),
+    token: v.string(),
+  },
+  returns: v.null(),
+  handler: async (_ctx, args) => {
+    const apiKey = process.env.RESEND_API_KEY?.trim();
+    if (!apiKey) {
+      console.log(
+        "[inviteEmail] RESEND_API_KEY not set; skipping email send (invite link still works)",
+      );
+      return null;
+    }
+
+    const from = process.env.RESEND_FROM_EMAIL?.trim() || DEFAULT_FROM_EMAIL;
+    const inviteUrl = buildInviteUrl(args.token);
+    const subject = buildInviteEmailSubject(args.inviterName, args.teamName);
+    const content = {
+      inviterName: args.inviterName,
+      teamName: args.teamName,
+      inviteUrl,
+    };
+
+    try {
+      const response = await fetch("https://api.resend.com/emails", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          from,
+          to: [args.toEmail],
+          subject,
+          text: buildInviteEmailText(content),
+          html: buildInviteEmailHtml(content),
+        }),
+      });
+
+      if (!response.ok) {
+        const body = await response.text();
+        console.error(
+          `[inviteEmail] Resend API error status=${response.status} body=${body.slice(0, 500)}`,
+        );
+        return null;
+      }
+    } catch (error) {
+      console.error("[inviteEmail] Failed to send invite email:", error);
+    }
+
+    return null;
+  },
+});

--- a/convex/inviteEmail.vitest.ts
+++ b/convex/inviteEmail.vitest.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildInviteEmailHtml,
+  buildInviteEmailSubject,
+  buildInviteEmailText,
+  buildInviteUrl,
+  getSiteUrl,
+} from "./inviteEmail";
+
+describe("invite email helpers", () => {
+  test("getSiteUrl prefers SITE_URL, then APP_URL, then default", () => {
+    expect(getSiteUrl({ SITE_URL: "https://app.example.com/" })).toBe("https://app.example.com");
+    expect(getSiteUrl({ APP_URL: "https://staging.example.com" })).toBe(
+      "https://staging.example.com",
+    );
+    expect(getSiteUrl({ SITE_URL: "  https://a.test  ", APP_URL: "https://b.test" })).toBe(
+      "https://a.test",
+    );
+    expect(getSiteUrl({})).toBe("https://lawn.video");
+  });
+
+  test("buildInviteUrl joins origin and token", () => {
+    expect(buildInviteUrl("abc123", "https://lawn.video")).toBe("https://lawn.video/invite/abc123");
+  });
+
+  test("buildInviteEmailSubject includes inviter and team", () => {
+    expect(buildInviteEmailSubject("Ada", "Lawn HQ")).toBe(
+      "Ada invited you to Lawn HQ on Lawn",
+    );
+  });
+
+  test("buildInviteEmailText includes invite URL and context", () => {
+    const text = buildInviteEmailText({
+      inviterName: "Ada",
+      teamName: "Lawn HQ",
+      inviteUrl: "https://lawn.video/invite/tok",
+    });
+    expect(text).toContain("Ada invited you to join Lawn HQ on Lawn.");
+    expect(text).toContain("https://lawn.video/invite/tok");
+    expect(text).toContain("expires in 7 days");
+  });
+
+  test("buildInviteEmailHtml escapes untrusted names and includes CTA", () => {
+    const html = buildInviteEmailHtml({
+      inviterName: `Ada <script>alert(1)</script>`,
+      teamName: `Team & "Crew"`,
+      inviteUrl: "https://lawn.video/invite/tok",
+    });
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("Ada &lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(html).toContain("Team &amp; &quot;Crew&quot;");
+    expect(html).toContain('href="https://lawn.video/invite/tok"');
+    expect(html).toContain("Accept invite");
+  });
+});

--- a/convex/teams.ts
+++ b/convex/teams.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
 import { internalMutation, mutation, query } from "./_generated/server";
+import { internal } from "./_generated/api";
 import {
   getUser,
   identityAvatarUrl,
@@ -215,6 +216,11 @@ export const inviteMember = mutation({
   handler: async (ctx, args) => {
     const { user } = await requireTeamAccess(ctx, args.teamId, "admin");
 
+    const team = await ctx.db.get(args.teamId);
+    if (!team) {
+      throw new Error("Team not found");
+    }
+
     const inviteEmail = normalizedEmail(args.email);
 
     const existingMembership = await ctx.db
@@ -239,15 +245,24 @@ export const inviteMember = mutation({
 
     const token = generateToken();
     const expiresAt = Date.now() + 7 * 24 * 60 * 60 * 1000; // 7 days
+    const inviterName = identityName(user);
 
     await ctx.db.insert("teamInvites", {
       teamId: args.teamId,
       email: inviteEmail,
       role: args.role,
       invitedByClerkId: user.subject,
-      invitedByName: identityName(user),
+      invitedByName: inviterName,
       token,
       expiresAt,
+    });
+
+    // Best-effort email: never block invite creation if send fails / is unconfigured.
+    await ctx.scheduler.runAfter(0, internal.inviteEmail.sendInviteEmail, {
+      toEmail: inviteEmail,
+      inviterName,
+      teamName: team.name,
+      token,
     });
 
     return token;

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -47,3 +47,9 @@ grouped by section (convex, clerk, stripe, mux, storage, autumn, chunkify).
 Stripe webhook endpoint (for the Convex Stripe component):
 
 - `https://<your-deployment>.convex.site/stripe/webhook`
+
+Team invite email (optional — shareable invite links always work):
+
+- `RESEND_API_KEY` — Resend API key for sending invite emails from Convex
+- `RESEND_FROM_EMAIL` — optional from address; defaults to `Lawn <invites@lawn.video>` (set a verified sender if that domain is not verified in Resend)
+- `SITE_URL` or `APP_URL` — public app origin used in invite links (defaults to `https://lawn.video`)

--- a/scripts/convex-local-setup.sh
+++ b/scripts/convex-local-setup.sh
@@ -64,7 +64,7 @@ echo "convex-local-setup: seeding deployment environment variables..."
 seed="$(mktemp)"
 trap 'rm -f "$seed"' EXIT
 # Backend runtime secrets only; drop client (VITE_) and selection (CONVEX_) vars.
-grep -hE '^(STRIPE_|CLERK_|CHUNKIFY_|AUTUMN_|RAILWAY_|MUX_)' .env.local .env.convex.local 2>/dev/null \
+grep -hE '^(STRIPE_|CLERK_|CHUNKIFY_|AUTUMN_|RAILWAY_|MUX_|RESEND_|SITE_URL=|APP_URL=)' .env.local .env.convex.local 2>/dev/null \
   | grep -vE '^VITE_' > "$seed" || true
 # Derive CLERK_JWT_ISSUER_DOMAIN from the Clerk publishable key when not provided.
 # A Clerk pk_(test|live)_ key base64-encodes "<frontend-api-host>$"; the JWT

--- a/src/components/teams/MemberInvite.tsx
+++ b/src/components/teams/MemberInvite.tsx
@@ -38,12 +38,17 @@ const roleLabels: Record<Role, string> = {
   viewer: "Viewer",
 };
 
+function inviteUrlForToken(token: string): string {
+  const baseUrl = typeof window !== "undefined" ? window.location.origin : "";
+  return `${baseUrl}/invite/${token}`;
+}
+
 export function MemberInvite({ teamId, open, onOpenChange }: MemberInviteProps) {
   const [email, setEmail] = useState("");
   const [role, setRole] = useState<Role>("member");
   const [isLoading, setIsLoading] = useState(false);
   const [inviteLink, setInviteLink] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
 
   const members = useQuery(api.teams.getMembers, { teamId });
   const invites = useQuery(api.teams.getInvites, { teamId });
@@ -62,8 +67,7 @@ export function MemberInvite({ teamId, open, onOpenChange }: MemberInviteProps) 
         email: email.trim(),
         role,
       });
-      const baseUrl = typeof window !== "undefined" ? window.location.origin : "";
-      setInviteLink(`${baseUrl}/invite/${token}`);
+      setInviteLink(inviteUrlForToken(token));
       setEmail("");
     } catch (error) {
       console.error("Failed to invite member:", error);
@@ -72,12 +76,10 @@ export function MemberInvite({ teamId, open, onOpenChange }: MemberInviteProps) 
     }
   };
 
-  const handleCopyLink = () => {
-    if (inviteLink) {
-      navigator.clipboard.writeText(inviteLink);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }
+  const handleCopyLink = (link: string, key: string) => {
+    navigator.clipboard.writeText(link);
+    setCopiedKey(key);
+    setTimeout(() => setCopiedKey(null), 2000);
   };
 
   const handleRemoveMember = async (memberId: Id<"teamMembers">) => {
@@ -129,17 +131,29 @@ export function MemberInvite({ teamId, open, onOpenChange }: MemberInviteProps) 
           </div>
           <Button type="submit" disabled={!email.trim() || isLoading} className="w-full">
             <UserPlus className="mr-2 h-4 w-4" />
-            {isLoading ? "Sending..." : "Send invite"}
+            {isLoading ? "Creating invite..." : "Send invite"}
           </Button>
         </form>
 
         {inviteLink && (
           <div className="border-2 border-[#1a1a1a] bg-[#e8e8e0] p-3">
-            <p className="mb-2 text-sm text-[#888]">Share this link with the invitee:</p>
+            <p className="mb-2 text-sm text-[#1a1a1a]">
+              Invite created. We emailed them if email is configured — you can also share this
+              link.
+            </p>
             <div className="flex gap-2">
               <Input value={inviteLink} readOnly className="text-sm" />
-              <Button variant="outline" size="icon" onClick={handleCopyLink}>
-                {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={() => handleCopyLink(inviteLink, "latest")}
+                aria-label="Copy invite link"
+              >
+                {copiedKey === "latest" ? (
+                  <Check className="h-4 w-4" />
+                ) : (
+                  <Copy className="h-4 w-4" />
+                )}
               </Button>
             </div>
           </div>
@@ -207,18 +221,37 @@ export function MemberInvite({ teamId, open, onOpenChange }: MemberInviteProps) 
           <div className="space-y-2">
             <h4 className="text-sm font-bold text-[#1a1a1a]">Pending invites</h4>
             <div className="space-y-2">
-              {invites.map((invite) => (
-                <div
-                  key={invite._id}
-                  className="flex items-center justify-between border-2 border-[#1a1a1a] bg-[#e8e8e0] p-2"
-                >
-                  <div>
-                    <p className="text-sm text-[#1a1a1a]">{invite.email}</p>
-                    <p className="text-xs text-[#888]">Invited as {roleLabels[invite.role]}</p>
+              {invites.map((invite) => {
+                const link = inviteUrlForToken(invite.token);
+                const copyKey = invite._id;
+                return (
+                  <div
+                    key={invite._id}
+                    className="flex items-center justify-between gap-2 border-2 border-[#1a1a1a] bg-[#e8e8e0] p-2"
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate text-sm text-[#1a1a1a]">{invite.email}</p>
+                      <p className="text-xs text-[#888]">Invited as {roleLabels[invite.role]}</p>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-1">
+                      <Badge variant="outline">Pending</Badge>
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        className="h-8 w-8"
+                        onClick={() => handleCopyLink(link, copyKey)}
+                        aria-label={`Copy invite link for ${invite.email}`}
+                      >
+                        {copiedKey === copyKey ? (
+                          <Check className="h-4 w-4" />
+                        ) : (
+                          <Copy className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </div>
                   </div>
-                  <Badge variant="outline">Pending</Badge>
-                </div>
-              ))}
+                );
+              })}
             </div>
           </div>
         )}


### PR DESCRIPTION
Closes https://github.com/pingdotgg/lawn/issues/9

## Summary
- `inviteMember` still creates the invite + returns a token, then schedules a best-effort `internal.inviteEmail.sendInviteEmail` action so the mutation never fails if email is unconfigured or Resend errors.
- Email is sent via the Resend HTTP API when `RESEND_API_KEY` is set; shareable `/invite/{token}` link remains the always-available fallback.
- Member invite UI copy updated; pending invites now have a copy-link button each.

## Env vars (Convex deployment)
Operators must set on the Convex deployment:

| Variable | Required | Notes |
|---|---|---|
| `RESEND_API_KEY` | for email | Without it, invite creation still works; only the email is skipped |
| `RESEND_FROM_EMAIL` | optional | Defaults to `Lawn <invites@lawn.video>` — set a verified sender if that domain is not verified in Resend |
| `SITE_URL` or `APP_URL` | optional | Public origin for invite links; defaults to `https://lawn.video` |

Also documented in `docs/setup.md`, `.env.example`, and `convex/.env.example`. Local seed script picks up `RESEND_*` / `SITE_URL` / `APP_URL` from `.env.local`.

## Test plan
- [x] Unit tests for pure email helpers (`convex/inviteEmail.vitest.ts`)
- [x] `convex typecheck` / `tsc` / lint
- [ ] Without `RESEND_API_KEY`: invite still creates, UI shows link, logs skip message
- [ ] With Resend configured: invitee receives subject `{name} invited you to {team} on Lawn` with working link
- [ ] Copy link from latest invite banner and from pending invites list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Invite creation is unchanged on failure paths; email is best-effort and optional. Minor note: email links use server `SITE_URL` while UI copy uses `window.location.origin`, which can differ in non-prod.
> 
> **Overview**
> Adds **optional team invite emails** through Resend while keeping shareable `/invite/{token}` links as the always-available path.
> 
> After `inviteMember` creates the invite, it schedules a best-effort `sendInviteEmail` internal action (skipped or logged on failure when `RESEND_API_KEY` is unset). Email bodies use `SITE_URL`/`APP_URL` for links; HTML escapes inviter/team names. **Member invite UI** explains email may have been sent, adds per-row copy-link on pending invites, and refines loading/copy state.
> 
> **Ops:** `RESEND_*`, `SITE_URL`/`APP_URL` documented in env examples and `docs/setup.md`; local Convex seed script includes those vars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68ce70d29804186cc94d28553dc9f1623f6bee17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Send team invite emails via Resend when members are invited
> - Adds [convex/inviteEmail.ts](https://github.com/pingdotgg/lawn/pull/60/files#diff-97c9edbc6043b74f69c0b74151930a80cca61cbfe3402a66496ddef3e77f4a12) with an `internalAction` that builds and sends a styled HTML+text invite email via the Resend API, including a CTA button and copyable invite link.
> - Schedules `sendInviteEmail` fire-and-forget from the `inviteMember` mutation after inserting the invite record; failures do not block invite creation.
> - Requires `RESEND_API_KEY` env var to send; `RESEND_FROM_EMAIL` and `SITE_URL`/`APP_URL` are optional with documented defaults.
> - Adds per-invite copy-to-clipboard buttons in the invite UI and updates banner text to reflect that an email is sent if configured.
> - Risk: `inviteMember` now throws `'Team not found'` if the team document is missing, which is new behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 68ce70d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->