### PR TITLE
feat: nested comment reply threads

### DIFF
--- a/app/routes/-share.tsx
+++ b/app/routes/-share.tsx
@@ -13,6 +13,8 @@ import { formatDuration, formatTimestamp, formatRelativeTime } from "@/lib/utils
 import { useVideoPresence } from "@/lib/useVideoPresence";
 import { VideoWatchers } from "@/components/presence/VideoWatchers";
 import { CommentText } from "@/components/comments/CommentText";
+import { NestedReplies } from "@/components/comments/NestedReplies";
+import { walkThreadedComments } from "@/lib/threadedComments";
 import { Lock, Video, AlertCircle, MessageSquare, Clock, Download } from "lucide-react";
 import { useShareData } from "./-share.data";
 
@@ -130,20 +132,13 @@ export default function SharePage() {
     if (!comments) return [] as Array<{ _id: string; timestampSeconds: number; resolved: boolean }>;
 
     const markers: Array<{ _id: string; timestampSeconds: number; resolved: boolean }> = [];
-    for (const comment of comments) {
+    walkThreadedComments(comments, (comment) => {
       markers.push({
         _id: comment._id,
         timestampSeconds: comment.timestampSeconds,
         resolved: comment.resolved,
       });
-      for (const reply of comment.replies) {
-        markers.push({
-          _id: reply._id,
-          timestampSeconds: reply.timestampSeconds,
-          resolved: reply.resolved,
-        });
-      }
-    }
+    });
     return markers;
   }, [comments]);
 
@@ -422,29 +417,10 @@ export default function SharePage() {
                     {formatRelativeTime(comment._creationTime)}
                   </p>
 
-                  {comment.replies.length > 0 ? (
-                    <div className="mt-3 ml-4 space-y-2 border-l-2 border-[#1a1a1a] pl-3">
-                      {comment.replies.map((reply) => (
-                        <div key={reply._id} className="text-sm">
-                          <div className="flex items-center justify-between gap-2">
-                            <span className="font-bold text-[#1a1a1a]">{reply.userName}</span>
-                            <button
-                              type="button"
-                              className="font-mono text-xs text-[#2d5a2d] hover:text-[#1a1a1a]"
-                              onClick={() =>
-                                playerRef.current?.seekTo(reply.timestampSeconds, { play: true })
-                              }
-                            >
-                              {formatTimestamp(reply.timestampSeconds)}
-                            </button>
-                          </div>
-                          <p className="break-words whitespace-pre-wrap text-[#1a1a1a]">
-                            <CommentText text={reply.text} />
-                          </p>
-                        </div>
-                      ))}
-                    </div>
-                  ) : null}
+                  <NestedReplies
+                    replies={comment.replies}
+                    onSeek={(seconds) => playerRef.current?.seekTo(seconds, { play: true })}
+                  />
                 </article>
               ))}
             </div>

--- a/app/routes/-watch.tsx
+++ b/app/routes/-watch.tsx
@@ -17,8 +17,10 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { CommentText } from "@/components/comments/CommentText";
+import { NestedReplies } from "@/components/comments/NestedReplies";
 import { triggerDownload } from "@/lib/download";
 import { watchPath } from "@/lib/routes";
+import { walkThreadedComments } from "@/lib/threadedComments";
 import { cn, formatDuration, formatTimestamp, formatRelativeTime } from "@/lib/utils";
 import {
   AlertCircle,
@@ -98,20 +100,13 @@ export default function WatchPage() {
     if (!comments) return [] as Array<{ _id: string; timestampSeconds: number; resolved: boolean }>;
 
     const markers: Array<{ _id: string; timestampSeconds: number; resolved: boolean }> = [];
-    for (const comment of comments) {
+    walkThreadedComments(comments, (comment) => {
       markers.push({
         _id: comment._id,
         timestampSeconds: comment.timestampSeconds,
         resolved: comment.resolved,
       });
-      for (const reply of comment.replies) {
-        markers.push({
-          _id: reply._id,
-          timestampSeconds: reply.timestampSeconds,
-          resolved: reply.resolved,
-        });
-      }
-    }
+    });
     return markers;
   }, [comments]);
 
