### PR TITLE
feat: gang video players (lead/follow playback sync)

### DIFF
--- a/app/routes/-share.tsx
+++ b/app/routes/-share.tsx
@@ -11,7 +11,9 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { triggerDownload } from "@/lib/download";
 import { formatDuration, formatTimestamp, formatRelativeTime } from "@/lib/utils";
 import { useVideoPresence } from "@/lib/useVideoPresence";
+import { useGangPlaybackSync } from "@/lib/useGangPlaybackSync";
 import { VideoWatchers } from "@/components/presence/VideoWatchers";
+import { GangPlaybackControls } from "@/components/presence/GangPlaybackControls";
 import { CommentText } from "@/components/comments/CommentText";
 import { Lock, Video, AlertCircle, MessageSquare, Clock, Download } from "lucide-react";
 import { useShareData } from "./-share.data";
@@ -52,11 +54,54 @@ export default function SharePage() {
 
   const { shareInfo, videoData, comments } = useShareData({ token, grantToken });
   const canTrackPresence = Boolean(playbackSession?.url && videoData?.video?._id);
-  const { watchers } = useVideoPresence({
+  const {
+    watchers,
+    canLead,
+    leader,
+    isLeading,
+    isFollowing,
+    followEnabled,
+    setFollowing,
+    claimLead,
+    releaseLead,
+    publishPlayback,
+  } = useVideoPresence({
     videoId: videoData?.video?._id,
     enabled: canTrackPresence,
     shareToken: token,
+    // Share viewers (guests) auto-follow when a leader is active. Team members
+    // who open the share link can still unfollow via the control.
+    isGuestViewer: true,
   });
+
+  useGangPlaybackSync({
+    enabled: isFollowing,
+    playerRef,
+    leaderPlayback: leader?.playback,
+    leaderUserId: leader?.userId,
+  });
+
+  const isPlayingRef = useRef(false);
+
+  const handleTimeUpdate = useCallback(
+    (time: number) => {
+      setCurrentTime(time);
+      publishPlayback(
+        { currentTime: time, paused: !isPlayingRef.current },
+        { force: !isPlayingRef.current },
+      );
+    },
+    [publishPlayback],
+  );
+
+  const handlePlayStateChange = useCallback(
+    (playing: boolean) => {
+      isPlayingRef.current = playing;
+      const time = playerRef.current?.getPlaybackState().currentTime ?? currentTime;
+      publishPlayback({ currentTime: time, paused: !playing }, { force: true });
+    },
+    [currentTime, publishPlayback],
+  );
 
   useEffect(() => {
     setGrantToken(null);
@@ -321,11 +366,22 @@ export default function SharePage() {
         <div>
           <h1 className="text-2xl font-black text-[#1a1a1a]">{video.title}</h1>
           {video.description && <p className="mt-1 text-[#888]">{video.description}</p>}
-          <div className="mt-2 flex items-center gap-4 text-sm text-[#888]">
+          <div className="mt-2 flex flex-wrap items-center gap-4 text-sm text-[#888]">
             {video.duration && <span className="font-mono">{formatDuration(video.duration)}</span>}
             {comments && <span>{comments.length} threads</span>}
             <VideoWatchers watchers={watchers} className="ml-auto" />
           </div>
+          <GangPlaybackControls
+            className="mt-3"
+            canLead={canLead}
+            isLeading={isLeading}
+            leader={leader}
+            isFollowing={isFollowing}
+            followEnabled={followEnabled}
+            onClaimLead={() => void claimLead()}
+            onReleaseLead={() => void releaseLead()}
+            onToggleFollow={() => setFollowing(!followEnabled)}
+          />
         </div>
 
         <div className="overflow-hidden border-2 border-[#1a1a1a]">
@@ -335,7 +391,8 @@ export default function SharePage() {
               src={playbackSession.url}
               poster={playbackSession.posterUrl}
               comments={flattenedComments}
-              onTimeUpdate={setCurrentTime}
+              onTimeUpdate={handleTimeUpdate}
+              onPlayStateChange={handlePlayStateChange}
               allowDownload={false}
             />
           ) : (

--- a/app/routes/dashboard/-video.tsx
+++ b/app/routes/dashboard/-video.tsx
@@ -21,8 +21,10 @@ import { cn, formatDuration } from "@/lib/utils";
 import { buildCommentsCsv, buildCommentsCsvFilename } from "@/lib/commentCsv";
 import { triggerTextDownload } from "@/lib/download";
 import { useVideoPresence } from "@/lib/useVideoPresence";
+import { useGangPlaybackSync } from "@/lib/useGangPlaybackSync";
 import { useSidebarCollapsed } from "@/lib/useSidebarCollapsed";
 import { VideoWatchers } from "@/components/presence/VideoWatchers";
+import { GangPlaybackControls } from "@/components/presence/GangPlaybackControls";
 import { DashboardHeader } from "@/components/DashboardHeader";
 import { UploadButton } from "@/components/upload/UploadButton";
 import { useDashboardUploadContext } from "@/lib/dashboardUploadContext";
@@ -395,9 +397,28 @@ export default function VideoPage() {
       projectId: resolvedProjectId,
     });
   });
-  const { watchers } = useVideoPresence({
+  const {
+    watchers,
+    canLead,
+    leader,
+    isLeading,
+    isFollowing,
+    followEnabled,
+    setFollowing,
+    claimLead,
+    releaseLead,
+    publishPlayback,
+  } = useVideoPresence({
     videoId: resolvedVideoId,
     enabled: Boolean(resolvedVideoId),
+    isGuestViewer: false,
+  });
+
+  useGangPlaybackSync({
+    enabled: isFollowing,
+    playerRef,
+    leaderPlayback: leader?.playback,
+    leaderUserId: leader?.userId,
   });
 
   useEffect(() => {
@@ -550,9 +571,28 @@ export default function VideoPage() {
     };
   }, [getOriginalPlaybackUrl, resolvedVideoId, video?.status, video?.s3Key]);
 
-  const handleTimeUpdate = useCallback((time: number) => {
-    setCurrentTime(time);
-  }, []);
+  const isPlayingRef = useRef(false);
+
+  const handleTimeUpdate = useCallback(
+    (time: number) => {
+      setCurrentTime(time);
+      // Throttled while playing; force on pause is handled by play-state.
+      publishPlayback(
+        { currentTime: time, paused: !isPlayingRef.current },
+        { force: !isPlayingRef.current },
+      );
+    },
+    [publishPlayback],
+  );
+
+  const handlePlayStateChange = useCallback(
+    (playing: boolean) => {
+      isPlayingRef.current = playing;
+      const time = playerRef.current?.getPlaybackState().currentTime ?? currentTime;
+      publishPlayback({ currentTime: time, paused: !playing }, { force: true });
+    },
+    [currentTime, publishPlayback],
+  );
 
   const handleOriginalPlaybackIssue = useCallback(
     (issue: VideoPlaybackIssue) => {
@@ -919,6 +959,16 @@ export default function VideoPage() {
             </>
           )}
           <VideoWatchers watchers={watchers} />
+          <GangPlaybackControls
+            canLead={canLead}
+            isLeading={isLeading}
+            leader={leader}
+            isFollowing={isFollowing}
+            followEnabled={followEnabled}
+            onClaimLead={() => void claimLead()}
+            onReleaseLead={() => void releaseLead()}
+            onToggleFollow={() => setFollowing(!followEnabled)}
+          />
         </div>
         <div className="ml-1 hidden flex-shrink-0 items-center gap-3 border-l-2 border-[#1a1a1a]/20 pl-3 lg:flex">
           {showVersionSelector && (
@@ -1125,6 +1175,21 @@ export default function VideoPage() {
             </div>
           ) : null}
 
+          <div className="flex flex-shrink-0 flex-wrap items-center gap-2 border-b border-white/10 bg-black px-3 py-2 2xl:hidden">
+            <VideoWatchers watchers={watchers} className="mr-1" />
+            <GangPlaybackControls
+              tone="dark"
+              canLead={canLead}
+              isLeading={isLeading}
+              leader={leader}
+              isFollowing={isFollowing}
+              followEnabled={followEnabled}
+              onClaimLead={() => void claimLead()}
+              onReleaseLead={() => void releaseLead()}
+              onToggleFollow={() => setFollowing(!followEnabled)}
+            />
+          </div>
+
           {activePlaybackUrl ? (
             <VideoPlayer
               key={resolvedVideoId}
@@ -1135,6 +1200,7 @@ export default function VideoPage() {
               poster={playbackSession?.posterUrl}
               comments={comments || []}
               onTimeUpdate={handleTimeUpdate}
+              onPlayStateChange={handlePlayStateChange}
               onMarkerClick={handleMarkerClick}
               allowDownload={video.status === "ready"}
               downloadFilename={`${video.title}.mp4`}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -165,4 +165,14 @@ export default defineSchema({
     .index("by_token", ["token"])
     .index("by_share_link", ["shareLinkId"])
     .index("by_expires_at", ["expiresAt"]),
+
+  // Ephemeral gang-playback leader for a video room. Last claim wins.
+  // Presence payloads mirror `leading` for cheap client reads; this table is
+  // the auth-backed source of truth for who may drive play/pause/seek.
+  videoLeaders: defineTable({
+    videoId: v.id("videos"),
+    leaderUserId: v.string(),
+    displayName: v.string(),
+    claimedAt: v.number(),
+  }).index("by_video", ["videoId"]),
 });

--- a/convex/videoPresence.ts
+++ b/convex/videoPresence.ts
@@ -1,18 +1,44 @@
 import { Presence } from "@convex-dev/presence";
 import { ConvexError, v } from "convex/values";
 import { components } from "./_generated/api";
-import { mutation, query, MutationCtx } from "./_generated/server";
-import { identityAvatarUrl, identityName, requireProjectAccess, requireVideoAccess } from "./auth";
+import { mutation, query, MutationCtx, QueryCtx } from "./_generated/server";
+import { Id } from "./_generated/dataModel";
+import {
+  identityAvatarUrl,
+  identityName,
+  requireProjectAccess,
+  requireVideoAccess,
+} from "./auth";
 import { findShareLinkByToken } from "./shareAccess";
 
 const presence = new Presence(components.presence);
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 15_000;
 
+const playbackValidator = v.object({
+  currentTime: v.number(),
+  paused: v.boolean(),
+  updatedAt: v.number(),
+});
+
 const watcherDataValidator = v.object({
   kind: v.union(v.literal("member"), v.literal("guest")),
   displayName: v.string(),
   avatarUrl: v.optional(v.string()),
+  leading: v.optional(v.boolean()),
+  playback: v.optional(playbackValidator),
 });
+
+type WatcherData = {
+  kind: "member" | "guest";
+  displayName: string;
+  avatarUrl?: string;
+  leading?: boolean;
+  playback?: {
+    currentTime: number;
+    paused: boolean;
+    updatedAt: number;
+  };
+};
 
 function roomIdForVideo(videoId: string) {
   return `video:${videoId}`;
@@ -26,8 +52,21 @@ function guestDisplayName(clientId: string) {
   return `Guest ${suffix || "USER"}`;
 }
 
+function clampPlayback(playback: {
+  currentTime: number;
+  paused: boolean;
+  updatedAt: number;
+}) {
+  return {
+    currentTime: Math.max(0, playback.currentTime),
+    paused: playback.paused,
+    // Reject absurd future timestamps; keep a small skew allowance.
+    updatedAt: Math.min(playback.updatedAt, Date.now() + 5_000),
+  };
+}
+
 async function hasShareTokenAccess(
-  ctx: MutationCtx,
+  ctx: MutationCtx | QueryCtx,
   shareToken: string | undefined,
   videoId: string,
 ) {
@@ -40,6 +79,170 @@ async function hasShareTokenAccess(
   return shareLink.videoId === videoId;
 }
 
+async function assertVideoRoomAccess(
+  ctx: MutationCtx,
+  videoId: Id<"videos">,
+  shareToken: string | undefined,
+) {
+  const identity = await ctx.auth.getUserIdentity();
+
+  let hasVideoAccess = false;
+  if (identity) {
+    try {
+      await requireVideoAccess(ctx, videoId, "viewer");
+      hasVideoAccess = true;
+    } catch {
+      hasVideoAccess = false;
+    }
+  }
+
+  // Only check share-token access when video membership didn't already grant
+  // access. This avoids a by_token index read on every authenticated
+  // heartbeat (the hottest path in the app).
+  if (!hasVideoAccess) {
+    const hasTokenAccess = await hasShareTokenAccess(ctx, shareToken, videoId);
+    if (!hasTokenAccess) {
+      throw new ConvexError({
+        code: "UNAUTHORIZED",
+        message: "You do not have access to this video.",
+      });
+    }
+  }
+
+  return identity;
+}
+
+async function resolvePresenceIdentity(
+  ctx: MutationCtx,
+  videoId: Id<"videos">,
+  clientId: string,
+  shareToken: string | undefined,
+) {
+  const identity = await assertVideoRoomAccess(ctx, videoId, shareToken);
+
+  if (identity) {
+    return {
+      userId: `clerk:${identity.subject}`,
+      kind: "member" as const,
+      displayName: identityName(identity),
+      avatarUrl: identityAvatarUrl(identity),
+      clerkSubject: identity.subject,
+    };
+  }
+
+  const trimmedClientId = clientId.trim();
+  if (!trimmedClientId) {
+    throw new ConvexError({
+      code: "BAD_REQUEST",
+      message: "Missing client identifier.",
+    });
+  }
+
+  return {
+    userId: `guest:${trimmedClientId}`,
+    kind: "guest" as const,
+    displayName: guestDisplayName(trimmedClientId),
+    avatarUrl: undefined as string | undefined,
+    clerkSubject: null as string | null,
+  };
+}
+
+async function getVideoLeader(ctx: QueryCtx | MutationCtx, videoId: Id<"videos">) {
+  return await ctx.db
+    .query("videoLeaders")
+    .withIndex("by_video", (q) => q.eq("videoId", videoId))
+    .unique();
+}
+
+function buildWatcherData(input: {
+  kind: "member" | "guest";
+  displayName: string;
+  avatarUrl?: string;
+  userId: string;
+  leaderUserId?: string | null;
+  playback?: {
+    currentTime: number;
+    paused: boolean;
+    updatedAt: number;
+  };
+}): WatcherData {
+  const data: WatcherData = {
+    kind: input.kind,
+    displayName: input.displayName,
+  };
+
+  if (input.avatarUrl) {
+    data.avatarUrl = input.avatarUrl;
+  }
+
+  if (input.leaderUserId && input.leaderUserId === input.userId) {
+    data.leading = true;
+  }
+
+  if (input.playback) {
+    data.playback = clampPlayback(input.playback);
+  }
+
+  return data;
+}
+
+function parseWatcherData(raw: unknown, userId: string): WatcherData {
+  if (
+    raw &&
+    typeof raw === "object" &&
+    ("kind" in raw || "displayName" in raw) &&
+    (raw as { kind?: string }).kind &&
+    (raw as { displayName?: string }).displayName
+  ) {
+    const candidate = raw as {
+      kind: "member" | "guest";
+      displayName: string;
+      avatarUrl?: string;
+      leading?: boolean;
+      playback?: {
+        currentTime: number;
+        paused: boolean;
+        updatedAt: number;
+      };
+    };
+
+    const data: WatcherData = {
+      kind: candidate.kind === "guest" ? "guest" : "member",
+      displayName: candidate.displayName,
+    };
+
+    if (candidate.avatarUrl) {
+      data.avatarUrl = candidate.avatarUrl;
+    }
+    if (candidate.leading) {
+      data.leading = true;
+    }
+    if (
+      candidate.playback &&
+      typeof candidate.playback.currentTime === "number" &&
+      typeof candidate.playback.paused === "boolean" &&
+      typeof candidate.playback.updatedAt === "number"
+    ) {
+      data.playback = clampPlayback(candidate.playback);
+    }
+
+    return data;
+  }
+
+  if (userId.startsWith("guest:")) {
+    const clientId = userId.slice("guest:".length);
+    return {
+      kind: "guest",
+      displayName: guestDisplayName(clientId),
+    };
+  }
+
+  return {
+    kind: "member",
+    displayName: "Member",
+  };
+}
+
 export const heartbeat = mutation({
   args: {
     videoId: v.id("videos"),
@@ -47,77 +250,248 @@ export const heartbeat = mutation({
     clientId: v.string(),
     interval: v.optional(v.number()),
     shareToken: v.optional(v.string()),
+    // Optional: keep playback on the identity refresh path so heartbeats
+    // don't wipe a more recent playback publish.
+    playback: v.optional(playbackValidator),
   },
   returns: v.object({
     roomToken: v.string(),
     sessionToken: v.string(),
+    userId: v.string(),
   }),
   handler: async (ctx, args) => {
-    const identity = await ctx.auth.getUserIdentity();
-
-    let hasVideoAccess = false;
-    if (identity) {
-      try {
-        await requireVideoAccess(ctx, args.videoId, "viewer");
-        hasVideoAccess = true;
-      } catch {
-        hasVideoAccess = false;
-      }
-    }
-
-    // Only check share-token access when video membership didn't already grant
-    // access. This avoids a by_token index read on every authenticated
-    // heartbeat (the hottest path in the app).
-    if (!hasVideoAccess) {
-      const hasTokenAccess = await hasShareTokenAccess(ctx, args.shareToken, args.videoId);
-      if (!hasTokenAccess) {
-        throw new ConvexError({
-          code: "UNAUTHORIZED",
-          message: "You do not have access to this video.",
-        });
-      }
-    }
+    const identity = await resolvePresenceIdentity(
+      ctx,
+      args.videoId,
+      args.clientId,
+      args.shareToken,
+    );
 
     const roomId = roomIdForVideo(args.videoId);
-    let userId: string;
-    let data: {
-      kind: "member" | "guest";
-      displayName: string;
-      avatarUrl?: string;
-    };
-
-    if (identity) {
-      userId = `clerk:${identity.subject}`;
-      data = {
-        kind: "member",
-        displayName: identityName(identity),
-        avatarUrl: identityAvatarUrl(identity),
-      };
-    } else {
-      const clientId = args.clientId.trim();
-      if (!clientId) {
-        throw new ConvexError({
-          code: "BAD_REQUEST",
-          message: "Missing client identifier.",
-        });
-      }
-
-      userId = `guest:${clientId}`;
-      data = {
-        kind: "guest",
-        displayName: guestDisplayName(clientId),
-      };
-    }
+    const leader = await getVideoLeader(ctx, args.videoId);
 
     const result = await presence.heartbeat(
       ctx,
       roomId,
-      userId,
+      identity.userId,
       args.sessionId,
       args.interval ?? DEFAULT_HEARTBEAT_INTERVAL_MS,
     );
-    await presence.updateRoomUser(ctx, roomId, userId, data);
-    return result;
+
+    await presence.updateRoomUser(
+      ctx,
+      roomId,
+      identity.userId,
+      buildWatcherData({
+        kind: identity.kind,
+        displayName: identity.displayName,
+        avatarUrl: identity.avatarUrl,
+        userId: identity.userId,
+        leaderUserId: leader?.leaderUserId,
+        playback: args.playback,
+      }),
+    );
+
+    return {
+      ...result,
+      userId: identity.userId,
+    };
+  },
+});
+
+/**
+ * Publish playhead / play-pause state for the current user.
+ * Intended to be throttled on the client (~250–500ms while playing;
+ * immediate on pause / seek / play).
+ */
+export const updatePlayback = mutation({
+  args: {
+    videoId: v.id("videos"),
+    clientId: v.string(),
+    shareToken: v.optional(v.string()),
+    playback: playbackValidator,
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const identity = await resolvePresenceIdentity(
+      ctx,
+      args.videoId,
+      args.clientId,
+      args.shareToken,
+    );
+
+    const roomId = roomIdForVideo(args.videoId);
+    const leader = await getVideoLeader(ctx, args.videoId);
+
+    await presence.updateRoomUser(
+      ctx,
+      roomId,
+      identity.userId,
+      buildWatcherData({
+        kind: identity.kind,
+        displayName: identity.displayName,
+        avatarUrl: identity.avatarUrl,
+        userId: identity.userId,
+        leaderUserId: leader?.leaderUserId,
+        playback: args.playback,
+      }),
+    );
+
+    return null;
+  },
+});
+
+/**
+ * Project members (member+) can claim lead. Last claim wins.
+ * Guests and viewers cannot lead.
+ */
+export const claimLead = mutation({
+  args: {
+    videoId: v.id("videos"),
+    playback: v.optional(playbackValidator),
+  },
+  returns: v.object({
+    leaderUserId: v.string(),
+    displayName: v.string(),
+  }),
+  handler: async (ctx, args) => {
+    // Only authenticated team members with member+ may lead.
+    const { user } = await requireVideoAccess(ctx, args.videoId, "member");
+    const userId = `clerk:${user.subject}`;
+    const displayName = identityName(user);
+    const avatarUrl = identityAvatarUrl(user);
+    const roomId = roomIdForVideo(args.videoId);
+    const now = Date.now();
+
+    const existing = await getVideoLeader(ctx, args.videoId);
+    if (existing) {
+      if (existing.leaderUserId !== userId) {
+        // Clear leading flag on the previous leader's presence payload when possible.
+        await presence.updateRoomUser(ctx, roomId, existing.leaderUserId, {
+          kind: "member",
+          displayName: existing.displayName,
+          leading: false,
+        });
+      }
+      await ctx.db.patch(existing._id, {
+        leaderUserId: userId,
+        displayName,
+        claimedAt: now,
+      });
+    } else {
+      await ctx.db.insert("videoLeaders", {
+        videoId: args.videoId,
+        leaderUserId: userId,
+        displayName,
+        claimedAt: now,
+      });
+    }
+
+    // Ensure the claimer is in the room with leading + optional playback.
+    // Room join is separate (heartbeat); update is a no-op if not present yet.
+    await presence.updateRoomUser(
+      ctx,
+      roomId,
+      userId,
+      buildWatcherData({
+        kind: "member",
+        displayName,
+        avatarUrl,
+        userId,
+        leaderUserId: userId,
+        playback: args.playback,
+      }),
+    );
+
+    return { leaderUserId: userId, displayName };
+  },
+});
+
+export const releaseLead = mutation({
+  args: {
+    videoId: v.id("videos"),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const { user } = await requireVideoAccess(ctx, args.videoId, "member");
+    const userId = `clerk:${user.subject}`;
+    const existing = await getVideoLeader(ctx, args.videoId);
+    if (!existing) return null;
+
+    // Only the current leader (or an admin+) may release.
+    if (existing.leaderUserId !== userId) {
+      await requireVideoAccess(ctx, args.videoId, "admin");
+    }
+
+    await ctx.db.delete(existing._id);
+
+    const roomId = roomIdForVideo(args.videoId);
+    await presence.updateRoomUser(ctx, roomId, existing.leaderUserId, {
+      kind: "member",
+      displayName: existing.displayName,
+      leading: false,
+    });
+
+    return null;
+  },
+});
+
+export const canLead = query({
+  args: {
+    videoId: v.id("videos"),
+  },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    try {
+      await requireVideoAccess(ctx, args.videoId, "member");
+      return true;
+    } catch {
+      return false;
+    }
+  },
+});
+
+export const getLeader = query({
+  args: {
+    videoId: v.id("videos"),
+    shareToken: v.optional(v.string()),
+  },
+  returns: v.union(
+    v.null(),
+    v.object({
+      leaderUserId: v.string(),
+      displayName: v.string(),
+      claimedAt: v.number(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    let hasAccess = false;
+
+    if (identity) {
+      try {
+        await requireVideoAccess(ctx, args.videoId, "viewer");
+        hasAccess = true;
+      } catch {
+        hasAccess = false;
+      }
+    }
+
+    if (!hasAccess) {
+      const hasTokenAccess = await hasShareTokenAccess(ctx, args.shareToken, args.videoId);
+      if (!hasTokenAccess) {
+        return null;
+      }
+    }
+
+    const leader = await getVideoLeader(ctx, args.videoId);
+    if (!leader) return null;
+
+    return {
+      leaderUserId: leader.leaderUserId,
+      displayName: leader.displayName,
+      claimedAt: leader.claimedAt,
+    };
   },
 });
 
@@ -136,53 +510,12 @@ export const list = query({
   handler: async (ctx, args) => {
     const state = await presence.list(ctx, args.roomToken);
 
-    return state.map((entry) => {
-      const raw = entry.data;
-      const parsed =
-        raw &&
-        typeof raw === "object" &&
-        ("kind" in raw || "displayName" in raw) &&
-        (raw as { kind?: string }).kind &&
-        (raw as { displayName?: string }).displayName
-          ? (raw as {
-              kind: "member" | "guest";
-              displayName: string;
-              avatarUrl?: string;
-            })
-          : undefined;
-
-      if (parsed) {
-        return {
-          userId: entry.userId,
-          online: entry.online,
-          lastDisconnected: entry.lastDisconnected,
-          data: parsed,
-        };
-      }
-
-      if (entry.userId.startsWith("guest:")) {
-        const clientId = entry.userId.slice("guest:".length);
-        return {
-          userId: entry.userId,
-          online: entry.online,
-          lastDisconnected: entry.lastDisconnected,
-          data: {
-            kind: "guest" as const,
-            displayName: guestDisplayName(clientId),
-          },
-        };
-      }
-
-      return {
-        userId: entry.userId,
-        online: entry.online,
-        lastDisconnected: entry.lastDisconnected,
-        data: {
-          kind: "member" as const,
-          displayName: "Member",
-        },
-      };
-    });
+    return state.map((entry) => ({
+      userId: entry.userId,
+      online: entry.online,
+      lastDisconnected: entry.lastDisconnected,
+      data: parseWatcherData(entry.data, entry.userId),
+    }));
   },
 });
 

--- a/src/components/presence/GangPlaybackControls.tsx
+++ b/src/components/presence/GangPlaybackControls.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { Lock, LockOpen, Radio, Unlink } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export function GangPlaybackControls({
+  canLead,
+  isLeading,
+  leader,
+  isFollowing,
+  followEnabled,
+  onClaimLead,
+  onReleaseLead,
+  onToggleFollow,
+  className,
+  tone = "light",
+}: {
+  canLead: boolean;
+  isLeading: boolean;
+  leader: { displayName: string; online: boolean } | null;
+  isFollowing: boolean;
+  followEnabled: boolean;
+  onClaimLead: () => void;
+  onReleaseLead: () => void;
+  onToggleFollow: () => void;
+  className?: string;
+  /** light = cream page chrome; dark = on-video black bar */
+  tone?: "light" | "dark";
+}) {
+  const hasLeader = Boolean(leader);
+  const showFollowToggle = hasLeader && !isLeading;
+  const isDark = tone === "dark";
+
+  const solidLead = cn(
+    "inline-flex h-8 items-center gap-1.5 border-2 px-3 text-[11px] font-bold tracking-wide uppercase transition",
+    isDark
+      ? "border-white/30 bg-[#2d5a2d] text-[#f0f0e8] hover:bg-[#3a6a3a]"
+      : "border-[#1a1a1a] bg-[#2d5a2d] text-[#f0f0e8] hover:bg-[#3a6a3a]",
+  );
+
+  const outlineBtn = cn(
+    "inline-flex h-8 items-center gap-1.5 border-2 px-3 text-[11px] font-bold tracking-wide uppercase transition",
+    isDark
+      ? "border-white/25 bg-transparent text-white hover:border-white/50 hover:bg-white/10"
+      : "border-[#1a1a1a] bg-transparent text-[#1a1a1a] hover:bg-[#1a1a1a] hover:text-[#f0f0e8]",
+  );
+
+  const ghostBtn = cn(
+    "inline-flex h-8 items-center gap-1.5 border-2 border-transparent px-3 text-[11px] font-bold tracking-wide uppercase transition",
+    isDark
+      ? "text-white/80 hover:border-white/25 hover:bg-white/10 hover:text-white"
+      : "text-[#1a1a1a] hover:border-[#1a1a1a] hover:bg-[#1a1a1a] hover:text-[#f0f0e8]",
+  );
+
+  const followingPill = cn(
+    "inline-flex items-center gap-1.5 border-2 px-2.5 py-1 text-[11px] font-bold tracking-wide uppercase",
+    isDark
+      ? "border-white/30 bg-white text-[#1a1a1a]"
+      : "border-[#1a1a1a] bg-[#1a1a1a] text-[#f0f0e8]",
+  );
+
+  const leaderPill = cn(
+    "inline-flex items-center gap-1.5 border-2 px-2.5 py-1 text-[11px] font-bold tracking-wide uppercase",
+    isDark ? "border-white/20 text-white/60" : "border-[#ccc] text-[#888]",
+  );
+
+  return (
+    <div className={cn("flex flex-wrap items-center gap-2", className)}>
+      {isLeading ? (
+        <button type="button" className={solidLead} onClick={onReleaseLead} title="Stop leading">
+          <Lock className="h-3.5 w-3.5" />
+          Leading
+        </button>
+      ) : canLead ? (
+        <button
+          type="button"
+          className={outlineBtn}
+          onClick={onClaimLead}
+          title="Drive play/pause/seek for viewers who follow"
+        >
+          <LockOpen className="h-3.5 w-3.5" />
+          Lead
+        </button>
+      ) : null}
+
+      {isFollowing ? (
+        <span className={followingPill} title="Your player matches the leader">
+          <Radio className={cn("h-3 w-3", isDark ? "text-[#2d5a2d]" : "text-[#7cb87c]")} />
+          Following {leader?.displayName ?? "leader"}
+        </span>
+      ) : hasLeader && leader && !isLeading ? (
+        <span
+          className={leaderPill}
+          title={leader.online ? "Leader is live" : "Leader is offline"}
+        >
+          <Lock className="h-3 w-3" />
+          {leader.online ? `Led by ${leader.displayName}` : `${leader.displayName} (offline)`}
+        </span>
+      ) : null}
+
+      {showFollowToggle ? (
+        <button
+          type="button"
+          className={ghostBtn}
+          onClick={onToggleFollow}
+          title={followEnabled ? "Stop matching the leader" : "Match the leader's playback"}
+        >
+          {followEnabled ? (
+            <>
+              <Unlink className="h-3.5 w-3.5" />
+              Unfollow
+            </>
+          ) : (
+            <>
+              <Radio className="h-3.5 w-3.5" />
+              Follow
+            </>
+          )}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/video-player/VideoPlayer.tsx
+++ b/src/components/video-player/VideoPlayer.tsx
@@ -50,6 +50,8 @@ interface VideoPlayerProps {
   poster?: string;
   comments?: Comment[];
   onTimeUpdate?: (currentTime: number) => void;
+  /** Fires on play / pause / ended so callers can publish gang presence. */
+  onPlayStateChange?: (playing: boolean) => void;
   onMarkerClick?: (comment: Comment) => void;
   initialTime?: number;
   initialPlay?: boolean;
@@ -90,6 +92,9 @@ export type VideoPlaybackIssue =
 
 export interface VideoPlayerHandle {
   seekTo: (time: number, options?: { play?: boolean }) => void;
+  play: () => void;
+  pause: () => void;
+  getPlaybackState: () => { currentTime: number; paused: boolean };
 }
 
 const PLAYBACK_RATES = [0.5, 0.75, 1, 1.25, 1.5, 2] as const;
@@ -114,6 +119,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
     poster,
     comments = [],
     onTimeUpdate,
+    onPlayStateChange,
     onMarkerClick,
     initialTime,
     initialPlay = false,
@@ -166,10 +172,15 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
   const resumePlaybackOnSourceChangeRef = useRef(initialPlay);
   const hasAttachedSourceRef = useRef(false);
   const onPlaybackIssueRef = useRef(onPlaybackIssue);
+  const onPlayStateChangeRef = useRef(onPlayStateChange);
 
   useEffect(() => {
     onPlaybackIssueRef.current = onPlaybackIssue;
   }, [onPlaybackIssue]);
+
+  useEffect(() => {
+    onPlayStateChangeRef.current = onPlayStateChange;
+  }, [onPlayStateChange]);
 
   const groupedMarkers = useMemo(() => {
     if (!duration || comments.length === 0) return [] as { position: number; comment: Comment }[];
@@ -231,13 +242,45 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
             });
           }
         }
+      } else if (options?.play === false) {
+        videoRef.current?.pause();
       }
       showControls();
     },
     [applyTime, showControls],
   );
 
-  useImperativeHandle(ref, () => ({ seekTo }), [seekTo]);
+  const play = useCallback(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    const playPromise = video.play();
+    if (playPromise) {
+      playPromise.catch(() => {
+        // Ignore autoplay rejections.
+      });
+    }
+    showControls();
+  }, [showControls]);
+
+  const pause = useCallback(() => {
+    videoRef.current?.pause();
+    showControls();
+  }, [showControls]);
+
+  const getPlaybackState = useCallback(() => {
+    const video = videoRef.current;
+    return {
+      currentTime: video?.currentTime ?? 0,
+      paused: video ? video.paused || video.ended : true,
+    };
+  }, []);
+
+  useImperativeHandle(ref, () => ({ seekTo, play, pause, getPlaybackState }), [
+    seekTo,
+    play,
+    pause,
+    getPlaybackState,
+  ]);
 
   const handleSeekBy = useCallback(
     (delta: number) => {
@@ -576,6 +619,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
       setIsPlaying(true);
       setIsBuffering(false);
       showControls();
+      onPlayStateChangeRef.current?.(true);
     };
 
     const handlePause = () => {
@@ -584,6 +628,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
       setIsPlaying(false);
       setIsBuffering(false);
       setControlsVisible(true);
+      onPlayStateChangeRef.current?.(false);
     };
 
     const handleWaiting = () => {
@@ -649,6 +694,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
       if (cancelled) return;
       setIsPlaying(false);
       setControlsVisible(true);
+      onPlayStateChangeRef.current?.(false);
     };
 
     const startPlaybackHealthMonitor = () => {

--- a/src/lib/useGangPlaybackSync.ts
+++ b/src/lib/useGangPlaybackSync.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { VideoPlayerHandle } from "@/components/video-player/VideoPlayer";
+import {
+  estimatePlaybackTime,
+  type VideoPlaybackPresence,
+} from "@/lib/useVideoPresence";
+
+/** Only seek when drift exceeds this (seconds) to avoid thrashing. */
+const DRIFT_SEEK_SECONDS = 0.85;
+/** Ignore leader updates older than the last applied timestamp. */
+const STALE_EPSILON_MS = 0;
+
+/**
+ * Keep a local VideoPlayer in sync with a leader's playback presence.
+ * Applies play/pause immediately and seeks only on meaningful drift.
+ */
+export function useGangPlaybackSync(input: {
+  enabled: boolean;
+  playerRef: React.RefObject<VideoPlayerHandle | null>;
+  leaderPlayback?: VideoPlaybackPresence;
+  leaderUserId?: string | null;
+}) {
+  const { enabled, playerRef, leaderPlayback, leaderUserId } = input;
+  const lastAppliedUpdatedAtRef = useRef(0);
+  const lastLeaderUserIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      lastAppliedUpdatedAtRef.current = 0;
+      return;
+    }
+    if (!leaderPlayback) return;
+
+    // New leader — force re-apply.
+    if (leaderUserId && leaderUserId !== lastLeaderUserIdRef.current) {
+      lastLeaderUserIdRef.current = leaderUserId;
+      lastAppliedUpdatedAtRef.current = 0;
+    }
+
+    if (leaderPlayback.updatedAt + STALE_EPSILON_MS < lastAppliedUpdatedAtRef.current) {
+      return;
+    }
+
+    const player = playerRef.current;
+    if (!player) return;
+
+    const estimated = estimatePlaybackTime(leaderPlayback);
+    if (estimated === null) return;
+
+    const local = player.getPlaybackState();
+    const drift = Math.abs(local.currentTime - estimated);
+    const pauseMismatch = local.paused !== leaderPlayback.paused;
+
+    // Seek only when meaningfully out of sync (or on a large jump/seek by leader).
+    if (drift > DRIFT_SEEK_SECONDS) {
+      player.seekTo(estimated, { play: !leaderPlayback.paused });
+      lastAppliedUpdatedAtRef.current = leaderPlayback.updatedAt;
+      return;
+    }
+
+    if (pauseMismatch) {
+      if (leaderPlayback.paused) {
+        player.pause();
+      } else {
+        player.play();
+      }
+      lastAppliedUpdatedAtRef.current = leaderPlayback.updatedAt;
+      return;
+    }
+
+    // Soft-track while playing without seeking (small drift is fine).
+    lastAppliedUpdatedAtRef.current = Math.max(
+      lastAppliedUpdatedAtRef.current,
+      leaderPlayback.updatedAt,
+    );
+  }, [enabled, leaderPlayback, leaderUserId, playerRef]);
+}

--- a/src/lib/useVideoPresence.test.ts
+++ b/src/lib/useVideoPresence.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { estimatePlaybackTime } from "./useVideoPresence";
+
+test("estimatePlaybackTime returns null without playback", () => {
+  assert.equal(estimatePlaybackTime(undefined), null);
+});
+
+test("estimatePlaybackTime returns currentTime when paused", () => {
+  assert.equal(
+    estimatePlaybackTime(
+      {
+        currentTime: 12.5,
+        paused: true,
+        updatedAt: 1_000,
+      },
+      5_000,
+    ),
+    12.5,
+  );
+});
+
+test("estimatePlaybackTime advances currentTime while playing based on updatedAt", () => {
+  assert.equal(
+    estimatePlaybackTime(
+      {
+        currentTime: 10,
+        paused: false,
+        updatedAt: 1_000,
+      },
+      2_500,
+    ),
+    11.5,
+  );
+});
+
+test("estimatePlaybackTime does not go negative when now is before updatedAt", () => {
+  assert.equal(
+    estimatePlaybackTime(
+      {
+        currentTime: 4,
+        paused: false,
+        updatedAt: 5_000,
+      },
+      4_000,
+    ),
+    4,
+  );
+});

--- a/src/lib/useVideoPresence.ts
+++ b/src/lib/useVideoPresence.ts
@@ -3,11 +3,19 @@
 import { useConvex, useMutation, useQuery } from "convex/react";
 import { api } from "@convex/_generated/api";
 import { Id } from "@convex/_generated/dataModel";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const STORAGE_KEY_CLIENT_ID = "lawn.presence.client_id";
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 15_000;
 const DISCONNECT_PATH = "videoPresence:disconnect";
+/** Throttle presence playback publishes while playing. */
+const PLAYBACK_THROTTLE_MS = 400;
+
+export type VideoPlaybackPresence = {
+  currentTime: number;
+  paused: boolean;
+  updatedAt: number;
+};
 
 export type VideoWatcher = {
   userId: string;
@@ -15,6 +23,8 @@ export type VideoWatcher = {
   kind: "member" | "guest";
   displayName: string;
   avatarUrl?: string;
+  leading: boolean;
+  playback?: VideoPlaybackPresence;
 };
 
 function createClientId() {
@@ -37,25 +47,53 @@ export function useVideoPresence(input: {
   enabled?: boolean;
   shareToken?: string;
   intervalMs?: number;
+  /**
+   * Guests auto-follow when a leader is active (good default).
+   * Team members default to free viewing and can toggle follow.
+   */
+  isGuestViewer?: boolean;
 }) {
   const convex = useConvex();
   const heartbeat = useMutation(api.videoPresence.heartbeat);
   const disconnect = useMutation(api.videoPresence.disconnect);
+  const updatePlayback = useMutation(api.videoPresence.updatePlayback);
+  const claimLeadMutation = useMutation(api.videoPresence.claimLead);
+  const releaseLeadMutation = useMutation(api.videoPresence.releaseLead);
 
   const [clientId, setClientId] = useState<string | null>(null);
   const [roomToken, setRoomToken] = useState<string | null>(null);
+  const [selfUserId, setSelfUserId] = useState<string | null>(null);
+  const [followEnabled, setFollowEnabled] = useState(Boolean(input.isGuestViewer));
   const sessionTokenRef = useRef<string | null>(null);
+  const latestPlaybackRef = useRef<VideoPlaybackPresence | null>(null);
+  const lastPublishAtRef = useRef(0);
+  const publishInFlightRef = useRef(false);
+  const pendingForcePublishRef = useRef(false);
 
-  const { videoId, enabled = true, shareToken, intervalMs = DEFAULT_HEARTBEAT_INTERVAL_MS } = input;
+  const {
+    videoId,
+    enabled = true,
+    shareToken,
+    intervalMs = DEFAULT_HEARTBEAT_INTERVAL_MS,
+    isGuestViewer = false,
+  } = input;
 
   useEffect(() => {
     if (typeof window === "undefined") return;
     setClientId(getOrCreateClientId());
   }, []);
 
+  // Guests auto-follow; members keep local toggle across video changes.
+  useEffect(() => {
+    if (isGuestViewer) {
+      setFollowEnabled(true);
+    }
+  }, [isGuestViewer, videoId]);
+
   useEffect(() => {
     if (!enabled || !videoId || !clientId) {
       setRoomToken(null);
+      setSelfUserId(null);
       return;
     }
 
@@ -69,11 +107,13 @@ export function useVideoPresence(input: {
         clientId,
         interval: intervalMs,
         shareToken,
+        playback: latestPlaybackRef.current ?? undefined,
       });
 
       if (!active) return;
       sessionTokenRef.current = result.sessionToken;
       setRoomToken(result.roomToken);
+      setSelfUserId(result.userId);
     };
 
     const handleBeforeUnload = () => {
@@ -106,6 +146,7 @@ export function useVideoPresence(input: {
       const sessionToken = sessionTokenRef.current;
       sessionTokenRef.current = null;
       setRoomToken(null);
+      setSelfUserId(null);
       if (sessionToken) {
         void disconnect({ sessionToken }).catch(() => {
           // Ignore disconnect failures during teardown.
@@ -115,6 +156,11 @@ export function useVideoPresence(input: {
   }, [clientId, convex.url, disconnect, enabled, heartbeat, intervalMs, shareToken, videoId]);
 
   const state = useQuery(api.videoPresence.list, roomToken ? { roomToken } : "skip");
+  const canLead = useQuery(api.videoPresence.canLead, videoId && enabled ? { videoId } : "skip");
+  const leaderRecord = useQuery(
+    api.videoPresence.getLeader,
+    videoId && enabled ? { videoId, shareToken } : "skip",
+  );
 
   const watchers = useMemo(() => {
     if (!state) return [];
@@ -127,11 +173,152 @@ export function useVideoPresence(input: {
         kind: watcher.data?.kind ?? "member",
         displayName: watcher.data?.displayName ?? "Member",
         avatarUrl: watcher.data?.avatarUrl,
+        leading: Boolean(watcher.data?.leading),
+        playback: watcher.data?.playback,
       })) satisfies VideoWatcher[];
   }, [state]);
+
+  // Prefer the auth-backed leader table, fall back to presence leading flag.
+  const leader = useMemo(() => {
+    if (leaderRecord) {
+      const onlineLeader = watchers.find((w) => w.userId === leaderRecord.leaderUserId);
+      if (onlineLeader) {
+        return {
+          userId: onlineLeader.userId,
+          displayName: onlineLeader.displayName || leaderRecord.displayName,
+          playback: onlineLeader.playback,
+          online: true as const,
+        };
+      }
+      // Leader claimed but offline — still expose name so UI can show lock state.
+      return {
+        userId: leaderRecord.leaderUserId,
+        displayName: leaderRecord.displayName,
+        playback: undefined as VideoPlaybackPresence | undefined,
+        online: false as const,
+      };
+    }
+
+    const fromPresence = watchers.find((w) => w.leading);
+    if (!fromPresence) return null;
+    return {
+      userId: fromPresence.userId,
+      displayName: fromPresence.displayName,
+      playback: fromPresence.playback,
+      online: true as const,
+    };
+  }, [leaderRecord, watchers]);
+
+  const isLeading = Boolean(selfUserId && leader?.userId === selfUserId);
+  const isFollowing = Boolean(followEnabled && leader?.online && !isLeading);
+
+  const flushPlayback = useCallback(
+    async (force: boolean) => {
+      if (!enabled || !videoId || !clientId) return;
+      const playback = latestPlaybackRef.current;
+      if (!playback) return;
+
+      const now = Date.now();
+      if (!force && now - lastPublishAtRef.current < PLAYBACK_THROTTLE_MS) {
+        pendingForcePublishRef.current = false;
+        return;
+      }
+
+      if (publishInFlightRef.current) {
+        if (force) pendingForcePublishRef.current = true;
+        return;
+      }
+
+      publishInFlightRef.current = true;
+      lastPublishAtRef.current = now;
+      pendingForcePublishRef.current = false;
+
+      try {
+        await updatePlayback({
+          videoId,
+          clientId,
+          shareToken,
+          playback,
+        });
+      } catch {
+        // Presence publishes are best-effort; next tick will retry.
+      } finally {
+        publishInFlightRef.current = false;
+        if (pendingForcePublishRef.current) {
+          pendingForcePublishRef.current = false;
+          void flushPlayback(true);
+        }
+      }
+    },
+    [clientId, enabled, shareToken, updatePlayback, videoId],
+  );
+
+  const publishPlayback = useCallback(
+    (next: { currentTime: number; paused: boolean }, options?: { force?: boolean }) => {
+      const playback: VideoPlaybackPresence = {
+        currentTime: Math.max(0, next.currentTime),
+        paused: next.paused,
+        updatedAt: Date.now(),
+      };
+      latestPlaybackRef.current = playback;
+
+      const force = options?.force ?? next.paused;
+      void flushPlayback(force);
+    },
+    [flushPlayback],
+  );
+
+  const claimLead = useCallback(async () => {
+    if (!videoId) return;
+    await claimLeadMutation({
+      videoId,
+      playback: latestPlaybackRef.current ?? undefined,
+    });
+    // Leading means you drive; stop following.
+    setFollowEnabled(false);
+  }, [claimLeadMutation, videoId]);
+
+  const releaseLead = useCallback(async () => {
+    if (!videoId) return;
+    await releaseLeadMutation({ videoId });
+  }, [releaseLeadMutation, videoId]);
+
+  const setFollowing = useCallback(
+    (next: boolean) => {
+      // Can't follow yourself while leading.
+      if (isLeading && next) return;
+      setFollowEnabled(next);
+    },
+    [isLeading],
+  );
 
   return {
     watchers,
     isLoading: roomToken !== null && state === undefined,
+    selfUserId,
+    clientId,
+    canLead: Boolean(canLead),
+    leader,
+    isLeading,
+    isFollowing,
+    followEnabled,
+    setFollowing,
+    claimLead,
+    releaseLead,
+    publishPlayback,
   };
+}
+
+/**
+ * Estimate the leader's current playhead, compensating for network delay
+ * while they are actively playing.
+ */
+export function estimatePlaybackTime(
+  playback: VideoPlaybackPresence | undefined,
+  nowMs: number = Date.now(),
+): number | null {
+  if (!playback) return null;
+  if (playback.paused) return playback.currentTime;
+  const elapsed = Math.max(0, (nowMs - playback.updatedAt) / 1000);
+  return playback.currentTime + elapsed;
 }


### PR DESCRIPTION
Closes https://github.com/pingdotgg/lawn/issues/14

## Summary
Ship a clean v1 of **gang video players**: anyone on a video can broadcast throttled playhead/play-pause presence; project members (member+) can **Lead** so share/dashboard viewers can **Follow** their play/pause/seek.

### Behavior
1. **Presence playback** — optional `{ currentTime, paused, updatedAt }` on room user data; throttled ~400ms while playing, immediate on pause/play/seek.
2. **Lead** — member+ claims a single leader per video (`videoLeaders` table, last claim wins). Guests/viewers cannot lead.
3. **Follow** — when a leader is online with playback, followers seek/play/pause to match with ~0.85s drift correction (no thrashing).
4. **Defaults** — share guests auto-follow; dashboard members stay free and can toggle Follow/Unfollow.
5. **UI** — brutalist Lead / Leading / Following {name} controls on dashboard video + share pages.
6. **Security** — room access still via membership or share token; lead requires authenticated member+ via `requireVideoAccess`.

### Not in scope (v1)
- Frame-perfect sync / WebRTC
- Following arbitrary non-leader watchers (payload is ready; UI is leader-focused)

## Test plan
- [ ] Open a video as member+, click **Lead**, play/pause/seek — second browser (share link guest) auto-follows
- [ ] Guest sees "Following {name}" and can **Unfollow** / **Follow**
- [ ] Dashboard member can toggle follow without leading
- [ ] Non-member / guest cannot claim Lead
- [ ] Second member can steal Lead (last claim wins); previous leader loses Leading state
- [ ] Presence still shows watchers facepile as before

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f923cb5c0eb5da3778b926b52734e6aa5d6540c7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add gang playback sync so video leaders can control play/pause/seek for followers
> - Adds a lead/follow system for synchronized video playback across viewers. Members can claim leadership; others can follow and will have their player auto-synced to the leader's playhead and play/pause state.
> - Introduces `claimLead`, `releaseLead`, `updatePlayback`, `canLead`, and `getLeader` mutations/queries in [convex/videoPresence.ts](https://github.com/pingdotgg/lawn/pull/62/files#diff-48da327a9978ec0fe2870cc986707c9f3a8fdcae8f329ce90f28ff6560af7395), backed by a new `videoLeaders` table in [convex/schema.ts](https://github.com/pingdotgg/lawn/pull/62/files#diff-00e6e27e65e72a0fd4a73f6942f41e1cf3f476a59f263513f3f47fdf801a0eb1).
> - Adds a new [useGangPlaybackSync](https://github.com/pingdotgg/lawn/pull/62/files#diff-a44a1506779c878eebdf10e915e1e0317020578e53930b857eae649f6cdd738f) hook that estimates the leader's current time using wall-clock drift and seeks/pauses the local player when drift exceeds a threshold.
> - Extends [VideoPlayer](https://github.com/pingdotgg/lawn/pull/62/files#diff-0e727e5783fa61e229c14aa994353bc1808e05a230a7171f3e203fb539050a6e) with `onPlayStateChange` callback and imperative `play()`, `pause()`, `getPlaybackState()` handle methods; `seekTo` gains an option to force-pause after seeking.
> - Renders [GangPlaybackControls](https://github.com/pingdotgg/lawn/pull/62/files#diff-a935dc8cfb79bf1adcfd9da781c072f2acc551ebea24d1d62c74f0c4bb1c776d) on both the share page and dashboard video page to expose lead/follow UI.
> - Behavioral Change: guests default to `isFollowing: true` and will auto-seek when a leader is active; playback presence is published on a throttle and immediately on play-state changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f923cb5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->