### PR TITLE
fix: auto-fallback unplayable original video to 720p

### DIFF
--- a/app/routes/dashboard/-video.tsx
+++ b/app/routes/dashboard/-video.tsx
@@ -20,6 +20,11 @@ import {
 import { cn, formatDuration } from "@/lib/utils";
 import { buildCommentsCsv, buildCommentsCsvFilename } from "@/lib/commentCsv";
 import { triggerTextDownload } from "@/lib/download";
+import {
+  getOriginalPlaybackFallbackNotice,
+  selectFallbackPlaybackSource,
+  shouldFallbackFromOriginalSource,
+} from "@/lib/originalPlaybackFallback";
 import { useVideoPresence } from "@/lib/useVideoPresence";
 import { useSidebarCollapsed } from "@/lib/useSidebarCollapsed";
 import { VideoWatchers } from "@/components/presence/VideoWatchers";
@@ -341,6 +346,7 @@ export default function VideoPage() {
     videoId: Id<"videos">;
     type: VideoPlaybackIssue["type"];
   } | null>(null);
+  const [originalFallbackNoticeDismissed, setOriginalFallbackNoticeDismissed] = useState(false);
   const [playbackResume, setPlaybackResume] = useState<{
     videoId: Id<"videos">;
     currentTime: number;
@@ -350,6 +356,7 @@ export default function VideoPage() {
   const deletePendingRef = useRef(false);
   const muxRecoveryVideoIdRef = useRef<Id<"videos"> | null>(null);
   const playbackRetryTimeoutRef = useRef<number | null>(null);
+  const originalFallbackNoticeTimeoutRef = useRef<number | null>(null);
   const isPlayable = video?.status === "ready" && Boolean(video?.muxPlaybackId);
   const playbackUrl = playbackSession?.url ?? null;
   const playbackRequestAttempt =
@@ -383,6 +390,15 @@ export default function VideoPage() {
     playbackLoadError &&
     playbackRequestAttempt < MAX_AUTOMATIC_PLAYBACK_ATTEMPTS - 1,
   );
+  const originalFallbackNotice =
+    activeOriginalPlaybackIssue && !originalFallbackNoticeDismissed
+      ? getOriginalPlaybackFallbackNotice({
+          issueType: activeOriginalPlaybackIssue.type,
+          hasMuxFallback: Boolean(playbackUrl),
+          muxLoadFailed: Boolean(playbackLoadError),
+          muxRetryPending: isAutomaticPlaybackRetryPending,
+        })
+      : null;
   const shouldCanonicalize =
     !!context && !context.isCanonical && pathname !== context.canonicalPath;
   const prewarmTeamIntentHandlers = useRoutePrewarmIntent(() =>
@@ -404,6 +420,7 @@ export default function VideoPage() {
     setSourcePreference(null);
     setFailedOriginalVideoId(null);
     setOriginalPlaybackIssue(null);
+    setOriginalFallbackNoticeDismissed(false);
     setPlaybackResume(null);
     setPlaybackLoadError(null);
     setPlaybackRequest(null);
@@ -411,6 +428,10 @@ export default function VideoPage() {
     if (playbackRetryTimeoutRef.current !== null) {
       window.clearTimeout(playbackRetryTimeoutRef.current);
       playbackRetryTimeoutRef.current = null;
+    }
+    if (originalFallbackNoticeTimeoutRef.current !== null) {
+      window.clearTimeout(originalFallbackNoticeTimeoutRef.current);
+      originalFallbackNoticeTimeoutRef.current = null;
     }
   }, [resolvedVideoId]);
 
@@ -419,6 +440,7 @@ export default function VideoPage() {
     setSourcePreference(null);
     setFailedOriginalVideoId(null);
     setOriginalPlaybackIssue(null);
+    setOriginalFallbackNoticeDismissed(false);
     setPlaybackResume(null);
     setPlaybackLoadError(null);
     setPlaybackRequest(null);
@@ -427,7 +449,31 @@ export default function VideoPage() {
       window.clearTimeout(playbackRetryTimeoutRef.current);
       playbackRetryTimeoutRef.current = null;
     }
+    if (originalFallbackNoticeTimeoutRef.current !== null) {
+      window.clearTimeout(originalFallbackNoticeTimeoutRef.current);
+      originalFallbackNoticeTimeoutRef.current = null;
+    }
   }, [video?.status]);
+
+  // Brief auto-dismiss once 720p is actually available after an Original failure.
+  useEffect(() => {
+    if (!activeOriginalPlaybackIssue || !playbackUrl || originalFallbackNoticeDismissed) {
+      return;
+    }
+    if (originalFallbackNoticeTimeoutRef.current !== null) {
+      window.clearTimeout(originalFallbackNoticeTimeoutRef.current);
+    }
+    originalFallbackNoticeTimeoutRef.current = window.setTimeout(() => {
+      originalFallbackNoticeTimeoutRef.current = null;
+      setOriginalFallbackNoticeDismissed(true);
+    }, 4_500);
+    return () => {
+      if (originalFallbackNoticeTimeoutRef.current !== null) {
+        window.clearTimeout(originalFallbackNoticeTimeoutRef.current);
+        originalFallbackNoticeTimeoutRef.current = null;
+      }
+    };
+  }, [activeOriginalPlaybackIssue, originalFallbackNoticeDismissed, playbackUrl]);
 
   useEffect(() => {
     if (shouldCanonicalize && context) {
@@ -557,6 +603,15 @@ export default function VideoPage() {
   const handleOriginalPlaybackIssue = useCallback(
     (issue: VideoPlaybackIssue) => {
       if (!resolvedVideoId) return;
+      if (
+        !shouldFallbackFromOriginalSource({
+          isProgressiveSource: true,
+          issueType: issue.type,
+        })
+      ) {
+        return;
+      }
+
       setPlaybackResume({
         videoId: resolvedVideoId,
         currentTime: issue.currentTime,
@@ -565,7 +620,14 @@ export default function VideoPage() {
       muxRecoveryVideoIdRef.current = resolvedVideoId;
       setFailedOriginalVideoId(resolvedVideoId);
       setOriginalPlaybackIssue({ videoId: resolvedVideoId, type: issue.type });
-      setSourcePreference({ videoId: resolvedVideoId, source: "mux720" });
+      setOriginalFallbackNoticeDismissed(false);
+      setSourcePreference({
+        videoId: resolvedVideoId,
+        source: selectFallbackPlaybackSource({
+          muxUrl: playbackUrl,
+          muxPlaybackReady: isPlayable,
+        }),
+      });
       if (isPlayable && !playbackUrl && !isLoadingPlayback) {
         setPlaybackRequest((request) => ({
           videoId: resolvedVideoId,
@@ -585,15 +647,28 @@ export default function VideoPage() {
           window.clearTimeout(playbackRetryTimeoutRef.current);
           playbackRetryTimeoutRef.current = null;
         }
+        if (originalFallbackNoticeTimeoutRef.current !== null) {
+          window.clearTimeout(originalFallbackNoticeTimeoutRef.current);
+          originalFallbackNoticeTimeoutRef.current = null;
+        }
         setFailedOriginalVideoId((failedVideoId) =>
           failedVideoId === resolvedVideoId ? null : failedVideoId,
         );
         setOriginalPlaybackIssue((issue) => (issue?.videoId === resolvedVideoId ? null : issue));
+        setOriginalFallbackNoticeDismissed(false);
       }
       setSourcePreference({ videoId: resolvedVideoId, source: id });
     },
     [resolvedVideoId],
   );
+
+  const dismissOriginalFallbackNotice = useCallback(() => {
+    setOriginalFallbackNoticeDismissed(true);
+    if (originalFallbackNoticeTimeoutRef.current !== null) {
+      window.clearTimeout(originalFallbackNoticeTimeoutRef.current);
+      originalFallbackNoticeTimeoutRef.current = null;
+    }
+  }, []);
 
   const handleRetryPlaybackSession = useCallback(() => {
     if (!resolvedVideoId || !isPlayable || isLoadingPlayback) return;
@@ -1102,26 +1177,26 @@ export default function VideoPage() {
             </div>
           ) : null}
 
-          {activeOriginalPlaybackIssue ? (
+          {originalFallbackNotice ? (
             <div
-              className="flex flex-shrink-0 items-center gap-2 bg-[#2a2114] px-4 py-2 text-sm text-[#fff1d5]"
+              className="flex flex-shrink-0 items-center gap-2 border-b-2 border-[#1a1a1a] bg-[#2a2114] px-4 py-2 text-sm text-[#fff1d5]"
               role="status"
               aria-live="polite"
               aria-atomic="true"
             >
-              <span className="inline-flex h-2.5 w-2.5 rounded-full bg-[#f0b45d]" />
-              <span className="font-semibold">
-                {activeOriginalPlaybackIssue.type === "frozen-video"
-                  ? "Original playback stalled."
-                  : "Original playback was unavailable."}
+              <span className="inline-flex h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[#f0b45d]" />
+              <span className="min-w-0 flex-1">
+                <span className="font-semibold">{originalFallbackNotice.headline}</span>
+                <span className="text-[#d8c6a8]"> — {originalFallbackNotice.detail}</span>
               </span>
-              <span className="text-[#d8c6a8]">
-                {playbackUrl
-                  ? "Switched to 720p."
-                  : playbackLoadError && !isAutomaticPlaybackRetryPending
-                    ? "720p needs another try."
-                    : "Preparing 720p…"}
-              </span>
+              <button
+                type="button"
+                onClick={dismissOriginalFallbackNotice}
+                className="ml-auto inline-flex h-7 w-7 flex-shrink-0 items-center justify-center border border-[#fff1d5]/35 text-[#fff1d5] transition hover:bg-[#fff1d5]/10"
+                aria-label="Dismiss playback notice"
+              >
+                <X className="h-3.5 w-3.5" aria-hidden="true" />
+              </button>
             </div>
           ) : null}
 

--- a/src/components/video-player/VideoPlayer.tsx
+++ b/src/components/video-player/VideoPlayer.tsx
@@ -33,6 +33,7 @@ import {
   observeVideoPlayback,
   resetVideoPlaybackHealthWindow,
 } from "@/lib/videoPlaybackHealth";
+import { classifyPlayFailure } from "@/lib/originalPlaybackFallback";
 
 interface Comment {
   _id: string;
@@ -247,6 +248,32 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
     [applyTime, showControls],
   );
 
+  const reportPlayFailure = useCallback(
+    (video: HTMLVideoElement, error: unknown) => {
+      const classification = classifyPlayFailure({
+        error,
+        mediaError: video.error ? { code: video.error.code, message: video.error.message } : null,
+        isProgressiveSource: !isHlsSource(src),
+      });
+      if (classification.kind !== "media-failure") return;
+
+      // Keep play intent across the host's Original → 720p source swap even though
+      // this element never reached the `playing` state.
+      resumePlaybackOnSourceChangeRef.current = true;
+
+      // Play rejections for unsupported progressive sources (ProRes MOV, etc.)
+      // can leave the control in a dead state if we only listen for `error`.
+      onPlaybackIssueRef.current?.({
+        type: "media-error",
+        currentTime: video.currentTime,
+        wasPlaying: true,
+        code: classification.code,
+        message: classification.message,
+      });
+    },
+    [src],
+  );
+
   const togglePlay = useCallback(() => {
     const video = videoRef.current;
     if (!video) return;
@@ -256,14 +283,16 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
     if (video.paused) {
       const playPromise = video.play();
       if (playPromise) {
-        playPromise.catch(() => {
-          // Ignore play errors caused by browser autoplay policies.
+        playPromise.catch((error) => {
+          // Autoplay/abort rejections are ignored; decode/support failures
+          // surface as playback issues so the host can fall back to 720p.
+          reportPlayFailure(video, error);
         });
       }
     } else {
       video.pause();
     }
-  }, [showControls]);
+  }, [reportPlayFailure, showControls]);
 
   const setVideoVolume = useCallback((nextVolume: number) => {
     const video = videoRef.current;
@@ -528,8 +557,25 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
       resumePlaybackOnSourceChangeRef.current = false;
       const playPromise = video.play();
       if (playPromise) {
-        playPromise.catch(() => {
-          // A browser may still reject resumed playback after a source swap.
+        playPromise.catch((error) => {
+          // Source swaps can still hit unsupported progressive codecs.
+          // Ignore autoplay/abort; report real media failures.
+          if (cancelled) return;
+          const classification = classifyPlayFailure({
+            error,
+            mediaError: video.error
+              ? { code: video.error.code, message: video.error.message }
+              : null,
+            isProgressiveSource: !isHlsSource(src),
+          });
+          if (classification.kind !== "media-failure") return;
+          reportPlaybackIssue({
+            type: "media-error",
+            currentTime: video.currentTime,
+            wasPlaying: true,
+            code: classification.code,
+            message: classification.message,
+          });
         });
       }
     };

--- a/src/lib/originalPlaybackFallback.test.ts
+++ b/src/lib/originalPlaybackFallback.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  classifyPlayFailure,
+  getOriginalPlaybackFallbackNotice,
+  isIgnorablePlayRejection,
+  selectFallbackPlaybackSource,
+  shouldFallbackFromOriginalSource,
+} from "./originalPlaybackFallback";
+
+test("ignores autoplay and abort play rejections", () => {
+  assert.equal(
+    isIgnorablePlayRejection(Object.assign(new Error("blocked"), { name: "NotAllowedError" })),
+    true,
+  );
+  assert.equal(
+    isIgnorablePlayRejection(Object.assign(new Error("aborted"), { name: "AbortError" })),
+    true,
+  );
+  assert.equal(
+    classifyPlayFailure({
+      error: Object.assign(new Error("blocked"), { name: "NotAllowedError" }),
+      isProgressiveSource: true,
+    }).kind,
+    "ignore",
+  );
+});
+
+test("classifies NotSupportedError play rejections on progressive sources", () => {
+  const result = classifyPlayFailure({
+    error: Object.assign(new Error("The element has no supported sources."), {
+      name: "NotSupportedError",
+    }),
+    isProgressiveSource: true,
+  });
+
+  assert.equal(result.kind, "media-failure");
+  if (result.kind === "media-failure") {
+    assert.equal(result.code, 0);
+    assert.match(result.message, /no supported sources/i);
+  }
+});
+
+test("classifies progressive play failures when the element already has a media error", () => {
+  const result = classifyPlayFailure({
+    error: new Error("play failed"),
+    mediaError: { code: 4, message: "MEDIA_ERR_SRC_NOT_SUPPORTED" },
+    isProgressiveSource: true,
+  });
+
+  assert.deepEqual(result, {
+    kind: "media-failure",
+    code: 4,
+    message: "MEDIA_ERR_SRC_NOT_SUPPORTED",
+  });
+});
+
+test("classifies demux/decode style rejection messages", () => {
+  const result = classifyPlayFailure({
+    error: new Error("Media resource could not be decoded"),
+    isProgressiveSource: true,
+  });
+
+  assert.equal(result.kind, "media-failure");
+});
+
+test("does not fall back for HLS play rejections", () => {
+  const result = classifyPlayFailure({
+    error: Object.assign(new Error("The element has no supported sources."), {
+      name: "NotSupportedError",
+    }),
+    mediaError: { code: 4, message: "MEDIA_ERR_SRC_NOT_SUPPORTED" },
+    isProgressiveSource: false,
+  });
+
+  assert.equal(result.kind, "ignore");
+});
+
+test("only progressive original issues request a source fallback", () => {
+  assert.equal(
+    shouldFallbackFromOriginalSource({
+      isProgressiveSource: true,
+      issueType: "media-error",
+    }),
+    true,
+  );
+  assert.equal(
+    shouldFallbackFromOriginalSource({
+      isProgressiveSource: true,
+      issueType: "frozen-video",
+    }),
+    true,
+  );
+  assert.equal(
+    shouldFallbackFromOriginalSource({
+      isProgressiveSource: false,
+      issueType: "media-error",
+    }),
+    false,
+  );
+});
+
+test("always recovers onto the mux720 path", () => {
+  assert.equal(
+    selectFallbackPlaybackSource({
+      muxUrl: "https://stream.example/a.m3u8",
+      muxPlaybackReady: true,
+    }),
+    "mux720",
+  );
+  assert.equal(selectFallbackPlaybackSource({ muxUrl: null, muxPlaybackReady: false }), "mux720");
+});
+
+test("builds the requested browser-unsupported notice when 720p is ready", () => {
+  assert.deepEqual(
+    getOriginalPlaybackFallbackNotice({
+      issueType: "media-error",
+      hasMuxFallback: true,
+      muxLoadFailed: false,
+      muxRetryPending: false,
+    }),
+    {
+      headline: "Original format isn't playable in this browser",
+      detail: "Switched to 720p",
+      message: "Original format isn't playable in this browser — switched to 720p",
+    },
+  );
+});
+
+test("builds pending and retry notices when mux is not ready yet", () => {
+  assert.equal(
+    getOriginalPlaybackFallbackNotice({
+      issueType: "media-error",
+      hasMuxFallback: false,
+      muxLoadFailed: false,
+      muxRetryPending: false,
+    }).detail,
+    "Preparing 720p…",
+  );
+  assert.equal(
+    getOriginalPlaybackFallbackNotice({
+      issueType: "frozen-video",
+      hasMuxFallback: false,
+      muxLoadFailed: true,
+      muxRetryPending: false,
+    }).detail,
+    "720p needs another try",
+  );
+});

--- a/src/lib/originalPlaybackFallback.ts
+++ b/src/lib/originalPlaybackFallback.ts
@@ -1,0 +1,199 @@
+/**
+ * Pure helpers for recovering when a progressive "Original" source fails to
+ * play in the browser (unsupported codecs like ProRes, demuxer errors, etc.).
+ */
+
+export type OriginalPlaybackIssueType = "frozen-video" | "media-error";
+
+export type OriginalPlaybackFallbackNotice = {
+  headline: string;
+  detail: string;
+  /** Single-line message for compact toasts. */
+  message: string;
+};
+
+export type MediaErrorLike = {
+  code: number;
+  message?: string;
+} | null;
+
+export type PlayFailureClassification =
+  | { kind: "ignore" }
+  | {
+      kind: "media-failure";
+      code: number;
+      message: string;
+    };
+
+const IGNORABLE_PLAY_REJECTION_NAMES = new Set(["NotAllowedError", "AbortError"]);
+
+const MEDIA_FAILURE_PLAY_REJECTION_NAMES = new Set([
+  "NotSupportedError",
+  "NotReadableError",
+  // Some engines surface a transient invalid state when the element has no
+  // decodable tracks after a failed progressive attach.
+  "InvalidStateError",
+]);
+
+const MEDIA_FAILURE_MESSAGE_PATTERN =
+  /decode|demux|not supported|no supported source|format|MEDIA_ERR|could not be decoded|no.*tracks/i;
+
+export function isIgnorablePlayRejection(error: unknown): boolean {
+  const name = getErrorName(error);
+  return name !== null && IGNORABLE_PLAY_REJECTION_NAMES.has(name);
+}
+
+/**
+ * Decide whether a rejected `HTMLMediaElement.play()` should trigger an
+ * automatic Original → playable-rendition fallback.
+ *
+ * Autoplay policy and abort rejections are ignored. Explicit media failures
+ * (and progressive sources that already have a media error) are not.
+ */
+export function classifyPlayFailure({
+  error,
+  mediaError,
+  isProgressiveSource,
+}: {
+  error: unknown;
+  mediaError?: MediaErrorLike;
+  isProgressiveSource: boolean;
+}): PlayFailureClassification {
+  if (!isProgressiveSource) {
+    return { kind: "ignore" };
+  }
+
+  if (isIgnorablePlayRejection(error)) {
+    return { kind: "ignore" };
+  }
+
+  if (mediaError && mediaError.code > 0) {
+    return {
+      kind: "media-failure",
+      code: mediaError.code,
+      message: mediaError.message?.trim() || "The browser could not play this video source.",
+    };
+  }
+
+  const name = getErrorName(error);
+  const message = getErrorMessage(error);
+
+  if (name && MEDIA_FAILURE_PLAY_REJECTION_NAMES.has(name)) {
+    return {
+      kind: "media-failure",
+      code: 0,
+      message: message || name,
+    };
+  }
+
+  if (message && MEDIA_FAILURE_MESSAGE_PATTERN.test(message)) {
+    return {
+      kind: "media-failure",
+      code: 0,
+      message,
+    };
+  }
+
+  return { kind: "ignore" };
+}
+
+/**
+ * Whether a progressive Original source should be abandoned after a reported
+ * player issue. HLS/Mux renditions are never abandoned by this helper.
+ */
+export function shouldFallbackFromOriginalSource({
+  isProgressiveSource,
+  issueType,
+}: {
+  isProgressiveSource: boolean;
+  issueType: OriginalPlaybackIssueType;
+}): boolean {
+  if (!isProgressiveSource) return false;
+  return issueType === "media-error" || issueType === "frozen-video";
+}
+
+/**
+ * Preferred recovery target after Original fails. Prefer an already-ready 720p
+ * Mux session; otherwise wait for Mux rather than retrying the broken original.
+ */
+export function selectFallbackPlaybackSource({
+  muxUrl,
+  muxPlaybackReady,
+}: {
+  muxUrl: string | null;
+  muxPlaybackReady: boolean;
+}): "mux720" {
+  void muxUrl;
+  void muxPlaybackReady;
+  return "mux720";
+}
+
+/**
+ * User-facing copy for the automatic Original → 720p recovery banner.
+ */
+export function getOriginalPlaybackFallbackNotice({
+  issueType,
+  hasMuxFallback,
+  muxLoadFailed,
+  muxRetryPending,
+}: {
+  issueType: OriginalPlaybackIssueType;
+  hasMuxFallback: boolean;
+  muxLoadFailed: boolean;
+  muxRetryPending: boolean;
+}): OriginalPlaybackFallbackNotice {
+  if (hasMuxFallback) {
+    if (issueType === "frozen-video") {
+      return {
+        headline: "Original playback stalled",
+        detail: "Switched to 720p",
+        message: "Original playback stalled — switched to 720p",
+      };
+    }
+    return {
+      headline: "Original format isn't playable in this browser",
+      detail: "Switched to 720p",
+      message: "Original format isn't playable in this browser — switched to 720p",
+    };
+  }
+
+  if (muxLoadFailed && !muxRetryPending) {
+    return {
+      headline:
+        issueType === "frozen-video"
+          ? "Original playback stalled"
+          : "Original format isn't playable in this browser",
+      detail: "720p needs another try",
+      message:
+        issueType === "frozen-video"
+          ? "Original playback stalled — 720p needs another try"
+          : "Original format isn't playable in this browser — 720p needs another try",
+    };
+  }
+
+  return {
+    headline:
+      issueType === "frozen-video"
+        ? "Original playback stalled"
+        : "Original format isn't playable in this browser",
+    detail: "Preparing 720p…",
+    message:
+      issueType === "frozen-video"
+        ? "Original playback stalled — preparing 720p…"
+        : "Original format isn't playable in this browser — preparing 720p…",
+  };
+}
+
+function getErrorName(error: unknown): string | null {
+  if (!error || typeof error !== "object") return null;
+  if (!("name" in error)) return null;
+  const name = (error as { name: unknown }).name;
+  return typeof name === "string" && name.length > 0 ? name : null;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (!error || typeof error !== "object") return "";
+  if (!("message" in error)) return "";
+  const message = (error as { message: unknown }).message;
+  return typeof message === "string" ? message : "";
+}


### PR DESCRIPTION
Closes https://github.com/pingdotgg/lawn/issues/8

## Summary
- Detect progressive **Original** playback failures more reliably, including `play()` rejections for unsupported codecs (ProRes / demuxer errors) that previously left the play button unresponsive.
- Automatically fall back to the Mux **720p** stream, preserving play intent and position.
- Show a brief, dismissible brutalist banner: *Original format isn't playable in this browser — switched to 720p* (auto-dismisses once 720p is ready).
- Extract pure fallback helpers with unit tests (`classifyPlayFailure`, notice copy, fallback source selection).

Builds on the existing recovery path from #49 / default 720p from #50 without rewriting the player or adding endpoints.

## Validation
- `bun test` for playback helpers (20 related unit tests)
- `bun run typecheck`
- `bun run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only playback UX and recovery logic; no auth or API changes, with behavior covered by unit tests.
> 
> **Overview**
> When progressive **Original** sources fail (unsupported codecs, `play()` rejections, stalls), the dashboard now routes recovery through shared helpers in `originalPlaybackFallback` instead of always forcing **mux720** with inline banner copy.
> 
> **VideoPlayer** classifies `play()` rejections via `classifyPlayFailure`, reports real media failures as playback issues (while still ignoring autoplay/abort), and preserves play intent across an Original → 720p swap when play never reached `playing`.
> 
> **Dashboard video page** gates fallback with `shouldFallbackFromOriginalSource`, picks the target with `selectFallbackPlaybackSource`, and shows a dismissible banner driven by `getOriginalPlaybackFallbackNotice` (auto-dismiss ~4.5s after 720p is available). Unit tests cover classification, fallback rules, and notice text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 053fd12af1bef8f710a04c67eaa643a960af1580. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to 720p when the original video source fails to play
> - Adds a new [`originalPlaybackFallback`](https://github.com/pingdotgg/lawn/pull/63/files#diff-7f12fdc3cb0b9be4ab000f275d785494581a8898ac15c06d291636a03f910466) module with pure helper functions to classify `play()` rejections, gate fallbacks to progressive sources, select the fallback quality (`mux720`), and build UI banner messages.
> - [`VideoPlayer`](https://github.com/pingdotgg/lawn/pull/63/files#diff-0e727e5783fa61e229c14aa994353bc1808e05a230a7171f3e203fb539050a6e) now reports `media-error` playback issues to its host when `play()` fails due to unsupported or undecodable progressive sources; autoplay policy and abort errors are ignored.
> - [`VideoPage`](https://github.com/pingdotgg/lawn/pull/63/files#diff-833e2f5b1e2fafc1cc96eaad146f828e4462dfc59201a1f837cf780c7d11a442) handles the reported issue by switching to 720p, showing a dismissible banner with failure-specific messaging, and auto-dismissing the banner ~4.5s after the 720p URL becomes available.
> - Switching back to 'Original' quality clears the failure state, pending notice timeout, and dismissal flag.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 053fd12.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->