@@ -393,31 +388,10 @@ export default function WatchPage() {
                       {formatRelativeTime(comment._creationTime)}
                     </p>
 
-                    {comment.replies.length > 0 ? (
-                      <div className="mt-3 ml-4 space-y-2 border-l-2 border-[#1a1a1a] pl-3">
-                        {comment.replies.map((reply) => (
-                          <div key={reply._id} className="text-sm">
-                            <div className="flex items-center justify-between gap-2">
-                              <span className="font-bold text-[#1a1a1a]">{reply.userName}</span>
-                              <button
-                                type="button"
-                                className="font-mono text-xs text-[#2d5a2d] hover:text-[#1a1a1a]"
-                                onClick={() =>
-                                  playerRef.current?.seekTo(reply.timestampSeconds, {
-                                    play: true,
-                                  })
-                                }
-                              >
-                                {formatTimestamp(reply.timestampSeconds)}
-                              </button>
-                            </div>
-                            <p className="break-words whitespace-pre-wrap text-[#1a1a1a]">
-                              <CommentText text={reply.text} />
-                            </p>
-                          </div>
-                        ))}
-                      </div>
-                    ) : null}
+                    <NestedReplies
+                      replies={comment.replies}
+                      onSeek={(seconds) => playerRef.current?.seekTo(seconds, { play: true })}
+                    />
                   </article>
                 ))}
               </div>
@@ -514,30 +488,13 @@ export default function WatchPage() {
                       {formatRelativeTime(comment._creationTime)}
                     </p>
 
-                    {comment.replies.length > 0 ? (
-                      <div className="mt-3 ml-4 space-y-2 border-l-2 border-[#1a1a1a] pl-3">
-                        {comment.replies.map((reply) => (
-                          <div key={reply._id} className="text-sm">
-                            <div className="flex items-center justify-between gap-2">
-                              <span className="font-bold text-[#1a1a1a]">{reply.userName}</span>
-                              <button
-                                type="button"
-                                className="font-mono text-xs text-[#2d5a2d] hover:text-[#1a1a1a]"
-                                onClick={() => {
-                                  playerRef.current?.seekTo(reply.timestampSeconds, { play: true });
-                                  setMobileCommentsOpen(false);
-                                }}
-                              >
-                                {formatTimestamp(reply.timestampSeconds)}
-                              </button>
-                            </div>
-                            <p className="break-words whitespace-pre-wrap text-[#1a1a1a]">
-                              <CommentText text={reply.text} />
-                            </p>
-                          </div>
-                        ))}
-                      </div>
-                    ) : null}
+                    <NestedReplies
+                      replies={comment.replies}
+                      onSeek={(seconds) => {
+                        playerRef.current?.seekTo(seconds, { play: true });
+                        setMobileCommentsOpen(false);
+                      }}
+                    />
                   </article>
                 ))}
               </div>

--- a/convex/comments.ts
+++ b/convex/comments.ts
@@ -1,22 +1,57 @@
 import { v } from "convex/values";
 import { mutation, query, MutationCtx, QueryCtx } from "./_generated/server";
+import type { Id } from "./_generated/dataModel";
 import { identityAvatarUrl, identityName, requireVideoAccess, requireUser } from "./auth";
 import { resolveActiveShareGrant } from "./shareAccess";
 import { resolvePublicVideo } from "./videos";
 
+type ThreadedComment<T> = T & { replies: ThreadedComment<T>[] };
+
+/**
+ * Build an arbitrarily nested reply tree from a flat comment list.
+ * Top-level comments are sorted by video timestamp; replies by creation time.
+ */
 function toThreadedComments<
   T extends { _id: string; parentId?: string; timestampSeconds: number; _creationTime: number },
