### PR TITLE
feat: frame-by-frame stepping & on-frame drawing annotations

### DIFF
--- a/app/routes/-share.tsx
+++ b/app/routes/-share.tsx
@@ -10,10 +10,11 @@ import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { triggerDownload } from "@/lib/download";
 import { formatDuration, formatTimestamp, formatRelativeTime } from "@/lib/utils";
+import { hasDrawing, type DrawingData } from "@/lib/drawing";
 import { useVideoPresence } from "@/lib/useVideoPresence";
 import { VideoWatchers } from "@/components/presence/VideoWatchers";
 import { CommentText } from "@/components/comments/CommentText";
-import { Lock, Video, AlertCircle, MessageSquare, Clock, Download } from "lucide-react";
+import { Lock, Video, AlertCircle, MessageSquare, Clock, Download, Pencil } from "lucide-react";
 import { useShareData } from "./-share.data";
 
 export default function SharePage() {
@@ -43,7 +44,16 @@ export default function SharePage() {
   const [commentError, setCommentError] = useState<string | null>(null);
   const [isDownloading, setIsDownloading] = useState(false);
   const [downloadError, setDownloadError] = useState<string | null>(null);
+  const [viewDrawing, setViewDrawing] = useState<DrawingData | null>(null);
   const playerRef = useRef<VideoPlayerHandle | null>(null);
+
+  const seekToComment = useCallback(
+    (timestampSeconds: number, drawing?: DrawingData | null) => {
+      playerRef.current?.seekTo(timestampSeconds, { play: false });
+      setViewDrawing(hasDrawing(drawing) ? (drawing ?? null) : null);
+    },
+    [],
+  );
 
   useEffect(() => {
     setIsDownloading(false);
@@ -337,6 +347,9 @@ export default function SharePage() {
               comments={flattenedComments}
               onTimeUpdate={setCurrentTime}
               allowDownload={false}
+              viewDrawing={viewDrawing}
+              onClearViewDrawing={() => setViewDrawing(null)}
+              allowDrawing={false}
             />
           ) : (
             <div className="relative aspect-video overflow-hidden rounded-xl border border-zinc-800/80 bg-black shadow-[0_10px_40px_rgba(0,0,0,0.45)]">
@@ -404,20 +417,37 @@ export default function SharePage() {
               {comments.map((comment) => (
                 <article key={comment._id} className="border-2 border-[#1a1a1a] bg-[#f0f0e8] p-3">
                   <div className="flex items-center justify-between gap-2">
-                    <div className="text-sm font-bold text-[#1a1a1a]">{comment.userName}</div>
+                    <div className="flex min-w-0 items-center gap-2">
+                      <div className="truncate text-sm font-bold text-[#1a1a1a]">
+                        {comment.userName}
+                      </div>
+                      {hasDrawing(comment.drawing) ? (
+                        <button
+                          type="button"
+                          onClick={() => seekToComment(comment.timestampSeconds, comment.drawing)}
+                          className="inline-flex shrink-0 items-center gap-1 border border-[#2d5a2d] bg-[#2d5a2d]/10 px-1.5 py-0.5 text-[10px] font-bold text-[#2d5a2d] hover:bg-[#2d5a2d] hover:text-[#f0f0e8]"
+                          title="View drawing on frame"
+                        >
+                          <Pencil className="h-3 w-3" />
+                          Drawing
+                        </button>
+                      ) : null}
+                    </div>
                     <button
                       type="button"
                       className="font-mono text-xs text-[#2d5a2d] hover:text-[#1a1a1a]"
-                      onClick={() =>
-                        playerRef.current?.seekTo(comment.timestampSeconds, { play: true })
-                      }
+                      onClick={() => seekToComment(comment.timestampSeconds, comment.drawing)}
                     >
                       {formatTimestamp(comment.timestampSeconds)}
                     </button>
                   </div>
-                  <p className="mt-1 text-sm break-words whitespace-pre-wrap text-[#1a1a1a]">
-                    <CommentText text={comment.text} />
-                  </p>
+                  {comment.text ? (
+                    <p className="mt-1 text-sm break-words whitespace-pre-wrap text-[#1a1a1a]">
+                      <CommentText text={comment.text} />
+                    </p>
+                  ) : hasDrawing(comment.drawing) ? (
+                    <p className="mt-1 text-sm text-[#888] italic">Frame drawing</p>
+                  ) : null}
                   <p className="mt-1 text-[11px] text-[#888]">
                     {formatRelativeTime(comment._creationTime)}
                   </p>
@@ -427,20 +457,29 @@ export default function SharePage() {
                       {comment.replies.map((reply) => (
                         <div key={reply._id} className="text-sm">
                           <div className="flex items-center justify-between gap-2">
-                            <span className="font-bold text-[#1a1a1a]">{reply.userName}</span>
+                            <span className="flex min-w-0 items-center gap-2 font-bold text-[#1a1a1a]">
+                              <span className="truncate">{reply.userName}</span>
+                              {hasDrawing(reply.drawing) ? (
+                                <Pencil className="h-3 w-3 shrink-0 text-[#2d5a2d]" />
+                              ) : null}
+                            </span>
                             <button
                               type="button"
                               className="font-mono text-xs text-[#2d5a2d] hover:text-[#1a1a1a]"
                               onClick={() =>
-                                playerRef.current?.seekTo(reply.timestampSeconds, { play: true })
+                                seekToComment(reply.timestampSeconds, reply.drawing)
                               }
                             >
                               {formatTimestamp(reply.timestampSeconds)}
                             </button>
                           </div>
-                          <p className="break-words whitespace-pre-wrap text-[#1a1a1a]">
-                            <CommentText text={reply.text} />
-                          </p>
+                          {reply.text ? (
+                            <p className="break-words whitespace-pre-wrap text-[#1a1a1a]">
+                              <CommentText text={reply.text} />
+                            </p>
+                          ) : hasDrawing(reply.drawing) ? (
+                            <p className="text-[#888] italic">Frame drawing</p>
+                          ) : null}
                         </div>
                       ))}
                     </div>

--- a/app/routes/-watch.tsx
+++ b/app/routes/-watch.tsx
@@ -20,6 +20,7 @@ import { CommentText } from "@/components/comments/CommentText";
 import { triggerDownload } from "@/lib/download";
 import { watchPath } from "@/lib/routes";
 import { cn, formatDuration, formatTimestamp, formatRelativeTime } from "@/lib/utils";
+import { hasDrawing, type DrawingData } from "@/lib/drawing";
 import {
   AlertCircle,
   Layers3,
@@ -28,6 +29,7 @@ import {
   Download,
   PanelRightClose,
   PanelRightOpen,
+  Pencil,
   X,
 } from "lucide-react";
 import { useSidebarCollapsed } from "@/lib/useSidebarCollapsed";
@@ -58,7 +60,16 @@ export default function WatchPage() {
   const [downloadError, setDownloadError] = useState<string | null>(null);
   const [mobileCommentsOpen, setMobileCommentsOpen] = useState(false);
   const [sidebarCollapsed, toggleSidebarCollapsed] = useSidebarCollapsed();
+  const [viewDrawing, setViewDrawing] = useState<DrawingData | null>(null);
   const playerRef = useRef<VideoPlayerHandle | null>(null);
+
+  const seekToComment = useCallback(
+    (timestampSeconds: number, drawing?: DrawingData | null) => {
+      playerRef.current?.seekTo(timestampSeconds, { play: false });
+      setViewDrawing(hasDrawing(drawing) ? (drawing ?? null) : null);
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!videoData?.video?.muxPlaybackId) {
@@ -330,6 +341,9 @@ export default function WatchPage() {
               onTimeUpdate={setCurrentTime}
               allowDownload={false}
               controlsBelow
+              viewDrawing={viewDrawing}
+              onClearViewDrawing={() => setViewDrawing(null)}
+              allowDrawing={false}
             />
           ) : (
             <div className="flex flex-1 items-center justify-center">
@@ -375,20 +389,39 @@ export default function WatchPage() {
                 {comments.map((comment) => (
                   <article key={comment._id} className="border-2 border-[#1a1a1a] bg-[#f0f0e8] p-3">
                     <div className="flex items-center justify-between gap-2">
-                      <div className="text-sm font-bold text-[#1a1a1a]">{comment.userName}</div>
+                      <div className="flex min-w-0 items-center gap-2">
+                        <div className="truncate text-sm font-bold text-[#1a1a1a]">
+                          {comment.userName}
+                        </div>
+                        {hasDrawing(comment.drawing) ? (
+                          <button
+                            type="button"
+                            onClick={() =>
+                              seekToComment(comment.timestampSeconds, comment.drawing)
+                            }
+                            className="inline-flex shrink-0 items-center gap-1 border border-[#2d5a2d] bg-[#2d5a2d]/10 px-1.5 py-0.5 text-[10px] font-bold text-[#2d5a2d] hover:bg-[#2d5a2d] hover:text-[#f0f0e8]"
+                            title="View drawing on frame"
+                          >
+                            <Pencil className="h-3 w-3" />
+                            Drawing
+                          </button>
+                        ) : null}
+                      </div>
                       <button
                         type="button"
                         className="font-mono text-xs text-[#2d5a2d] hover:text-[#1a1a1a]"
-                        onClick={() =>
-                          playerRef.current?.seekTo(comment.timestampSeconds, { play: true })
-                        }
+                        onClick={() => seekToComment(comment.timestampSeconds, comment.drawing)}
                       >
                         {formatTimestamp(comment.timestampSeconds)}
                       </button>
                     </div>
-                    <p className="mt-1 text-sm break-words whitespace-pre-wrap text-[#1a1a1a]">
-                      <CommentText text={comment.text} />
-                    </p>
+                    {comment.text ? (
+                      <p className="mt-1 text-sm break-words whitespace-pre-wrap text-[#1a1a1a]">
+                        <CommentText text={comment.text} />
+                      </p>
+                    ) : hasDrawing(comment.drawing) ? (
+                      <p className="mt-1 text-sm text-[#888] italic">Frame drawing</p>
+                    ) : null}
                     <p className="mt-1 text-[11px] text-[#888]">
                       {formatRelativeTime(comment._creationTime)}
                     </p>
@@ -398,22 +431,29 @@ export default function WatchPage() {
                         {comment.replies.map((reply) => (
                           <div key={reply._id} className="text-sm">
                             <div className="flex items-center justify-between gap-2">
-                              <span className="font-bold text-[#1a1a1a]">{reply.userName}</span>
+                              <span className="flex min-w-0 items-center gap-2 font-bold text-[#1a1a1a]">
+                                <span className="truncate">{reply.userName}</span>
+                                {hasDrawing(reply.drawing) ? (
+                                  <Pencil className="h-3 w-3 shrink-0 text-[#2d5a2d]" />
+                                ) : null}
+                              </span>
                               <button
                                 type="button"
                                 className="font-mono text-xs text-[#2d5a2d] hover:text-[#1a1a1a]"
                                 onClick={() =>
-                                  playerRef.current?.seekTo(reply.timestampSeconds, {
-                                    play: true,
-                                  })
+                                  seekToComment(reply.timestampSeconds, reply.drawing)
                                 }
                               >
                                 {formatTimestamp(reply.timestampSeconds)}
                               </button>
                             </div>
-                            <p className="break-words whitespace-pre-wrap text-[#1a1a1a]">
-                              <CommentText text={reply.text} />
-                            </p>
+                            {reply.text ? (
+                              <p className="break-words whitespace-pre-wrap text-[#1a1a1a]">
+                                <CommentText text={reply.text} />
+                              </p>
+                            ) : hasDrawing(reply.drawing) ? (
+                              <p className="text-[#888] italic">Frame drawing</p>
+                            ) : null}
                           </div>
                         ))}
                       </div>
@@ -495,21 +535,43 @@ export default function WatchPage() {
                 {comments.map((comment) => (
                   <article key={comment._id} className="border-2 border-[#1a1a1a] bg-[#f0f0e8] p-3">
                     <div className="flex items-center justify-between gap-2">
-                      <div className="text-sm font-bold text-[#1a1a1a]">{comment.userName}</div>
+                      <div className="flex min-w-0 items-center gap-2">
+                        <div className="truncate text-sm font-bold text-[#1a1a1a]">
+                          {comment.userName}
+                        </div>
+                        {hasDrawing(comment.drawing) ? (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              seekToComment(comment.timestampSeconds, comment.drawing);
+                              setMobileCommentsOpen(false);
+                            }}
+                            className="inline-flex shrink-0 items-center gap-1 border border-[#2d5a2d] bg-[#2d5a2d]/10 px-1.5 py-0.5 text-[10px] font-bold text-[#2d5a2d] hover:bg-[#2d5a2d] hover:text-[#f0f0e8]"
+                            title="View drawing on frame"
+                          >
+                            <Pencil className="h-3 w-3" />
+                            Drawing
+                          </button>
+                        ) : null}
+                      </div>
                       <button
                         type="button"
                         className="font-mono text-xs text-[#2d5a2d] hover:text-[#1a1a1a]"
                         onClick={() => {
-                          playerRef.current?.seekTo(comment.timestampSeconds, { play: true });
+                          seekToComment(comment.timestampSeconds, comment.drawing);
                           setMobileCommentsOpen(false);
                         }}
                       >
                         {formatTimestamp(comment.timestampSeconds)}
                       </button>
                     </div>
-                    <p className="mt-1 text-sm break-words whitespace-pre-wrap text-[#1a1a1a]">
-                      <CommentText text={comment.text} />
-                    </p>
+                    {comment.text ? (
+                      <p className="mt-1 text-sm break-words whitespace-pre-wrap text-[#1a1a1a]">
+                        <CommentText text={comment.text} />
+                      </p>
+                    ) : hasDrawing(comment.drawing) ? (
+                      <p className="mt-1 text-sm text-[#888] italic">Frame drawing</p>
+                    ) : null}
                     <p className="mt-1 text-[11px] text-[#888]">
                       {formatRelativeTime(comment._creationTime)}
                     </p>
@@ -519,21 +581,30 @@ export default function WatchPage() {
                         {comment.replies.map((reply) => (
                           <div key={reply._id} className="text-sm">
                             <div className="flex items-center justify-between gap-2">
-                              <span className="font-bold text-[#1a1a1a]">{reply.userName}</span>
+                              <span className="flex min-w-0 items-center gap-2 font-bold text-[#1a1a1a]">
+                                <span className="truncate">{reply.userName}</span>
+                                {hasDrawing(reply.drawing) ? (
+                                  <Pencil className="h-3 w-3 shrink-0 text-[#2d5a2d]" />
+                                ) : null}
+                              </span>
                               <button
                                 type="button"
                                 className="font-mono text-xs text-[#2d5a2d] hover:text-[#1a1a1a]"
                                 onClick={() => {
-                                  playerRef.current?.seekTo(reply.timestampSeconds, { play: true });
+                                  seekToComment(reply.timestampSeconds, reply.drawing);
                                   setMobileCommentsOpen(false);
                                 }}
                               >
                                 {formatTimestamp(reply.timestampSeconds)}
                               </button>
                             </div>
-                            <p className="break-words whitespace-pre-wrap text-[#1a1a1a]">
-                              <CommentText text={reply.text} />
-                            </p>
+                            {reply.text ? (
+                              <p className="break-words whitespace-pre-wrap text-[#1a1a1a]">
+                                <CommentText text={reply.text} />
+                              </p>
+                            ) : hasDrawing(reply.drawing) ? (
+                              <p className="text-[#888] italic">Frame drawing</p>
+                            ) : null}
                           </div>
                         ))}
                       </div>

--- a/app/routes/dashboard/-video.tsx
+++ b/app/routes/dashboard/-video.tsx
@@ -20,6 +20,7 @@ import {
 import { cn, formatDuration } from "@/lib/utils";
 import { buildCommentsCsv, buildCommentsCsvFilename } from "@/lib/commentCsv";
 import { triggerTextDownload } from "@/lib/download";
+import { hasDrawing, type DrawingData } from "@/lib/drawing";
 import { useVideoPresence } from "@/lib/useVideoPresence";
 import { useSidebarCollapsed } from "@/lib/useSidebarCollapsed";
 import { VideoWatchers } from "@/components/presence/VideoWatchers";
@@ -310,6 +311,9 @@ export default function VideoPage() {
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [editedTitle, setEditedTitle] = useState("");
   const [highlightedCommentId, setHighlightedCommentId] = useState<Id<"comments"> | undefined>();
+  const [drawMode, setDrawMode] = useState(false);
+  const [draftDrawing, setDraftDrawing] = useState<DrawingData | null>(null);
+  const [viewDrawing, setViewDrawing] = useState<DrawingData | null>(null);
   const [shareDialogOpen, setShareDialogOpen] = useState(false);
   const [mobileCommentsOpen, setMobileCommentsOpen] = useState(false);
   const [sidebarCollapsed, toggleSidebarCollapsed] = useSidebarCollapsed();
@@ -604,10 +608,15 @@ export default function VideoPage() {
     }));
   }, [isLoadingPlayback, isPlayable, resolvedVideoId]);
 
-  const handleMarkerClick = useCallback((comment: { _id: string }) => {
-    setHighlightedCommentId(comment._id as Id<"comments">);
-    setTimeout(() => setHighlightedCommentId(undefined), 3000);
-  }, []);
+  const handleMarkerClick = useCallback(
+    (comment: { _id: string; drawing?: DrawingData | null }) => {
+      setHighlightedCommentId(comment._id as Id<"comments">);
+      setDrawMode(false);
+      setViewDrawing(hasDrawing(comment.drawing) ? (comment.drawing ?? null) : null);
+      setTimeout(() => setHighlightedCommentId(undefined), 3000);
+    },
+    [],
+  );
 
   const requestDownload = useCallback(async () => {
     if (!video || video.status !== "ready" || !resolvedVideoId) return null;
@@ -621,12 +630,35 @@ export default function VideoPage() {
   }, [getDownloadUrl, video, resolvedVideoId]);
 
   const handleTimestampClick = useCallback(
-    (time: number) => {
+    (
+      time: number,
+      options?: { drawing?: DrawingData | null; commentId?: Id<"comments"> },
+    ) => {
       playerRef.current?.seekTo(time);
-      setHighlightedCommentId(undefined);
+      setDrawMode(false);
+      setViewDrawing(hasDrawing(options?.drawing) ? (options?.drawing ?? null) : null);
+      if (options?.commentId) {
+        setHighlightedCommentId(options.commentId);
+        setTimeout(() => setHighlightedCommentId(undefined), 3000);
+      } else {
+        setHighlightedCommentId(undefined);
+      }
     },
-    [playerRef, setHighlightedCommentId],
+    [],
   );
+
+  const handleEnterDrawMode = useCallback(() => {
+    setViewDrawing(null);
+    setDrawMode(true);
+    playerRef.current?.enterDrawMode();
+  }, []);
+
+  // Drop draft/view drawings when switching versions/videos.
+  useEffect(() => {
+    setDrawMode(false);
+    setDraftDrawing(null);
+    setViewDrawing(null);
+  }, [resolvedVideoId]);
 
   const handleExportComments = useCallback(() => {
     if (!video || !commentsThreaded?.length) return;
@@ -1140,6 +1172,13 @@ export default function VideoPage() {
               downloadFilename={`${video.title}.mp4`}
               onRequestDownload={requestDownload}
               controlsBelow
+              drawMode={drawMode}
+              onDrawModeChange={setDrawMode}
+              draftDrawing={draftDrawing}
+              onDraftDrawingChange={setDraftDrawing}
+              viewDrawing={viewDrawing}
+              onClearViewDrawing={() => setViewDrawing(null)}
+              allowDrawing={canComment}
               qualityOptionsConfig={[
                 {
                   id: "mux720",
@@ -1272,6 +1311,10 @@ export default function VideoPage() {
                 timestampSeconds={currentTime}
                 showTimestamp
                 variant="seamless"
+                drawing={draftDrawing}
+                onClearDrawing={() => setDraftDrawing(null)}
+                onRequestDrawMode={handleEnterDrawMode}
+                drawModeActive={drawMode}
               />
             </div>
           )}
@@ -1315,8 +1358,8 @@ export default function VideoPage() {
             <CommentList
               videoId={resolvedVideoId}
               comments={commentsThreaded}
-              onTimestampClick={(time) => {
-                handleTimestampClick(time);
+              onTimestampClick={(time, options) => {
+                handleTimestampClick(time, options);
                 setMobileCommentsOpen(false);
               }}
               highlightedCommentId={highlightedCommentId}
@@ -1330,6 +1373,13 @@ export default function VideoPage() {
                 timestampSeconds={currentTime}
                 showTimestamp
                 variant="seamless"
+                drawing={draftDrawing}
+                onClearDrawing={() => setDraftDrawing(null)}
+                onRequestDrawMode={() => {
+                  setMobileCommentsOpen(false);
+                  handleEnterDrawMode();
+                }}
+                drawModeActive={drawMode}
               />
             </div>
           )}

--- a/convex/comments.ts
+++ b/convex/comments.ts
@@ -4,6 +4,121 @@ import { identityAvatarUrl, identityName, requireVideoAccess, requireUser } from
 import { resolveActiveShareGrant } from "./shareAccess";
 import { resolvePublicVideo } from "./videos";
 
+/** Max freehand strokes on a single comment drawing. */
+export const MAX_DRAWING_STROKES = 40;
+/** Max points per stroke. */
+export const MAX_POINTS_PER_STROKE = 400;
+/** Max points across all strokes. */
+export const MAX_TOTAL_DRAWING_POINTS = 4000;
+/** Serialized JSON length cap (~48KB). */
+export const MAX_DRAWING_SERIALIZED_LENGTH = 48_000;
+
+const drawingPointValidator = v.object({
+  x: v.number(),
+  y: v.number(),
+});
+
+const drawingStrokeValidator = v.object({
+  points: v.array(drawingPointValidator),
+});
+
+export const drawingValidator = v.object({
+  width: v.number(),
+  height: v.number(),
+  strokes: v.array(drawingStrokeValidator),
+});
+
+type DrawingInput = {
+  width: number;
+  height: number;
+  strokes: Array<{ points: Array<{ x: number; y: number }> }>;
+};
+
+function clamp01(n: number): number {
+  return Math.min(1, Math.max(0, n));
+}
+
+function round4(n: number): number {
+  return Math.round(n * 10_000) / 10_000;
+}
+
+/**
+ * Validate and normalize an optional drawing payload for storage.
+ * Throws on invalid / oversized drawings. Returns undefined when absent.
+ */
+export function normalizeDrawing(drawing: DrawingInput | undefined): DrawingInput | undefined {
+  if (drawing === undefined) return undefined;
+
+  const width = Number(drawing.width);
+  const height = Number(drawing.height);
+  if (!Number.isFinite(width) || width <= 0 || width > 10_000) {
+    throw new Error("Drawing width is invalid");
+  }
+  if (!Number.isFinite(height) || height <= 0 || height > 10_000) {
+    throw new Error("Drawing height is invalid");
+  }
+  if (!Array.isArray(drawing.strokes)) {
+    throw new Error("Drawing strokes must be an array");
+  }
+  if (drawing.strokes.length > MAX_DRAWING_STROKES) {
+    throw new Error(`Drawing can have at most ${MAX_DRAWING_STROKES} strokes`);
+  }
+
+  let totalPoints = 0;
+  const strokes: DrawingInput["strokes"] = [];
+
+  for (const stroke of drawing.strokes) {
+    if (!stroke || !Array.isArray(stroke.points)) {
+      throw new Error("Stroke points must be an array");
+    }
+    if (stroke.points.length > MAX_POINTS_PER_STROKE) {
+      throw new Error(`Each stroke can have at most ${MAX_POINTS_PER_STROKE} points`);
+    }
+
+    const points: Array<{ x: number; y: number }> = [];
+    for (const point of stroke.points) {
+      const x = Number(point?.x);
+      const y = Number(point?.y);
+      if (!Number.isFinite(x) || !Number.isFinite(y)) {
+        throw new Error("Point coordinates must be finite numbers");
+      }
+      points.push({ x: clamp01(round4(x)), y: clamp01(round4(y)) });
+    }
+
+    if (points.length < 2) continue;
+    totalPoints += points.length;
+    if (totalPoints > MAX_TOTAL_DRAWING_POINTS) {
+      throw new Error(`Drawing can have at most ${MAX_TOTAL_DRAWING_POINTS} points`);
+    }
+    strokes.push({ points });
+  }
+
+  if (strokes.length === 0) {
+    throw new Error("Drawing has no strokes");
+  }
+
+  const normalized: DrawingInput = {
+    width: Math.round(width),
+    height: Math.round(height),
+    strokes,
+  };
+
+  // Guard overall document size once serialized.
+  if (JSON.stringify(normalized).length > MAX_DRAWING_SERIALIZED_LENGTH) {
+    throw new Error("Drawing is too large");
+  }
+
+  return normalized;
+}
+
+function requireCommentBody(text: string, drawing: DrawingInput | undefined) {
+  const trimmed = text.trim();
+  if (!trimmed && !drawing) {
+    throw new Error("Comment must include text or a drawing");
+  }
+  return trimmed;
+}
+
 function toThreadedComments<
   T extends { _id: string; parentId?: string; timestampSeconds: number; _creationTime: number },
 >(comments: T[]) {
@@ -28,6 +143,7 @@ function toPublicCommentPayload(comment: {
   resolved: boolean;
   userName: string;
   userAvatarUrl?: string;
+  drawing?: DrawingInput;
 }) {
   return {
     _id: comment._id,
@@ -38,6 +154,7 @@ function toPublicCommentPayload(comment: {
     resolved: comment.resolved,
     userName: comment.userName,
     userAvatarUrl: comment.userAvatarUrl,
+    drawing: comment.drawing,
   };
 }
 
@@ -67,6 +184,7 @@ export const create = mutation({
     text: v.string(),
     timestampSeconds: v.number(),
     parentId: v.optional(v.id("comments")),
+    drawing: v.optional(drawingValidator),
   },
   handler: async (ctx, args) => {
     const { user } = await requireVideoAccess(ctx, args.videoId, "viewer");
@@ -78,15 +196,19 @@ export const create = mutation({
       }
     }
 
+    const drawing = normalizeDrawing(args.drawing);
+    const text = requireCommentBody(args.text, drawing);
+
     return await ctx.db.insert("comments", {
       videoId: args.videoId,
       userClerkId: user.subject,
       userName: identityName(user),
       userAvatarUrl: identityAvatarUrl(user),
-      text: args.text,
+      text,
       timestampSeconds: args.timestampSeconds,
       parentId: args.parentId,
       resolved: false,
+      ...(drawing ? { drawing } : {}),
     });
   },
 });
@@ -97,6 +219,7 @@ export const createForPublic = mutation({
     text: v.string(),
     timestampSeconds: v.number(),
     parentId: v.optional(v.id("comments")),
+    drawing: v.optional(drawingValidator),
   },
   handler: async (ctx, args) => {
     const user = await requireUser(ctx);
@@ -113,15 +236,19 @@ export const createForPublic = mutation({
       }
     }
 
+    const drawing = normalizeDrawing(args.drawing);
+    const text = requireCommentBody(args.text, drawing);
+
     return await ctx.db.insert("comments", {
       videoId: video._id,
       userClerkId: user.subject,
       userName: identityName(user),
       userAvatarUrl: identityAvatarUrl(user),
-      text: args.text,
+      text,
       timestampSeconds: args.timestampSeconds,
       parentId: args.parentId,
       resolved: false,
+      ...(drawing ? { drawing } : {}),
     });
   },
 });
@@ -132,6 +259,7 @@ export const createForShareGrant = mutation({
     text: v.string(),
     timestampSeconds: v.number(),
     parentId: v.optional(v.id("comments")),
+    drawing: v.optional(drawingValidator),
   },
   handler: async (ctx, args) => {
     const user = await requireUser(ctx);
@@ -153,15 +281,19 @@ export const createForShareGrant = mutation({
       }
     }
 
+    const drawing = normalizeDrawing(args.drawing);
+    const text = requireCommentBody(args.text, drawing);
+
     return await ctx.db.insert("comments", {
       videoId: video._id,
       userClerkId: user.subject,
       userName: identityName(user),
       userAvatarUrl: identityAvatarUrl(user),
-      text: args.text,
+      text,
       timestampSeconds: args.timestampSeconds,
       parentId: args.parentId,
       resolved: false,
+      ...(drawing ? { drawing } : {}),
     });
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -135,6 +135,24 @@ export default defineSchema({
     timestampSeconds: v.number(),
     parentId: v.optional(v.id("comments")),
     resolved: v.boolean(),
+    // Freehand on-frame annotation (normalized strokes). Optional — existing
+    // rows need no backfill.
+    drawing: v.optional(
+      v.object({
+        width: v.number(),
+        height: v.number(),
+        strokes: v.array(
+          v.object({
+            points: v.array(
+              v.object({
+                x: v.number(),
+                y: v.number(),
+              }),
+            ),
+          }),
+        ),
+      }),
+    ),
   })
     .index("by_video", ["videoId"])
     .index("by_video_and_timestamp", ["videoId", "timestampSeconds"])

--- a/src/components/comments/CommentInput.tsx
+++ b/src/components/comments/CommentInput.tsx
@@ -6,7 +6,8 @@ import { api } from "../../../convex/_generated/api";
 import { Id } from "../../../convex/_generated/dataModel";
 import { Button } from "@/components/ui/button";
 import { formatTimestamp } from "@/lib/utils";
-import { Send, X } from "lucide-react";
+import { hasDrawing, type DrawingData } from "@/lib/drawing";
+import { Pencil, Send, X } from "lucide-react";
 
 interface CommentInputProps {
   videoId: Id<"videos">;
@@ -18,6 +19,11 @@ interface CommentInputProps {
   placeholder?: string;
   showTimestamp?: boolean;
   variant?: "default" | "seamless";
+  /** Optional freehand drawing attached to this comment. */
+  drawing?: DrawingData | null;
+  onClearDrawing?: () => void;
+  onRequestDrawMode?: () => void;
+  drawModeActive?: boolean;
 }
 
 export function CommentInput({
@@ -30,11 +36,18 @@ export function CommentInput({
   placeholder,
   showTimestamp = false,
   variant = "default",
+  drawing = null,
+  onClearDrawing,
+  onRequestDrawMode,
+  drawModeActive = false,
 }: CommentInputProps) {
   const [text, setText] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const createComment = useMutation(api.comments.create);
+
+  const hasAttachedDrawing = hasDrawing(drawing);
+  const canSubmit = (Boolean(text.trim()) || hasAttachedDrawing) && !isLoading;
 
   const defaultPlaceholder = showTimestamp
     ? `Comment at ${formatTimestamp(timestampSeconds)}...`
@@ -49,7 +62,7 @@ export function CommentInput({
   }, [text]);
 
   const submitComment = async () => {
-    if (!text.trim()) return;
+    if (!canSubmit) return;
 
     setIsLoading(true);
     try {
@@ -58,8 +71,20 @@ export function CommentInput({
         text: text.trim(),
         timestampSeconds,
         parentId,
+        ...(hasAttachedDrawing && drawing
+          ? {
+              drawing: {
+                width: drawing.width,
+                height: drawing.height,
+                strokes: drawing.strokes.map((stroke) => ({
+                  points: stroke.points.map((p) => ({ x: p.x, y: p.y })),
+                })),
+              },
+            }
+          : {}),
       });
       setText("");
+      onClearDrawing?.();
       onSubmit?.();
     } catch (error) {
       console.error("Failed to create comment:", error);
@@ -111,6 +136,38 @@ export function CommentInput({
             : "absolute right-3 bottom-3 flex items-center gap-2"
         }
       >
+        {onRequestDrawMode && (
+          <Button
+            type="button"
+            variant={drawModeActive || hasAttachedDrawing ? "primary" : "outline"}
+            size="icon"
+            className="h-8 w-8 shrink-0"
+            onClick={onRequestDrawMode}
+            title={
+              hasAttachedDrawing
+                ? "Edit drawing on video"
+                : drawModeActive
+                  ? "Drawing mode active"
+                  : "Draw on frame"
+            }
+            aria-label="Draw on frame"
+            aria-pressed={drawModeActive}
+          >
+            <Pencil className="h-4 w-4" />
+          </Button>
+        )}
+        {hasAttachedDrawing && onClearDrawing && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 shrink-0 px-2 text-[10px] font-bold"
+            onClick={onClearDrawing}
+            title="Remove drawing"
+          >
+            Clear draw
+          </Button>
+        )}
         {onCancel && (
           <Button
             type="button"
@@ -127,11 +184,22 @@ export function CommentInput({
           variant={variant === "seamless" ? "ghost" : "primary"}
           size="icon"
           className="h-8 w-8 shrink-0 disabled:opacity-50"
-          disabled={!text.trim() || isLoading}
+          disabled={!canSubmit}
         >
           <Send className="h-4 w-4" />
         </Button>
       </div>
+      {hasAttachedDrawing && (
+        <div className="pointer-events-none absolute bottom-3 left-3 flex items-center gap-1.5 text-[11px] font-bold text-[#2d5a2d]">
+          <Pencil className="h-3 w-3" />
+          Drawing attached
+          {drawing?.strokes?.length ? (
+            <span className="font-mono font-normal text-[#888]">
+              · {drawing.strokes.length} stroke{drawing.strokes.length === 1 ? "" : "s"}
+            </span>
+          ) : null}
+        </div>
+      )}
     </form>
   );
 }

--- a/src/components/comments/CommentItem.tsx
+++ b/src/components/comments/CommentItem.tsx
@@ -7,7 +7,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { formatTimestamp, formatRelativeTime, getInitials, cn } from "@/lib/utils";
-import { Check, MoreVertical, Trash2, Reply } from "lucide-react";
+import { Check, MoreVertical, Pencil, Trash2, Reply } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -17,6 +17,7 @@ import {
 import { useState } from "react";
 import { CommentInput } from "./CommentInput";
 import { CommentText } from "./CommentText";
+import { hasDrawing, type DrawingData } from "@/lib/drawing";
 
 interface Comment {
   _id: Id<"comments">;
@@ -28,11 +29,17 @@ interface Comment {
   userName: string;
   userAvatarUrl?: string;
   _creationTime: number;
+  drawing?: DrawingData | null;
 }
+
+export type CommentSeekOptions = {
+  drawing?: DrawingData | null;
+  commentId?: Id<"comments">;
+};
 
 interface CommentItemProps {
   comment: Comment;
-  onTimestampClick: (seconds: number) => void;
+  onTimestampClick: (seconds: number, options?: CommentSeekOptions) => void;
   isHighlighted?: boolean;
   isReply?: boolean;
   canResolve?: boolean;
@@ -48,6 +55,7 @@ export function CommentItem({
   const [isReplying, setIsReplying] = useState(false);
   const toggleResolved = useMutation(api.comments.toggleResolved);
   const deleteComment = useMutation(api.comments.remove);
+  const commentHasDrawing = hasDrawing(comment.drawing);
 
   const handleToggleResolved = async () => {
     try {
@@ -64,6 +72,13 @@ export function CommentItem({
     } catch (error) {
       console.error("Failed to delete comment:", error);
     }
+  };
+
+  const handleSeek = () => {
+    onTimestampClick(comment.timestampSeconds, {
+      drawing: comment.drawing ?? null,
+      commentId: comment._id,
+    });
   };
 
   return (
@@ -85,11 +100,22 @@ export function CommentItem({
             <div className="flex min-w-0 items-center gap-2">
               <span className="truncate text-sm font-bold text-[#1a1a1a]">{comment.userName}</span>
               <button
-                onClick={() => onTimestampClick(comment.timestampSeconds)}
+                onClick={handleSeek}
                 className="shrink-0 font-mono text-xs font-bold text-[#2d5a2d] hover:text-[#1a1a1a]"
               >
                 {formatTimestamp(comment.timestampSeconds)}
               </button>
+              {commentHasDrawing && (
+                <button
+                  type="button"
+                  onClick={handleSeek}
+                  className="inline-flex shrink-0 items-center gap-1 border border-[#2d5a2d] bg-[#2d5a2d]/10 px-1.5 py-0.5 text-[10px] font-bold text-[#2d5a2d] hover:bg-[#2d5a2d] hover:text-[#f0f0e8]"
+                  title="View drawing on frame"
+                >
+                  <Pencil className="h-3 w-3" />
+                  Drawing
+                </button>
+              )}
               {comment.resolved && (
                 <Badge variant="success" className="shrink-0 text-[10px]">
                   Resolved
@@ -125,9 +151,13 @@ export function CommentItem({
               </DropdownMenuContent>
             </DropdownMenu>
           </div>
-          <p className="mt-1 text-sm break-words whitespace-pre-wrap text-[#1a1a1a]">
-            <CommentText text={comment.text} />
-          </p>
+          {comment.text ? (
+            <p className="mt-1 text-sm break-words whitespace-pre-wrap text-[#1a1a1a]">
+              <CommentText text={comment.text} />
+            </p>
+          ) : commentHasDrawing ? (
+            <p className="mt-1 text-sm text-[#888] italic">Frame drawing</p>
+          ) : null}
           <p className="mt-1 text-[11px] text-[#888]">
             {formatRelativeTime(comment._creationTime)}
           </p>

--- a/src/components/comments/CommentList.tsx
+++ b/src/components/comments/CommentList.tsx
@@ -4,7 +4,7 @@ import { useQuery } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import { Id } from "../../../convex/_generated/dataModel";
 import { FunctionReturnType } from "convex/server";
-import { CommentItem } from "./CommentItem";
+import { CommentItem, type CommentSeekOptions } from "./CommentItem";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
 type ThreadedComments = FunctionReturnType<typeof api.comments.getThreaded>;
@@ -12,7 +12,7 @@ type ThreadedComments = FunctionReturnType<typeof api.comments.getThreaded>;
 interface CommentListProps {
   videoId: Id<"videos">;
   comments?: ThreadedComments;
-  onTimestampClick: (seconds: number) => void;
+  onTimestampClick: (seconds: number, options?: CommentSeekOptions) => void;
   highlightedCommentId?: Id<"comments">;
   canResolve?: boolean;
 }

--- a/src/components/video-player/DrawingOverlay.tsx
+++ b/src/components/video-player/DrawingOverlay.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  DRAWING_STROKE_COLOR,
+  type DrawingData,
+  type DrawingPoint,
+  type DrawingStroke,
+  emptyDrawing,
+  hasDrawing,
+  normalizePoint,
+} from "@/lib/drawing";
+import { cn } from "@/lib/utils";
+
+interface DrawingOverlayProps {
+  /** Interactive draw mode captures pointer strokes. View mode is read-only. */
+  mode: "draw" | "view";
+  value: DrawingData | null;
+  onChange?: (drawing: DrawingData | null) => void;
+  className?: string;
+  strokeColor?: string;
+  strokeWidth?: number;
+}
+
+/**
+ * Canvas overlay for freehand annotations. Mount only when drawing or viewing
+ * a drawing — pointer moves are batched with rAF to avoid re-rendering the
+ * parent player on every event.
+ */
+export function DrawingOverlay({
+  mode,
+  value,
+  onChange,
+  className,
+  strokeColor = DRAWING_STROKE_COLOR,
+  strokeWidth = 3,
+}: DrawingOverlayProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const strokesRef = useRef<DrawingStroke[]>(value?.strokes ?? []);
+  const activeStrokeRef = useRef<DrawingPoint[] | null>(null);
+  const sizeRef = useRef({ width: value?.width ?? 1, height: value?.height ?? 1 });
+  const rafRef = useRef<number | null>(null);
+  const needsDrawRef = useRef(false);
+  const [isDrawing, setIsDrawing] = useState(false);
+
+  const paint = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    // After setTransform(dpr…), drawing uses CSS pixel space.
+    const rect = canvas.getBoundingClientRect();
+    const width = Math.max(1, rect.width);
+    const height = Math.max(1, rect.height);
+    ctx.clearRect(0, 0, width, height);
+    ctx.lineCap = "round";
+    ctx.lineJoin = "round";
+    ctx.strokeStyle = strokeColor;
+    // Keep stroke width readable across sizes: ~0.35% of the shorter side, min 2.
+    const minDim = Math.min(width, height);
+    ctx.lineWidth = Math.max(2, strokeWidth, minDim * 0.0035);
+
+    const allStrokes = strokesRef.current.slice();
+    if (activeStrokeRef.current && activeStrokeRef.current.length > 0) {
+      allStrokes.push({ points: activeStrokeRef.current });
+    }
+
+    for (const stroke of allStrokes) {
+      if (stroke.points.length < 2) continue;
+      ctx.beginPath();
+      const first = stroke.points[0]!;
+      ctx.moveTo(first.x * width, first.y * height);
+      for (let i = 1; i < stroke.points.length; i++) {
+        const p = stroke.points[i]!;
+        ctx.lineTo(p.x * width, p.y * height);
+      }
+      ctx.stroke();
+    }
+  }, [strokeColor, strokeWidth]);
+
+  const schedulePaint = useCallback(() => {
+    needsDrawRef.current = true;
+    if (rafRef.current !== null) return;
+    rafRef.current = window.requestAnimationFrame(() => {
+      rafRef.current = null;
+      if (!needsDrawRef.current) return;
+      needsDrawRef.current = false;
+      paint();
+    });
+  }, [paint]);
+
+  // Sync external value when not mid-stroke (e.g. undo/clear/view seek).
+  useEffect(() => {
+    if (activeStrokeRef.current) return;
+    strokesRef.current = value?.strokes ? value.strokes.map((s) => ({ points: [...s.points] })) : [];
+    if (value?.width && value?.height) {
+      sizeRef.current = { width: value.width, height: value.height };
+    }
+    schedulePaint();
+  }, [value, schedulePaint]);
+
+  const resizeCanvas = useCallback(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!canvas || !container) return;
+
+    const rect = container.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+    const cssWidth = Math.max(1, Math.round(rect.width));
+    const cssHeight = Math.max(1, Math.round(rect.height));
+
+    canvas.style.width = `${cssWidth}px`;
+    canvas.style.height = `${cssHeight}px`;
+    canvas.width = Math.round(cssWidth * dpr);
+    canvas.height = Math.round(cssHeight * dpr);
+
+    const ctx = canvas.getContext("2d");
+    if (ctx) {
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+
+    // Logical size tracks CSS pixels for storage aspect.
+    sizeRef.current = { width: cssWidth, height: cssHeight };
+    schedulePaint();
+  }, [schedulePaint]);
+
+  useEffect(() => {
+    resizeCanvas();
+    const container = containerRef.current;
+    if (!container || typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", resizeCanvas);
+      return () => window.removeEventListener("resize", resizeCanvas);
+    }
+
+    const observer = new ResizeObserver(() => resizeCanvas());
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [resizeCanvas]);
+
+  useEffect(() => {
+    return () => {
+      if (rafRef.current !== null) {
+        window.cancelAnimationFrame(rafRef.current);
+      }
+    };
+  }, []);
+
+  const pointFromEvent = (clientX: number, clientY: number): DrawingPoint | null => {
+    const canvas = canvasRef.current;
+    if (!canvas) return null;
+    const rect = canvas.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return null;
+    return normalizePoint((clientX - rect.left) / rect.width, (clientY - rect.top) / rect.height);
+  };
+
+  const emitChange = (strokes: DrawingStroke[]) => {
+    if (!onChange) return;
+    if (strokes.length === 0) {
+      onChange(null);
+      return;
+    }
+    const next: DrawingData = {
+      strokes,
+      width: sizeRef.current.width,
+      height: sizeRef.current.height,
+    };
+    onChange(hasDrawing(next) ? next : null);
+  };
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (mode !== "draw") return;
+    e.preventDefault();
+    e.stopPropagation();
+    const point = pointFromEvent(e.clientX, e.clientY);
+    if (!point) return;
+
+    (e.target as HTMLCanvasElement).setPointerCapture(e.pointerId);
+    activeStrokeRef.current = [point];
+    setIsDrawing(true);
+    schedulePaint();
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (mode !== "draw" || !activeStrokeRef.current) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const point = pointFromEvent(e.clientX, e.clientY);
+    if (!point) return;
+
+    const stroke = activeStrokeRef.current;
+    const last = stroke[stroke.length - 1];
+    if (last && last.x === point.x && last.y === point.y) return;
+    stroke.push(point);
+    schedulePaint();
+  };
+
+  const endStroke = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (mode !== "draw" || !activeStrokeRef.current) return;
+    e.preventDefault();
+    e.stopPropagation();
+
+    try {
+      (e.target as HTMLCanvasElement).releasePointerCapture(e.pointerId);
+    } catch {
+      // ignore if already released
+    }
+
+    const finished = activeStrokeRef.current;
+    activeStrokeRef.current = null;
+    setIsDrawing(false);
+
+    if (finished.length >= 2) {
+      const next = [...strokesRef.current, { points: finished }];
+      strokesRef.current = next;
+      emitChange(next);
+    }
+    schedulePaint();
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(
+        "absolute inset-0 z-[15]",
+        mode === "draw" ? "pointer-events-auto cursor-crosshair" : "pointer-events-none",
+        className,
+      )}
+      data-drawing-mode={mode}
+      data-drawing-active={isDrawing ? "true" : "false"}
+    >
+      <canvas
+        ref={canvasRef}
+        className="h-full w-full touch-none"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={endStroke}
+        onPointerCancel={endStroke}
+        // Prevent click-to-play on the video underneath while drawing.
+        onClick={(e) => {
+          if (mode === "draw") {
+            e.preventDefault();
+            e.stopPropagation();
+          }
+        }}
+        aria-label={mode === "draw" ? "Drawing canvas" : "Annotation overlay"}
+      />
+    </div>
+  );
+}
+
+export function createEmptyDrawing(width = 1280, height = 720): DrawingData {
+  return emptyDrawing(width, height);
+}

--- a/src/components/video-player/VideoPlayer.tsx
+++ b/src/components/video-player/VideoPlayer.tsx
@@ -24,6 +24,12 @@ import {
   Settings2,
   Check,
   ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  Pencil,
+  Undo2,
+  Eraser,
+  X,
 } from "lucide-react";
 import { cn, formatDuration, formatTimestamp } from "@/lib/utils";
 import { triggerDownload } from "@/lib/download";
@@ -33,11 +39,20 @@ import {
   observeVideoPlayback,
   resetVideoPlaybackHealthWindow,
 } from "@/lib/videoPlaybackHealth";
+import {
+  DEFAULT_VIDEO_FPS,
+  formatFrameTimecode,
+  frameDeltaSeconds,
+  nextFrameTime,
+} from "@/lib/frameStep";
+import { hasDrawing, type DrawingData } from "@/lib/drawing";
+import { DrawingOverlay } from "./DrawingOverlay";
 
 interface Comment {
   _id: string;
   timestampSeconds: number;
   resolved: boolean;
+  drawing?: DrawingData | null;
 }
 
 interface DownloadResult {
@@ -72,6 +87,17 @@ interface VideoPlayerProps {
   onSelectQuality?: (id: string) => void;
   /** Render controls below the video frame instead of overlaid. Ideal for mobile. */
   controlsBelow?: boolean;
+  /** Enter freehand draw mode on the video frame. */
+  drawMode?: boolean;
+  onDrawModeChange?: (active: boolean) => void;
+  /** In-progress drawing attached to the next comment. */
+  draftDrawing?: DrawingData | null;
+  onDraftDrawingChange?: (drawing: DrawingData | null) => void;
+  /** Read-only drawing to display (e.g. after seeking to an annotated comment). */
+  viewDrawing?: DrawingData | null;
+  onClearViewDrawing?: () => void;
+  /** Show draw-mode entry control. Defaults to true when draw handlers are provided. */
+  allowDrawing?: boolean;
 }
 
 export type VideoPlaybackIssue =
@@ -90,6 +116,9 @@ export type VideoPlaybackIssue =
 
 export interface VideoPlayerHandle {
   seekTo: (time: number, options?: { play?: boolean }) => void;
+  stepFrame: (direction: 1 | -1) => void;
+  enterDrawMode: () => void;
+  exitDrawMode: () => void;
 }
 
 const PLAYBACK_RATES = [0.5, 0.75, 1, 1.25, 1.5, 2] as const;
@@ -127,6 +156,13 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
     selectedQualityId,
     onSelectQuality,
     controlsBelow = false,
+    drawMode = false,
+    onDrawModeChange,
+    draftDrawing = null,
+    onDraftDrawingChange,
+    viewDrawing = null,
+    onClearViewDrawing,
+    allowDrawing,
   },
   ref,
 ) {
@@ -155,6 +191,12 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
   const [qualityMenuOpen, setQualityMenuOpen] = useState(false);
   const [qualityOptions, setQualityOptions] = useState<QualityLevelOption[]>([]);
   const [selectedQualityLevel, setSelectedQualityLevel] = useState<number>(AUTO_QUALITY_LEVEL);
+  const [detectedFps, setDetectedFps] = useState(DEFAULT_VIDEO_FPS);
+
+  const canDraw =
+    allowDrawing ?? Boolean(onDrawModeChange || onDraftDrawingChange);
+  const showDrawingOverlay =
+    drawMode || hasDrawing(viewDrawing) || hasDrawing(draftDrawing);
 
   const hideControlsTimeoutRef = useRef<number | null>(null);
   const wasPlayingBeforeScrubRef = useRef(false);
@@ -237,7 +279,117 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
     [applyTime, showControls],
   );
 
-  useImperativeHandle(ref, () => ({ seekTo }), [seekTo]);
+  const detectFpsFromSources = useCallback(() => {
+    const hls = hlsRef.current;
+    if (hls) {
+      const levelIndex = hls.currentLevel >= 0 ? hls.currentLevel : hls.loadLevel;
+      const level =
+        (levelIndex >= 0 ? hls.levels[levelIndex] : undefined) ?? hls.levels[0];
+      const attrs = level?.attrs as Record<string, string> | undefined;
+      const fromAttr = attrs?.["FRAME-RATE"] ?? attrs?.["frame-rate"];
+      const parsedAttr = fromAttr ? Number.parseFloat(fromAttr) : Number.NaN;
+      if (Number.isFinite(parsedAttr) && parsedAttr > 0 && parsedAttr <= 240) {
+        return parsedAttr;
+      }
+      const levelAny = level as { frameRate?: number } | undefined;
+      if (
+        levelAny?.frameRate &&
+        Number.isFinite(levelAny.frameRate) &&
+        levelAny.frameRate > 0 &&
+        levelAny.frameRate <= 240
+      ) {
+        return levelAny.frameRate;
+      }
+    }
+    return DEFAULT_VIDEO_FPS;
+  }, []);
+
+  const stepFrame = useCallback(
+    (direction: 1 | -1) => {
+      const video = videoRef.current;
+      if (!video) return;
+
+      // Frame step always freezes first so reviewers land on a still frame.
+      if (!video.paused) {
+        video.pause();
+      }
+      if (drawMode) {
+        // Stay in draw mode; stepping while drawing is useful for frame-precise marks.
+      } else {
+        onClearViewDrawing?.();
+      }
+
+      const fps = detectFpsFromSources();
+      if (fps !== detectedFps) {
+        setDetectedFps(fps);
+      }
+
+      const next = nextFrameTime(
+        video.currentTime ?? 0,
+        direction,
+        fps,
+        duration || video.duration || undefined,
+      );
+      applyTime(next);
+      showControls();
+    },
+    [
+      applyTime,
+      detectFpsFromSources,
+      detectedFps,
+      drawMode,
+      duration,
+      onClearViewDrawing,
+      showControls,
+    ],
+  );
+
+  const enterDrawMode = useCallback(() => {
+    if (!canDraw) return;
+    const video = videoRef.current;
+    if (video && !video.paused) {
+      video.pause();
+    }
+    onClearViewDrawing?.();
+    onDrawModeChange?.(true);
+    showControls();
+  }, [canDraw, onClearViewDrawing, onDrawModeChange, showControls]);
+
+  const exitDrawMode = useCallback(() => {
+    onDrawModeChange?.(false);
+    showControls();
+  }, [onDrawModeChange, showControls]);
+
+  const undoLastStroke = useCallback(() => {
+    if (!draftDrawing?.strokes?.length) {
+      onDraftDrawingChange?.(null);
+      return;
+    }
+    const nextStrokes = draftDrawing.strokes.slice(0, -1);
+    if (nextStrokes.length === 0) {
+      onDraftDrawingChange?.(null);
+      return;
+    }
+    onDraftDrawingChange?.({
+      ...draftDrawing,
+      strokes: nextStrokes,
+    });
+  }, [draftDrawing, onDraftDrawingChange]);
+
+  const clearDraftDrawing = useCallback(() => {
+    onDraftDrawingChange?.(null);
+  }, [onDraftDrawingChange]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      seekTo,
+      stepFrame,
+      enterDrawMode,
+      exitDrawMode,
+    }),
+    [seekTo, stepFrame, enterDrawMode, exitDrawMode],
+  );
 
   const handleSeekBy = useCallback(
     (delta: number) => {
@@ -254,6 +406,11 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
     showControls();
 
     if (video.paused) {
+      // Playing dismisses draw mode and read-only annotation overlay.
+      if (drawMode) {
+        onDrawModeChange?.(false);
+      }
+      onClearViewDrawing?.();
       const playPromise = video.play();
       if (playPromise) {
         playPromise.catch(() => {
@@ -263,7 +420,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
     } else {
       video.pause();
     }
-  }, [showControls]);
+  }, [drawMode, onClearViewDrawing, onDrawModeChange, showControls]);
 
   const setVideoVolume = useCallback((nextVolume: number) => {
     const video = videoRef.current;
@@ -879,10 +1036,26 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
     };
   }, [qualityMenuOpen]);
 
+  // Keep fps in sync when media becomes ready / quality changes.
+  useEffect(() => {
+    if (!isMediaReady) return;
+    const fps = detectFpsFromSources();
+    setDetectedFps(fps);
+  }, [detectFpsFromSources, isMediaReady, selectedQualityLevel, selectedQualityId, src]);
+
+  // Exit draw mode if the parent revokes drawing permission mid-session.
+  useEffect(() => {
+    if (!canDraw && drawMode) {
+      onDrawModeChange?.(false);
+    }
+  }, [canDraw, drawMode, onDrawModeChange]);
+
   const displayTime = isScrubbing ? scrubTime : currentTime;
   const playedPercent = duration > 0 ? clamp(displayTime / duration, 0, 1) : 0;
   const canDownload = allowDownload && (Boolean(downloadUrl) || Boolean(onRequestDownload));
   const isHls = isHlsSource(src);
+  const frameStepSeconds = frameDeltaSeconds(detectedFps);
+  const pausedTimecode = formatFrameTimecode(displayTime, detectedFps);
   const hasExternalQualityOptions = Boolean(
     qualityOptionsConfig && qualityOptionsConfig.length > 0,
   );
@@ -1012,11 +1185,46 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
 
         <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-white/90">
           <span className="font-mono">
-            {formatDuration(displayTime)} / {formatDuration(duration || 0)}
+            {isPlaying ? (
+              <>
+                {formatDuration(displayTime)} / {formatDuration(duration || 0)}
+              </>
+            ) : (
+              <>
+                {pausedTimecode}
+                <span className="text-white/50"> / {formatDuration(duration || 0)}</span>
+              </>
+            )}
           </span>
         </div>
 
         <div className="ml-auto flex items-center gap-2">
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              stepFrame(-1);
+            }}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/10 bg-white/5 transition hover:border-white/25 hover:bg-white/15"
+            aria-label="Previous frame"
+            title={`Previous frame (,) · ${frameStepSeconds.toFixed(4)}s`}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              stepFrame(1);
+            }}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/10 bg-white/5 transition hover:border-white/25 hover:bg-white/15"
+            aria-label="Next frame"
+            title={`Next frame (.) · ${frameStepSeconds.toFixed(4)}s`}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+
           <button
             type="button"
             onClick={(e) => {
@@ -1042,6 +1250,32 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
           >
             <RotateCw className="h-4 w-4" />
           </button>
+
+          {canDraw && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                if (drawMode) {
+                  exitDrawMode();
+                } else {
+                  enterDrawMode();
+                }
+              }}
+              className={cn(
+                "inline-flex h-9 items-center justify-center gap-1.5 rounded-full border px-3 text-xs font-medium transition",
+                drawMode
+                  ? "border-[#7cb87c]/60 bg-[#2d5a2d] text-[#f0f0e8]"
+                  : "border-white/10 bg-white/5 text-white/95 hover:border-white/25 hover:bg-white/15",
+              )}
+              aria-label={drawMode ? "Exit draw mode" : "Draw on frame"}
+              aria-pressed={drawMode}
+              title={drawMode ? "Exit draw mode" : "Draw on frame"}
+            >
+              <Pencil className="h-3.5 w-3.5" />
+              <span className="hidden sm:inline">{drawMode ? "Drawing" : "Draw"}</span>
+            </button>
+          )}
 
           <button
             type="button"
@@ -1195,9 +1429,32 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
           }
         }}
         onKeyDown={(e) => {
+          // Don't steal keys while typing in inputs (shouldn't be focused here, but safe).
+          const target = e.target as HTMLElement | null;
+          if (
+            target &&
+            (target.tagName === "INPUT" ||
+              target.tagName === "TEXTAREA" ||
+              target.isContentEditable)
+          ) {
+            return;
+          }
+
           if (e.key === " " || e.key.toLowerCase() === "k") {
             e.preventDefault();
             togglePlay();
+            return;
+          }
+          // NLE-style frame step (Final Cut / Resolve): comma / period.
+          // Distinct from ArrowLeft/Right which seek by seconds.
+          if (e.key === "," || e.key === "<") {
+            e.preventDefault();
+            stepFrame(-1);
+            return;
+          }
+          if (e.key === "." || e.key === ">") {
+            e.preventDefault();
+            stepFrame(1);
             return;
           }
           if (e.key === "ArrowLeft") {
@@ -1208,6 +1465,20 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
           if (e.key === "ArrowRight") {
             e.preventDefault();
             handleSeekBy(5);
+            return;
+          }
+          if (e.key.toLowerCase() === "d" && canDraw) {
+            e.preventDefault();
+            if (drawMode) {
+              exitDrawMode();
+            } else {
+              enterDrawMode();
+            }
+            return;
+          }
+          if (e.key === "Escape" && drawMode) {
+            e.preventDefault();
+            exitDrawMode();
             return;
           }
           if (e.key.toLowerCase() === "f") {
@@ -1243,9 +1514,66 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
           preload="auto"
           onClick={(e) => {
             e.stopPropagation();
+            if (drawMode) return;
             togglePlay();
           }}
         />
+
+        {/* Drawing / annotation overlay — only mounted when needed */}
+        {showDrawingOverlay && (
+          <DrawingOverlay
+            mode={drawMode ? "draw" : "view"}
+            value={drawMode ? draftDrawing : (viewDrawing ?? draftDrawing)}
+            onChange={drawMode ? onDraftDrawingChange : undefined}
+          />
+        )}
+
+        {/* Draw-mode toolbar */}
+        {drawMode && (
+          <div className="absolute top-3 left-1/2 z-[25] flex -translate-x-1/2 items-center gap-1 border-2 border-[#1a1a1a] bg-[#f0f0e8] p-1 text-[#1a1a1a] shadow-[3px_3px_0px_0px_#1a1a1a]">
+            <span className="hidden px-2 font-mono text-[10px] font-bold tracking-wide uppercase sm:inline">
+              Draw
+            </span>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                undoLastStroke();
+              }}
+              disabled={!draftDrawing?.strokes?.length}
+              className="inline-flex h-8 items-center gap-1 px-2 text-xs font-bold transition hover:bg-[#1a1a1a]/10 disabled:opacity-40"
+              title="Undo last stroke"
+            >
+              <Undo2 className="h-3.5 w-3.5" />
+              Undo
+            </button>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                clearDraftDrawing();
+              }}
+              disabled={!draftDrawing?.strokes?.length}
+              className="inline-flex h-8 items-center gap-1 px-2 text-xs font-bold transition hover:bg-[#1a1a1a]/10 disabled:opacity-40"
+              title="Clear drawing"
+            >
+              <Eraser className="h-3.5 w-3.5" />
+              Clear
+            </button>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                exitDrawMode();
+              }}
+              className="inline-flex h-8 items-center gap-1 bg-[#2d5a2d] px-2 text-xs font-bold text-[#f0f0e8] transition hover:bg-[#3a6a3a]"
+              title="Done drawing — attach via comment"
+            >
+              <X className="h-3.5 w-3.5" />
+              Done
+            </button>
+          </div>
+        )}
 
         {!isMediaReady && (
           <div className="pointer-events-none absolute inset-0 z-[5]">
@@ -1262,8 +1590,8 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(funct
           </div>
         )}
 
-        {/* Big play button */}
-        {!isPlaying && (
+        {/* Big play button — hidden while drawing so the canvas stays clear */}
+        {!isPlaying && !drawMode && (
           <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center">
             <button
               type="button"

--- a/src/lib/drawing.test.ts
+++ b/src/lib/drawing.test.ts
@@ -1,0 +1,109 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  countDrawingPoints,
+  emptyDrawing,
+  hasDrawing,
+  MAX_DRAWING_STROKES,
+  MAX_POINTS_PER_STROKE,
+  normalizePoint,
+  parseDrawing,
+  serializeDrawing,
+  simplifyStroke,
+  strokeToSvgPath,
+} from "./drawing";
+
+test("normalizePoint clamps and rounds", () => {
+  assert.deepEqual(normalizePoint(-0.5, 1.5), { x: 0, y: 1 });
+  assert.deepEqual(normalizePoint(0.123456, 0.987654), { x: 0.1235, y: 0.9877 });
+});
+
+test("simplifyStroke drops near-duplicates but keeps endpoints", () => {
+  const points = [
+    { x: 0, y: 0 },
+    { x: 0.001, y: 0 },
+    { x: 0.5, y: 0.5 },
+    { x: 0.501, y: 0.5 },
+    { x: 1, y: 1 },
+  ];
+  const simplified = simplifyStroke(points, 0.01);
+  assert.equal(simplified[0]?.x, 0);
+  assert.equal(simplified[simplified.length - 1]?.x, 1);
+  assert.ok(simplified.length < points.length);
+});
+
+test("serializeDrawing returns null for empty drawings", () => {
+  assert.equal(serializeDrawing(null), null);
+  assert.equal(serializeDrawing(emptyDrawing()), null);
+  assert.equal(
+    serializeDrawing({
+      width: 100,
+      height: 100,
+      strokes: [{ points: [{ x: 0.1, y: 0.1 }] }],
+    }),
+    null,
+  );
+});
+
+test("serialize + parse round-trips a multi-stroke drawing", () => {
+  const drawing = {
+    width: 1280,
+    height: 720,
+    strokes: [
+      {
+        points: [
+          { x: 0.1, y: 0.2 },
+          { x: 0.3, y: 0.4 },
+          { x: 0.5, y: 0.6 },
+        ],
+      },
+      {
+        points: [
+          { x: 0.9, y: 0.1 },
+          { x: 0.8, y: 0.2 },
+        ],
+      },
+    ],
+  };
+
+  const serialized = serializeDrawing(drawing);
+  assert.ok(serialized);
+  const parsed = parseDrawing(serialized);
+  assert.equal(parsed.width, 1280);
+  assert.equal(parsed.height, 720);
+  assert.equal(parsed.strokes.length, 2);
+  assert.equal(countDrawingPoints(parsed), 5);
+  assert.equal(hasDrawing(parsed), true);
+});
+
+test("parseDrawing rejects oversized stroke counts", () => {
+  const strokes = Array.from({ length: MAX_DRAWING_STROKES + 1 }, () => ({
+    points: [
+      { x: 0, y: 0 },
+      { x: 1, y: 1 },
+    ],
+  }));
+  assert.throws(() => parseDrawing({ width: 10, height: 10, strokes }), /at most/);
+});
+
+test("parseDrawing rejects oversized point counts per stroke", () => {
+  const points = Array.from({ length: MAX_POINTS_PER_STROKE + 1 }, (_, i) => ({
+    x: i / (MAX_POINTS_PER_STROKE + 1),
+    y: 0.5,
+  }));
+  assert.throws(
+    () => parseDrawing({ width: 10, height: 10, strokes: [{ points }] }),
+    /at most/,
+  );
+});
+
+test("strokeToSvgPath builds an M/L path", () => {
+  assert.equal(
+    strokeToSvgPath([
+      { x: 0, y: 0 },
+      { x: 0.5, y: 0.5 },
+      { x: 1, y: 1 },
+    ]),
+    "M 0 0 L 0.5 0.5 L 1 1",
+  );
+});

--- a/src/lib/drawing.ts
+++ b/src/lib/drawing.ts
@@ -1,0 +1,237 @@
+/**
+ * Lightweight freehand drawing payloads for on-frame comment annotations.
+ * Points are normalized to [0, 1] relative to the video frame so overlays
+ * scale with any player size.
+ */
+
+export type DrawingPoint = {
+  x: number;
+  y: number;
+};
+
+export type DrawingStroke = {
+  points: DrawingPoint[];
+};
+
+export type DrawingData = {
+  strokes: DrawingStroke[];
+  /** Logical canvas size at capture time (for aspect / quality hints). */
+  width: number;
+  height: number;
+};
+
+/** Accent pen color for v1 (lawn forest green). */
+export const DRAWING_STROKE_COLOR = "#2d5a2d";
+
+export const MAX_DRAWING_STROKES = 40;
+export const MAX_POINTS_PER_STROKE = 400;
+export const MAX_TOTAL_DRAWING_POINTS = 4000;
+/** Rough serialized size cap (~48KB) to keep comment docs small. */
+export const MAX_DRAWING_SERIALIZED_LENGTH = 48_000;
+
+export function emptyDrawing(width = 1, height = 1): DrawingData {
+  return {
+    strokes: [],
+    width: Math.max(1, width),
+    height: Math.max(1, height),
+  };
+}
+
+export function countDrawingPoints(drawing: DrawingData | null | undefined): number {
+  if (!drawing?.strokes?.length) return 0;
+  let total = 0;
+  for (const stroke of drawing.strokes) {
+    total += stroke.points?.length ?? 0;
+  }
+  return total;
+}
+
+export function hasDrawing(drawing: DrawingData | null | undefined): boolean {
+  return countDrawingPoints(drawing) >= 2;
+}
+
+/**
+ * Round and clamp a normalized point for compact storage.
+ */
+export function normalizePoint(x: number, y: number): DrawingPoint {
+  return {
+    x: clamp01(round4(x)),
+    y: clamp01(round4(y)),
+  };
+}
+
+/**
+ * Drop near-duplicate points so long freehand strokes stay compact.
+ * distance is in normalized units (default ~0.3% of frame).
+ */
+export function simplifyStroke(
+  points: DrawingPoint[],
+  minDistance = 0.003,
+): DrawingPoint[] {
+  if (points.length <= 2) return points.slice();
+
+  const out: DrawingPoint[] = [points[0]!];
+  let last = points[0]!;
+  for (let i = 1; i < points.length - 1; i++) {
+    const p = points[i]!;
+    const dx = p.x - last.x;
+    const dy = p.y - last.y;
+    if (dx * dx + dy * dy >= minDistance * minDistance) {
+      out.push(p);
+      last = p;
+    }
+  }
+  const end = points[points.length - 1]!;
+  const lastOut = out[out.length - 1]!;
+  if (lastOut.x !== end.x || lastOut.y !== end.y) {
+    out.push(end);
+  }
+  return out;
+}
+
+/**
+ * Serialize drawing for transport. Returns null when empty.
+ */
+export function serializeDrawing(drawing: DrawingData | null | undefined): string | null {
+  if (!hasDrawing(drawing) || !drawing) return null;
+  const compact: DrawingData = {
+    width: Math.round(drawing.width) || 1,
+    height: Math.round(drawing.height) || 1,
+    strokes: drawing.strokes
+      .map((stroke) => ({
+        points: simplifyStroke(stroke.points).map((p) => normalizePoint(p.x, p.y)),
+      }))
+      .filter((stroke) => stroke.points.length >= 2),
+  };
+  if (!hasDrawing(compact)) return null;
+  return JSON.stringify(compact);
+}
+
+/**
+ * Parse a drawing payload from JSON or a plain object.
+ * Throws on invalid / oversized input.
+ */
+export function parseDrawing(input: unknown): DrawingData {
+  if (input == null) {
+    throw new Error("Drawing is required");
+  }
+
+  let value: unknown = input;
+  if (typeof input === "string") {
+    if (input.length > MAX_DRAWING_SERIALIZED_LENGTH) {
+      throw new Error("Drawing is too large");
+    }
+    try {
+      value = JSON.parse(input);
+    } catch {
+      throw new Error("Drawing payload is not valid JSON");
+    }
+  }
+
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Drawing must be an object");
+  }
+
+  const record = value as Record<string, unknown>;
+  const width = Number(record.width);
+  const height = Number(record.height);
+  if (!Number.isFinite(width) || width <= 0 || width > 10_000) {
+    throw new Error("Drawing width is invalid");
+  }
+  if (!Number.isFinite(height) || height <= 0 || height > 10_000) {
+    throw new Error("Drawing height is invalid");
+  }
+
+  if (!Array.isArray(record.strokes)) {
+    throw new Error("Drawing strokes must be an array");
+  }
+  if (record.strokes.length > MAX_DRAWING_STROKES) {
+    throw new Error(`Drawing can have at most ${MAX_DRAWING_STROKES} strokes`);
+  }
+
+  let totalPoints = 0;
+  const strokes: DrawingStroke[] = [];
+
+  for (const rawStroke of record.strokes) {
+    if (typeof rawStroke !== "object" || rawStroke === null || Array.isArray(rawStroke)) {
+      throw new Error("Each stroke must be an object");
+    }
+    const pointsRaw = (rawStroke as { points?: unknown }).points;
+    if (!Array.isArray(pointsRaw)) {
+      throw new Error("Stroke points must be an array");
+    }
+    if (pointsRaw.length > MAX_POINTS_PER_STROKE) {
+      throw new Error(`Each stroke can have at most ${MAX_POINTS_PER_STROKE} points`);
+    }
+
+    const points: DrawingPoint[] = [];
+    for (const rawPoint of pointsRaw) {
+      if (typeof rawPoint !== "object" || rawPoint === null || Array.isArray(rawPoint)) {
+        throw new Error("Each point must be an object with x and y");
+      }
+      const x = Number((rawPoint as { x?: unknown }).x);
+      const y = Number((rawPoint as { y?: unknown }).y);
+      if (!Number.isFinite(x) || !Number.isFinite(y)) {
+        throw new Error("Point coordinates must be finite numbers");
+      }
+      points.push(normalizePoint(x, y));
+    }
+
+    if (points.length < 2) continue;
+    totalPoints += points.length;
+    if (totalPoints > MAX_TOTAL_DRAWING_POINTS) {
+      throw new Error(`Drawing can have at most ${MAX_TOTAL_DRAWING_POINTS} points`);
+    }
+    strokes.push({ points });
+  }
+
+  if (strokes.length === 0) {
+    throw new Error("Drawing has no strokes");
+  }
+
+  const result: DrawingData = {
+    width: Math.round(width),
+    height: Math.round(height),
+    strokes,
+  };
+
+  const serialized = JSON.stringify(result);
+  if (serialized.length > MAX_DRAWING_SERIALIZED_LENGTH) {
+    throw new Error("Drawing is too large");
+  }
+
+  return result;
+}
+
+/**
+ * Soft-validate and return drawing or null (for optional client paths).
+ */
+export function coerceDrawing(input: unknown): DrawingData | null {
+  if (input == null || input === undefined) return null;
+  try {
+    return parseDrawing(input);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build an SVG path string for a stroke (normalized points, viewBox 0 0 1 1).
+ */
+export function strokeToSvgPath(points: DrawingPoint[]): string {
+  if (points.length === 0) return "";
+  const [first, ...rest] = points;
+  let d = `M ${first!.x} ${first!.y}`;
+  for (const p of rest) {
+    d += ` L ${p.x} ${p.y}`;
+  }
+  return d;
+}
+
+function clamp01(n: number): number {
+  return Math.min(1, Math.max(0, n));
+}
+
+function round4(n: number): number {
+  return Math.round(n * 10_000) / 10_000;
+}

--- a/src/lib/frameStep.test.ts
+++ b/src/lib/frameStep.test.ts
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_VIDEO_FPS,
+  frameDeltaSeconds,
+  frameIndexAtTime,
+  formatFrameTimecode,
+  nextFrameTime,
+} from "./frameStep";
+
+test("frameDeltaSeconds uses 1/fps and defaults to 30", () => {
+  assert.equal(frameDeltaSeconds(30), 1 / 30);
+  assert.equal(frameDeltaSeconds(24), 1 / 24);
+  assert.equal(frameDeltaSeconds(undefined), 1 / DEFAULT_VIDEO_FPS);
+  assert.equal(frameDeltaSeconds(0), 1 / DEFAULT_VIDEO_FPS);
+  assert.equal(frameDeltaSeconds(-5), 1 / DEFAULT_VIDEO_FPS);
+  assert.equal(frameDeltaSeconds(Number.NaN), 1 / DEFAULT_VIDEO_FPS);
+});
+
+test("nextFrameTime steps forward and backward within duration", () => {
+  assert.ok(Math.abs(nextFrameTime(1, 1, 30) - (1 + 1 / 30)) < 1e-9);
+  assert.ok(Math.abs(nextFrameTime(1, -1, 30) - (1 - 1 / 30)) < 1e-9);
+  assert.equal(nextFrameTime(0, -1, 30, 10), 0);
+  assert.equal(nextFrameTime(10, 1, 30, 10), 10);
+});
+
+test("frameIndexAtTime rounds to nearest frame", () => {
+  assert.equal(frameIndexAtTime(0, 30), 0);
+  assert.equal(frameIndexAtTime(1, 30), 30);
+  assert.equal(frameIndexAtTime(1 / 30, 30), 1);
+  assert.equal(frameIndexAtTime(-1, 30), 0);
+});
+
+test("formatFrameTimecode renders MM:SS:FF (and HH when needed)", () => {
+  assert.equal(formatFrameTimecode(0, 30), "00:00:00");
+  assert.equal(formatFrameTimecode(1, 30), "00:01:00");
+  assert.equal(formatFrameTimecode(1 + 15 / 30, 30), "00:01:15");
+  assert.equal(formatFrameTimecode(3661, 30), "01:01:01:00");
+});

--- a/src/lib/frameStep.ts
+++ b/src/lib/frameStep.ts
@@ -1,0 +1,63 @@
+/** Default FPS when the stream does not expose a frame rate. */
+export const DEFAULT_VIDEO_FPS = 30;
+
+/**
+ * Seconds to seek for a single frame step.
+ * Falls back to 30fps when fps is missing or non-positive.
+ */
+export function frameDeltaSeconds(fps?: number | null): number {
+  const rate = typeof fps === "number" && Number.isFinite(fps) && fps > 0 ? fps : DEFAULT_VIDEO_FPS;
+  return 1 / rate;
+}
+
+/**
+ * Clamp a stepped time into [0, duration] when duration is known.
+ */
+export function nextFrameTime(
+  currentTime: number,
+  direction: 1 | -1,
+  fps?: number | null,
+  duration?: number | null,
+): number {
+  const delta = frameDeltaSeconds(fps) * direction;
+  let next = currentTime + delta;
+  if (typeof duration === "number" && Number.isFinite(duration) && duration > 0) {
+    next = Math.min(Math.max(next, 0), duration);
+  } else {
+    next = Math.max(next, 0);
+  }
+  return next;
+}
+
+/**
+ * Zero-based frame index for a timestamp at the given fps.
+ */
+export function frameIndexAtTime(seconds: number, fps?: number | null): number {
+  const rate = typeof fps === "number" && Number.isFinite(fps) && fps > 0 ? fps : DEFAULT_VIDEO_FPS;
+  if (!Number.isFinite(seconds) || seconds < 0) return 0;
+  return Math.round(seconds * rate);
+}
+
+/**
+ * SMPTE-style timecode `HH:MM:SS:FF` (or `MM:SS:FF` when under an hour).
+ */
+export function formatFrameTimecode(seconds: number, fps?: number | null): string {
+  const rate = typeof fps === "number" && Number.isFinite(fps) && fps > 0 ? fps : DEFAULT_VIDEO_FPS;
+  const safeSeconds = Number.isFinite(seconds) && seconds > 0 ? seconds : 0;
+  const totalFrames = Math.max(0, Math.round(safeSeconds * rate));
+  const ff = totalFrames % Math.round(rate);
+  const totalSeconds = Math.floor(totalFrames / Math.round(rate));
+  const ss = totalSeconds % 60;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const mm = totalMinutes % 60;
+  const hh = Math.floor(totalMinutes / 60);
+
+  const framePart = ff.toString().padStart(2, "0");
+  const secPart = ss.toString().padStart(2, "0");
+  const minPart = mm.toString().padStart(2, "0");
+
+  if (hh > 0) {
+    return `${hh.toString().padStart(2, "0")}:${minPart}:${secPart}:${framePart}`;
+  }
+  return `${minPart}:${secPart}:${framePart}`;
+}


### PR DESCRIPTION
Closes https://github.com/pingdotgg/lawn/issues/16

## Summary
v1 of frame-precise review for body language / coaching workflows:

### Frame stepping
- Keyboard: `,` previous frame, `.` next frame (NLE convention; distinct from ArrowLeft/Right ±5s seek)
- Control bar buttons for previous/next frame
- Pauses playback, then seeks by `1/fps` (detects HLS `FRAME-RATE` when available, else assumes 30fps)
- When paused, controls show SMPTE-style `MM:SS:FF` timecode

### Drawing annotations
- **Draw** button on player (also `d` when focused) enters freehand draw mode on the video frame
- Forest-green pen (`#2d5a2d`), undo last stroke, clear all, done
- Attach drawing to a new comment at the current timestamp (drawing-only comments allowed)
- Strokes stored as normalized JSON on the comment document (`drawing: { width, height, strokes: [{ points: [{x,y}] }] }`)
- Server-side size caps (strokes / points / serialized length)
- Comment list shows a **Drawing** badge; click seeks and re-renders the overlay
- Share + public watch pages render drawings read-only

### Auth / security
- Same create permissions as existing comments (viewer+ team, signed-in share grant / public)
- Drawing payload validated and capped in `create` / `createForPublic` / `createForShareGrant`

### Performance
- Canvas overlay only mounts in draw mode or when viewing an annotated frame
- Pointer moves batched with `requestAnimationFrame` (no full player re-render per move)

## Tests
- `src/lib/frameStep.test.ts` — delta, clamp, frame index, timecode
- `src/lib/drawing.test.ts` — normalize, simplify, serialize/parse, size limits

## Out of scope (v1)
- Multi-color tools, shapes, arrows, text boxes, pressure sensitivity
- Collaborative multi-user live drawing
- Drawing creation UI on share/watch pages (view-only; create path exists on mutations)
- Perfect letterbox-aware canvas alignment for non-matching aspect ratios
- Attaching a drawing to an already-posted comment (new comment only)

## Test plan
- [ ] Open a dashboard video, focus player, press `,` / `.` — steps one frame while paused; arrows still seek ±5s
- [ ] Click frame step buttons in controls
- [ ] Enter Draw mode, freehand mark, undo, clear, Done
- [ ] Post comment with drawing (with and without text); confirm Drawing badge in list
- [ ] Click Drawing / timestamp — seeks and shows overlay
- [ ] Play dismisses overlay
- [ ] Open share link / public watch — drawing badge + read-only overlay on seek
- [ ] Oversize drawing rejected by mutation (optional)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches comment mutations and stores unbounded-ish (capped) JSON on documents; player seek/draw state is new but gated with server validation and existing comment auth.
> 
> **Overview**
> Adds **frame-precise review** in `VideoPlayer`: pause-then-step by `1/fps` (HLS frame rate when available, else 30fps), control-bar prev/next frame buttons, `,`/`.` keyboard shortcuts, and SMPTE-style `MM:SS:FF` timecode while paused.
> 
> Adds **freehand on-frame annotations** tied to comments: optional normalized stroke JSON on comment documents (schema + `normalizeDrawing` caps in Convex create paths), dashboard draw mode with canvas overlay (`DrawingOverlay`, rAF-batched strokes), attach via `CommentInput` (text optional), and **Drawing** badges that seek paused and show a read-only overlay. Share and public watch pages get view-only drawing display with `allowDrawing={false}`.
> 
> Comment seek behavior shifts from auto-play to **pause + optional overlay** via shared `seekToComment` / extended `onTimestampClick` options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07935abce8a9e59282f5172f172fea52cf1757da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add frame-by-frame stepping and freehand drawing annotations to VideoPlayer
> - Adds frame-step controls (UI buttons and `,`/`.` keys) to `VideoPlayer` that pause playback, detect HLS FPS, and display SMPTE-style timecodes when paused via new utilities in [`src/lib/frameStep.ts`](https://github.com/pingdotgg/lawn/pull/65/files#diff-485eb02864965355bf31fde379a30c3ac2d1eb0698823d5544b1db9a90338f1f).
> - Adds a draw mode to `VideoPlayer` that pauses playback, mounts a canvas `DrawingOverlay` for freehand strokes, and exposes `enterDrawMode()`/`exitDrawMode()`/`stepFrame()` via the imperative handle.
> - Drawings are typed, validated, normalized, and serialized via [`src/lib/drawing.ts`](https://github.com/pingdotgg/lawn/pull/65/files#diff-2f7bed93e6ea6891a62ead75d27c024b7548261dea58c416efc0ea0acfdc5a08), with matching server-side validation in [`convex/comments.ts`](https://github.com/pingdotgg/lawn/pull/65/files#diff-c80a7dedb648ed766459b227a9ef3247e874e70bb4ff22caf5309ed4d0ce30e4) and a new optional `drawing` field in the [`convex/schema.ts`](https://github.com/pingdotgg/lawn/pull/65/files#diff-00e6e27e65e72a0fd4a73f6942f41e1cf3f476a59f263513f3f47fdf801a0eb1) comments table.
> - `CommentInput` now accepts and submits an attached drawing; comments with drawings but no text render a 'Frame drawing' placeholder in `CommentItem`.
> - Watch, Share, and dashboard video pages wire up `viewDrawing` state so clicking a comment timestamp or drawing button seeks without autoplay and displays the associated frame drawing in the player.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07935ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->