->(comments: T[]) {
-  const topLevel = comments
-    .filter((c) => !c.parentId)
-    .sort((a, b) => a.timestampSeconds - b.timestampSeconds);
+>(comments: T[]): ThreadedComment<T>[] {
+  const childrenByParent = new Map<string, T[]>();
+  const topLevel: T[] = [];
 
-  return topLevel.map((comment) => ({
-    ...comment,
-    replies: comments
-      .filter((c) => c.parentId === comment._id)
-      .sort((a, b) => a._creationTime - b._creationTime),
-  }));
+  for (const comment of comments) {
+    if (!comment.parentId) {
+      topLevel.push(comment);
+      continue;
+    }
+    const siblings = childrenByParent.get(comment.parentId) ?? [];
+    siblings.push(comment);
+    childrenByParent.set(comment.parentId, siblings);
+  }
+
+  topLevel.sort((a, b) => a.timestampSeconds - b.timestampSeconds);
+
+  function buildTree(comment: T): ThreadedComment<T> {
+    const children = childrenByParent.get(comment._id) ?? [];
+    children.sort((a, b) => a._creationTime - b._creationTime);
+    return {
+      ...comment,
+      replies: children.map(buildTree),
+    };
+  }
+
+  return topLevel.map(buildTree);
+}
+
+async function deleteCommentTree(ctx: MutationCtx, commentId: Id<"comments">) {
+  const replies = await ctx.db
+    .query("comments")
+    .withIndex("by_parent", (q) => q.eq("parentId", commentId))
+    .collect();
+
+  for (const reply of replies) {
+    await deleteCommentTree(ctx, reply._id);
+  }
+
+  await ctx.db.delete(commentId);
 }
 
 function toPublicCommentPayload(comment: {
@@ -197,16 +232,8 @@ export const remove = mutation({
       await requireVideoAccess(ctx, comment.videoId, "admin");
     }
 
-    const replies = await ctx.db
-      .query("comments")
-      .withIndex("by_parent", (q) => q.eq("parentId", args.commentId))
-      .collect();
-
-    for (const reply of replies) {
-      await ctx.db.delete(reply._id);
-    }
-
-    await ctx.db.delete(args.commentId);
+    // Cascade so nested reply trees are not orphaned.
+    await deleteCommentTree(ctx, args.commentId);
   },
 });
 

--- a/src/components/comments/CommentItem.tsx
+++ b/src/components/comments/CommentItem.tsx
@@ -35,7 +35,11 @@ interface CommentItemProps {
   onTimestampClick: (seconds: number) => void;
   isHighlighted?: boolean;
   isReply?: boolean;
+  /** Soft-cap for nesting; when false, Reply is hidden. Defaults to true. */
+  canReply?: boolean;
   canResolve?: boolean;
+  /** Shown on nested replies so users see who this is responding to. */
+  replyToName?: string;
 }
 
 export function CommentItem({
@@ -43,7 +47,9 @@ export function CommentItem({
   onTimestampClick,
   isHighlighted = false,
   isReply = false,
+  canReply = true,
   canResolve = false,
+  replyToName,
 }: CommentItemProps) {
   const [isReplying, setIsReplying] = useState(false);
   const toggleResolved = useMutation(api.comments.toggleResolved);
@@ -76,14 +82,19 @@ export function CommentItem({
       )}
     >
       <div className="flex items-start gap-3">
-        <Avatar className="h-9 w-9 shadow-sm">
+        <Avatar className={cn("shadow-sm", isReply ? "h-7 w-7" : "h-9 w-9")}>
           <AvatarImage src={comment.userAvatarUrl} />
           <AvatarFallback className="text-[10px]">{getInitials(comment.userName)}</AvatarFallback>
         </Avatar>
         <div className="min-w-0 flex-1">
           <div className="flex items-center justify-between gap-2">
-            <div className="flex min-w-0 items-center gap-2">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
               <span className="truncate text-sm font-bold text-[#1a1a1a]">{comment.userName}</span>
+              {replyToName && (
+                <span className="truncate text-[11px] text-[#888]">
+                  replying to <span className="font-medium text-[#1a1a1a]">{replyToName}</span>
+                </span>
+              )}
               <button
                 onClick={() => onTimestampClick(comment.timestampSeconds)}
                 className="shrink-0 font-mono text-xs font-bold text-[#2d5a2d] hover:text-[#1a1a1a]"
@@ -103,13 +114,13 @@ export function CommentItem({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                {!isReply && (
+                {canReply && (
                   <DropdownMenuItem onClick={() => setIsReplying(true)}>
                     <Reply className="mr-2 h-4 w-4" />
                     Reply
                   </DropdownMenuItem>
                 )}
-                {canResolve && !isReply && (
+                {canResolve && (
                   <DropdownMenuItem onClick={handleToggleResolved}>
                     <Check className="mr-2 h-4 w-4" />
                     {comment.resolved ? "Unresolve" : "Resolve"}
@@ -135,7 +146,7 @@ export function CommentItem({
       </div>
 
       {isReplying && (
-        <div className="mt-3 ml-10">
+        <div className={cn("mt-3", isReply ? "ml-8" : "ml-10")}>
           <CommentInput
             videoId={comment.videoId}
             timestampSeconds={comment.timestampSeconds}

--- a/src/components/comments/CommentList.tsx
+++ b/src/components/comments/CommentList.tsx
@@ -6,8 +6,13 @@ import { Id } from "../../../convex/_generated/dataModel";
 import { FunctionReturnType } from "convex/server";
 import { CommentItem } from "./CommentItem";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
 
 type ThreadedComments = FunctionReturnType<typeof api.comments.getThreaded>;
+type ThreadedComment = ThreadedComments[number];
+
+/** Soft-cap nesting depth in the UI so layout stays usable on mobile. */
+const MAX_REPLY_DEPTH = 5;
 
 interface CommentListProps {
   videoId: Id<"videos">;
@@ -15,6 +20,65 @@ interface CommentListProps {
   onTimestampClick: (seconds: number) => void;
   highlightedCommentId?: Id<"comments">;
   canResolve?: boolean;
+}
+
+interface CommentThreadProps {
+  comment: ThreadedComment;
+  depth: number;
+  parentName?: string;
+  onTimestampClick: (seconds: number) => void;
+  highlightedCommentId?: Id<"comments">;
+  canResolve: boolean;
+}
+
+function CommentThread({
+  comment,
+  depth,
+  parentName,
+  onTimestampClick,
+  highlightedCommentId,
+  canResolve,
+}: CommentThreadProps) {
+  const isReply = depth > 0;
+  const canReply = depth < MAX_REPLY_DEPTH;
+
+  return (
+    <div className="relative">
+      <CommentItem
+        comment={comment}
+        onTimestampClick={onTimestampClick}
+        isHighlighted={highlightedCommentId === comment._id}
+        isReply={isReply}
+        canReply={canReply}
+        canResolve={canResolve}
+        replyToName={parentName}
+      />
+      {comment.replies.length > 0 && (
+        <div
+          className={cn(
+            "relative space-y-1",
+            // First nesting level uses the existing pl-14 rail; deeper levels indent less so mobile stays usable.
+            depth === 0 ? "space-y-2 pr-4 pb-4 pl-14" : "ml-3 space-y-1 border-l border-[#1a1a1a]/15 pr-2 pl-3 sm:ml-4 sm:pl-4 dark:border-white/10",
+          )}
+        >
+          {depth === 0 && (
+            <div className="absolute top-0 bottom-6 left-[1.35rem] w-px bg-[#1a1a1a]/10 dark:bg-white/10" />
+          )}
+          {comment.replies.map((reply) => (
+            <CommentThread
+              key={reply._id}
+              comment={reply}
+              depth={depth + 1}
+              parentName={comment.userName}
+              onTimestampClick={onTimestampClick}
+              highlightedCommentId={highlightedCommentId}
+              canResolve={canResolve}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }
 
 export function CommentList({
@@ -47,29 +111,14 @@ export function CommentList({
     <ScrollArea className="h-full">
       <div className="flex flex-col divide-y divide-[#1a1a1a]/10 dark:divide-white/10">
         {comments.map((comment) => (
-          <div key={comment._id} className="relative">
-            <CommentItem
-              comment={comment}
-              onTimestampClick={onTimestampClick}
-              isHighlighted={highlightedCommentId === comment._id}
-              canResolve={canResolve}
-            />
-            {comment.replies.length > 0 && (
-              <div className="relative space-y-4 pr-4 pb-4 pl-14">
-                <div className="absolute top-0 bottom-6 left-[1.35rem] w-px bg-[#1a1a1a]/10 dark:bg-white/10" />
-                {comment.replies.map((reply) => (
-                  <CommentItem
-                    key={reply._id}
-                    comment={reply}
-                    onTimestampClick={onTimestampClick}
-                    isHighlighted={highlightedCommentId === reply._id}
-                    isReply
-                    canResolve={canResolve}
-                  />
-                ))}
-              </div>
-            )}
-          </div>
+          <CommentThread
+            key={comment._id}
+            comment={comment}
+            depth={0}
+            onTimestampClick={onTimestampClick}
+            highlightedCommentId={highlightedCommentId}
+            canResolve={canResolve}
+          />
         ))}
       </div>
     </ScrollArea>

--- a/src/components/comments/NestedReplies.tsx
+++ b/src/components/comments/NestedReplies.tsx
@@ -1,0 +1,64 @@
+import { CommentText } from "./CommentText";
+import { formatTimestamp } from "@/lib/utils";
+import { cn } from "@/lib/utils";
+
+export interface NestedReplyNode {
+  _id: string;
+  userName: string;
+  text: string;
+  timestampSeconds: number;
+  replies: NestedReplyNode[];
+}
+
+interface NestedRepliesProps {
+  replies: NestedReplyNode[];
+  onSeek: (seconds: number) => void;
+  depth?: number;
+  /** Soft-cap so public/share layouts stay readable on small screens. */
+  maxDepth?: number;
+}
+
+/**
+ * Read-only recursive reply tree for public watch / share pages.
+ */
+export function NestedReplies({
+  replies,
+  onSeek,
+  depth = 1,
+  maxDepth = 5,
+}: NestedRepliesProps) {
+  if (replies.length === 0 || depth > maxDepth) return null;
+
+  return (
+    <div
+      className={cn(
+        "mt-3 space-y-2 border-l-2 border-[#1a1a1a] pl-3",
+        depth === 1 ? "ml-4" : "ml-2",
+      )}
+    >
+      {replies.map((reply) => (
+        <div key={reply._id} className="text-sm">
+          <div className="flex items-center justify-between gap-2">
+            <span className="font-bold text-[#1a1a1a]">{reply.userName}</span>
+            <button
+              type="button"
+              className="font-mono text-xs text-[#2d5a2d] hover:text-[#1a1a1a]"
+              onClick={() => onSeek(reply.timestampSeconds)}
+            >
+              {formatTimestamp(reply.timestampSeconds)}
+            </button>
+          </div>
+          <p className="break-words whitespace-pre-wrap text-[#1a1a1a]">
+            <CommentText text={reply.text} />
+          </p>
+          <NestedReplies
+            replies={reply.replies}
+            onSeek={onSeek}
+            depth={depth + 1}
+            maxDepth={maxDepth}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/commentCsv.test.ts
+++ b/src/lib/commentCsv.test.ts
@@ -11,10 +11,18 @@ test("exports comments and replies in thread order", () => {
         {
           text: "First reply",
           timestampSeconds: 65,
+          replies: [
+            {
+              text: "Nested reply",
+              timestampSeconds: 66,
+              replies: [],
+            },
+          ],
         },
         {
           text: "Second reply",
           timestampSeconds: 65,
+          replies: [],
         },
       ],
     },
@@ -31,6 +39,7 @@ test("exports comments and replies in thread order", () => {
       "Timestamp,Comment",
       '"1:05","First comment"',
       '"1:05","Reply: First reply"',
+      '"1:06","Reply: Nested reply"',
       '"1:05","Reply: Second reply"',
       '"2:05","Later comment"',
     ].join("\r\n"),
@@ -46,6 +55,7 @@ test("escapes CSV content and neutralizes spreadsheet formulas", () => {
         {
           text: "Reply with a comma, too",
           timestampSeconds: 0,
+          replies: [],
         },
       ],
     },

--- a/src/lib/commentCsv.ts
+++ b/src/lib/commentCsv.ts
@@ -6,7 +6,7 @@ interface CsvComment {
 }
 
 interface CsvCommentThread extends CsvComment {
-  replies: CsvComment[];
+  replies: CsvCommentThread[];
 }
 
 function escapeCsvCell(value: string) {
@@ -14,14 +14,21 @@ function escapeCsvCell(value: string) {
   return `"${spreadsheetSafeValue.replaceAll('"', '""')}"`;
 }
 
+function flattenCommentRows(
+  comment: CsvCommentThread,
+  isReply = false,
+): Array<{ text: string; timestampSeconds: number }> {
+  return [
+    {
+      timestampSeconds: comment.timestampSeconds,
+      text: isReply ? `Reply: ${comment.text}` : comment.text,
+    },
+    ...comment.replies.flatMap((reply) => flattenCommentRows(reply, true)),
+  ];
+}
+
 export function buildCommentsCsv(comments: CsvCommentThread[]) {
-  const rows = comments.flatMap((comment) => [
-    comment,
-    ...comment.replies.map((reply) => ({
-      ...reply,
-      text: `Reply: ${reply.text}`,
-    })),
-  ]);
+  const rows = comments.flatMap((comment) => flattenCommentRows(comment));
 
   return [
     "Timestamp,Comment",

--- a/src/lib/threadedComments.ts
+++ b/src/lib/threadedComments.ts
@@ -1,0 +1,15 @@
+/**
+ * Depth-first walk of a threaded comment tree (arbitrary nesting).
+ */
+export function walkThreadedComments<T extends { replies: T[] }>(
+  comments: T[],
+  visit: (comment: T, depth: number) => void,
+  depth = 0,
+) {
+  for (const comment of comments) {
+    visit(comment, depth);
+    if (comment.replies.length > 0) {
+      walkThreadedComments(comment.replies, visit, depth + 1);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Make `toThreadedComments` build an arbitrarily nested reply tree (was one level only).
- Enable **Reply** (and resolve) on nested comments in the dashboard UI with recursive rendering and a soft depth cap (~5).
- Cascade-delete full reply trees so nested descendants are not orphaned.
- Walk nested replies for CSV export and public watch/share timeline markers + display.

Closes https://github.com/pingdotgg/lawn/issues/13

## Test plan
- [ ] Open a video, post a top-level comment, reply to it, then reply to the reply — nested UI should indent correctly.
- [ ] Resolve and delete nested comments; deleting a parent should remove descendants.
- [ ] Export CSV includes nested replies in thread order.
- [ ] Public `/watch` and share pages show nested replies and timeline markers for them.
- [ ] Reply option stops after ~5 levels of nesting.
- [ ] `bun test src/lib/commentCsv.test.ts` and typecheck pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes comment delete semantics (cascade) and threading shape consumed by multiple UIs; create/parent validation is unchanged but wrong trees would affect markers and export.
> 
> **Overview**
> Comment threads can nest **beyond one level** everywhere: backend threading, dashboard UI, public watch/share, CSV export, and timeline markers.
> 
> **Backend:** `toThreadedComments` now builds a full tree from `parentId` links (top-level by timestamp, siblings by creation time). Deleting a comment **recursively removes** all descendants via `deleteCommentTree` so nested replies are not orphaned.
> 
> **Dashboard:** `CommentList` renders threads with recursive `CommentThread`; nested items get **Reply** (hidden after ~5 levels), **Resolve**, and a “replying to …” label. `CommentItem` adjusts layout for nested replies.
> 
> **Public pages:** Share and watch routes use shared `NestedReplies` (read-only, depth-capped) and `walkThreadedComments` so **all nested comments** appear in the list and on the player timeline.
> 
> **Export:** `buildCommentsCsv` walks nested `replies` in depth-first order with the existing “Reply:” prefix on non-root rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08f3e65aee7d59d4e57af884319d8161e9ea6505. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add nested comment reply threads with recursive rendering and cascading deletion
> - Replaces single-level reply flattening with a recursive `toThreadedComments` tree builder in [convex/comments.ts](https://github.com/pingdotgg/lawn/pull/61/files#diff-c80a7dedb648ed766459b227a9ef3247e874e70bb4ff22caf5309ed4d0ce30e4), supporting arbitrary nesting depth.
> - Adds a `CommentThread` recursive component in [CommentList.tsx](https://github.com/pingdotgg/lawn/pull/61/files#diff-d2076decc108172cb4f6b910851b7c9153675cd301cbbd961d342fc9f7f493d5) and a `NestedReplies` component in [NestedReplies.tsx](https://github.com/pingdotgg/lawn/pull/61/files#diff-d41419ada1fbc226d7826db94e7c0bb4d1c8257a25539fa86ec64584c6b89039) for read-only public/share pages, both capped at depth 5.
> - Adds `walkThreadedComments` in [threadedComments.ts](https://github.com/pingdotgg/lawn/pull/61/files#diff-a1a94aa1f27995c0257498c9b3b2368e9498b7a8f8b7e33b4ae3c81ba9a95775) for depth-first traversal; used in watch and share pages to collect timeline markers from all nested replies.
> - Replaces single-level reply deletion with a recursive `deleteCommentTree` that cascades to all descendants before deleting the parent.
> - `CommentItem` gains `canReply` and `replyToName` props; resolve/unresolve is now available on nested replies regardless of depth.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08f3e65.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->