### PR TITLE
fix: don't restart the player when the 720p transform finalizes mid-review

### DIFF
--- a/app/routes/dashboard/-video.tsx
+++ b/app/routes/dashboard/-video.tsx
@@ -56,6 +56,7 @@ import { projectPath, teamHomePath, videoPath } from "@/lib/routes";
 import { findPreferredReplacementVideoId } from "@/lib/videoVersionDeletion";
 import { useRoutePrewarmIntent } from "@/lib/useRoutePrewarmIntent";
 import {
+  selectDashboardPlaybackPreferenceAfterOriginalLoad,
   selectDashboardPlaybackUrl,
   type DashboardPlaybackSource,
 } from "@/lib/dashboardPlaybackSource";
@@ -314,8 +315,11 @@ export default function VideoPage() {
   const [mobileCommentsOpen, setMobileCommentsOpen] = useState(false);
   const [sidebarCollapsed, toggleSidebarCollapsed] = useSidebarCollapsed();
   const [playbackSession, setPlaybackSession] = useState<{
-    url: string;
-    posterUrl: string;
+    videoId: Id<"videos">;
+    session: {
+      url: string;
+      posterUrl: string;
+    };
   } | null>(null);
   const [isLoadingPlayback, setIsLoadingPlayback] = useState(false);
   const [playbackLoadError, setPlaybackLoadError] = useState<string | null>(null);
@@ -323,7 +327,10 @@ export default function VideoPage() {
     videoId: Id<"videos">;
     attempt: number;
   } | null>(null);
-  const [originalPlaybackUrl, setOriginalPlaybackUrl] = useState<string | null>(null);
+  const [originalPlayback, setOriginalPlayback] = useState<{
+    videoId: Id<"videos">;
+    url: string;
+  } | null>(null);
   const [isLoadingOriginalPlayback, setIsLoadingOriginalPlayback] = useState(false);
   const [isRetryingFailedProcessing, setIsRetryingFailedProcessing] = useState(false);
   const [retryFailedProcessingError, setRetryFailedProcessingError] = useState<string | null>(null);
@@ -350,8 +357,15 @@ export default function VideoPage() {
   const deletePendingRef = useRef(false);
   const muxRecoveryVideoIdRef = useRef<Id<"videos"> | null>(null);
   const playbackRetryTimeoutRef = useRef<number | null>(null);
+  // Survives effect re-runs so a processing -> ready flip mid-request can't
+  // drop the Original session lock for a page opened during processing.
+  const sawProcessingVideoIdRef = useRef<Id<"videos"> | null>(null);
   const isPlayable = video?.status === "ready" && Boolean(video?.muxPlaybackId);
-  const playbackUrl = playbackSession?.url ?? null;
+  const activePlaybackSession =
+    playbackSession?.videoId === resolvedVideoId ? playbackSession.session : null;
+  const playbackUrl = activePlaybackSession?.url ?? null;
+  const originalPlaybackUrl =
+    originalPlayback?.videoId === resolvedVideoId ? originalPlayback.url : null;
   const playbackRequestAttempt =
     playbackRequest?.videoId === resolvedVideoId ? playbackRequest.attempt : 0;
   const processingFailed = video?.status === "failed";
@@ -407,6 +421,9 @@ export default function VideoPage() {
     setPlaybackResume(null);
     setPlaybackLoadError(null);
     setPlaybackRequest(null);
+    setOriginalPlayback(null);
+    setIsLoadingOriginalPlayback(false);
+    sawProcessingVideoIdRef.current = null;
     muxRecoveryVideoIdRef.current = null;
     if (playbackRetryTimeoutRef.current !== null) {
       window.clearTimeout(playbackRetryTimeoutRef.current);
@@ -422,6 +439,7 @@ export default function VideoPage() {
     setPlaybackResume(null);
     setPlaybackLoadError(null);
     setPlaybackRequest(null);
+    sawProcessingVideoIdRef.current = null;
     muxRecoveryVideoIdRef.current = null;
     if (playbackRetryTimeoutRef.current !== null) {
       window.clearTimeout(playbackRetryTimeoutRef.current);
@@ -479,7 +497,7 @@ export default function VideoPage() {
     void getPlaybackSession({ videoId: resolvedVideoId })
       .then((session) => {
         if (cancelled) return;
-        setPlaybackSession(session);
+        setPlaybackSession({ videoId: resolvedVideoId, session });
       })
       .catch(() => {
         if (cancelled) return;
@@ -523,22 +541,46 @@ export default function VideoPage() {
 
   useEffect(() => {
     if (!resolvedVideoId || !video || video.status === "uploading" || video.status === "failed") {
-      setOriginalPlaybackUrl(null);
+      setOriginalPlayback(null);
       setIsLoadingOriginalPlayback(false);
       return;
     }
+    if (originalPlaybackUrl) return;
 
+    // Remember that this page session saw the video processing. The status can
+    // flip to "ready" while the Original URL request is still in flight, which
+    // cancels and restarts this effect — the restarted request must still
+    // commit the Original session lock or the player would unmount while the
+    // 720p session loads.
+    if (video.status === "processing") {
+      sawProcessingVideoIdRef.current = resolvedVideoId;
+    }
+    const startedWhileProcessing = sawProcessingVideoIdRef.current === resolvedVideoId;
     let cancelled = false;
     setIsLoadingOriginalPlayback(true);
 
     void getOriginalPlaybackUrl({ videoId: resolvedVideoId })
       .then((result) => {
         if (cancelled) return;
-        setOriginalPlaybackUrl(result.url);
+        if (result.url) {
+          setOriginalPlayback({ videoId: resolvedVideoId, url: result.url });
+        } else {
+          setOriginalPlayback(null);
+        }
+        setSourcePreference((preference) => {
+          const currentPreference =
+            preference?.videoId === resolvedVideoId ? preference.source : null;
+          const nextPreference = selectDashboardPlaybackPreferenceAfterOriginalLoad({
+            currentPreference,
+            startedWhileProcessing,
+            originalUrl: result.url,
+          });
+          return nextPreference ? { videoId: resolvedVideoId, source: nextPreference } : preference;
+        });
       })
       .catch(() => {
         if (cancelled) return;
-        setOriginalPlaybackUrl(null);
+        setOriginalPlayback(null);
       })
       .finally(() => {
         if (cancelled) return;
@@ -548,7 +590,7 @@ export default function VideoPage() {
     return () => {
       cancelled = true;
     };
-  }, [getOriginalPlaybackUrl, resolvedVideoId, video?.status, video?.s3Key]);
+  }, [getOriginalPlaybackUrl, originalPlaybackUrl, resolvedVideoId, video?.status, video?.s3Key]);
 
   const handleTimeUpdate = useCallback((time: number) => {
     setCurrentTime(time);
@@ -1122,6 +1164,33 @@ export default function VideoPage() {
                     ? "720p needs another try."
                     : "Preparing 720p…"}
               </span>
+              {playbackLoadError && !isLoadingPlayback && !isAutomaticPlaybackRetryPending ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="ml-auto"
+                  onClick={handleRetryPlaybackSession}
+                >
+                  Retry 720p
+                </Button>
+              ) : null}
+            </div>
+          ) : null}
+
+          {activePlaybackUrl &&
+          !activeOriginalPlaybackIssue &&
+          isPlayable &&
+          playbackLoadError &&
+          !isLoadingPlayback &&
+          !isAutomaticPlaybackRetryPending ? (
+            <div
+              className="flex flex-shrink-0 items-center justify-between gap-3 bg-[#2a2114] px-4 py-2 text-sm text-[#fff1d5]"
+              role="status"
+            >
+              <span>{playbackLoadError} Original playback is continuing.</span>
+              <Button variant="outline" size="sm" onClick={handleRetryPlaybackSession}>
+                Retry 720p
+              </Button>
             </div>
           ) : null}
 
@@ -1132,7 +1201,7 @@ export default function VideoPage() {
               src={activePlaybackUrl}
               initialTime={activePlaybackResume?.currentTime}
               initialPlay={activePlaybackResume?.wasPlaying}
-              poster={playbackSession?.posterUrl}
+              poster={activePlaybackSession?.posterUrl}
               comments={comments || []}
               onTimeUpdate={handleTimeUpdate}
               onMarkerClick={handleMarkerClick}

--- a/src/lib/dashboardPlaybackSource.test.ts
+++ b/src/lib/dashboardPlaybackSource.test.ts
@@ -1,29 +1,113 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { selectDashboardPlaybackUrl } from "./dashboardPlaybackSource";
+import {
+  selectDashboardPlaybackPreferenceAfterOriginalLoad,
+  selectDashboardPlaybackUrl,
+  type DashboardPlaybackSource,
+} from "./dashboardPlaybackSource";
 
-test("waits for the 720p session when Mux playback is ready", () => {
+const originalUrl = "https://storage.example/original.mov";
+const muxUrl = "https://stream.example/video.m3u8";
+
+test("waits for the 720p session on a fresh ready page", () => {
   assert.equal(
     selectDashboardPlaybackUrl({
       preferredSource: "mux720",
       muxPlaybackReady: true,
       muxUrl: null,
-      originalUrl: "https://storage.example/original.mov",
+      originalUrl,
     }),
     null,
   );
 });
 
-test("uses 720p by default once its session is available", () => {
+test("keeps a processing session on Original when Mux becomes ready", () => {
+  let preference: DashboardPlaybackSource | null = null;
+  const playbackSequence = [
+    selectDashboardPlaybackUrl({
+      preferredSource: preference ?? "mux720",
+      muxPlaybackReady: false,
+      muxUrl: null,
+      originalUrl,
+    }),
+  ];
+
+  preference = selectDashboardPlaybackPreferenceAfterOriginalLoad({
+    currentPreference: preference,
+    startedWhileProcessing: true,
+    originalUrl,
+  });
+  playbackSequence.push(
+    selectDashboardPlaybackUrl({
+      preferredSource: preference ?? "mux720",
+      muxPlaybackReady: true,
+      muxUrl: null,
+      originalUrl,
+    }),
+    selectDashboardPlaybackUrl({
+      preferredSource: preference ?? "mux720",
+      muxPlaybackReady: true,
+      muxUrl,
+      originalUrl,
+    }),
+  );
+
+  assert.deepEqual(playbackSequence, [originalUrl, originalUrl, originalUrl]);
+});
+
+test("does not replace an existing playback preference", () => {
+  assert.equal(
+    selectDashboardPlaybackPreferenceAfterOriginalLoad({
+      currentPreference: "mux720",
+      startedWhileProcessing: true,
+      originalUrl,
+    }),
+    "mux720",
+  );
+});
+
+test("does not lock a fresh ready page to Original", () => {
+  assert.equal(
+    selectDashboardPlaybackPreferenceAfterOriginalLoad({
+      currentPreference: null,
+      startedWhileProcessing: false,
+      originalUrl,
+    }),
+    null,
+  );
+});
+
+test("switches to 720p when the session preference is replaced", () => {
   assert.equal(
     selectDashboardPlaybackUrl({
       preferredSource: "mux720",
       muxPlaybackReady: true,
-      muxUrl: "https://stream.example/video.m3u8",
-      originalUrl: "https://storage.example/original.mov",
+      muxUrl,
+      originalUrl,
     }),
-    "https://stream.example/video.m3u8",
+    muxUrl,
+  );
+});
+
+test("falls back from unavailable Original to Mux", () => {
+  assert.equal(
+    selectDashboardPlaybackUrl({
+      preferredSource: "original",
+      muxPlaybackReady: true,
+      muxUrl,
+      originalUrl: null,
+    }),
+    muxUrl,
+  );
+  assert.equal(
+    selectDashboardPlaybackUrl({
+      preferredSource: "original",
+      muxPlaybackReady: true,
+      muxUrl: null,
+      originalUrl: null,
+    }),
+    null,
   );
 });
 
@@ -33,20 +117,20 @@ test("falls back to the original while Mux is still processing", () => {
       preferredSource: "mux720",
       muxPlaybackReady: false,
       muxUrl: null,
-      originalUrl: "https://storage.example/original.mov",
+      originalUrl,
     }),
-    "https://storage.example/original.mov",
+    originalUrl,
   );
 });
 
-test("honors an explicit Original selection", () => {
+test("returns null when neither playback source is available", () => {
   assert.equal(
     selectDashboardPlaybackUrl({
-      preferredSource: "original",
-      muxPlaybackReady: true,
-      muxUrl: "https://stream.example/video.m3u8",
-      originalUrl: "https://storage.example/original.mov",
+      preferredSource: "mux720",
+      muxPlaybackReady: false,
+      muxUrl: null,
+      originalUrl: null,
     }),
-    "https://storage.example/original.mov",
+    null,
   );
 });

--- a/src/lib/dashboardPlaybackSource.ts
+++ b/src/lib/dashboardPlaybackSource.ts
@@ -1,5 +1,21 @@
 export type DashboardPlaybackSource = "mux720" | "original";
 
+export function selectDashboardPlaybackPreferenceAfterOriginalLoad({
+  currentPreference,
+  startedWhileProcessing,
+  originalUrl,
+}: {
+  currentPreference: DashboardPlaybackSource | null;
+  startedWhileProcessing: boolean;
+  originalUrl: string | null;
+}): DashboardPlaybackSource | null {
+  if (currentPreference || !startedWhileProcessing || !originalUrl) {
+    return currentPreference;
+  }
+
+  return "original";
+}
+
 export function selectDashboardPlaybackUrl({
   preferredSource,
   muxPlaybackReady,


### PR DESCRIPTION
## What happened

A reviewer watching a freshly uploaded video (playing the **Original** source while Mux was still encoding) got kicked off the player the moment the 720p transform finalized. The page appeared to restart: the player unmounted, showed "Loading 720p stream...", then came back at 0:00 on the new source.

## Why

While a video is `processing`, the dashboard plays the original upload but the source preference silently defaults to `mux720`. When Convex reactively flips `video.status` to `ready`, `selectDashboardPlaybackUrl` immediately stops returning the (still perfectly good) original URL and returns the Mux session URL instead — which is still `null` because `getPlaybackSession` hasn't resolved yet. So the active URL goes `original → null → mux`. `VideoPlayer` only renders when the URL is truthy, so the null unmounts it and the remount starts from zero.

## The fix

- When an original playback URL is acquired **while the video is processing**, commit a video-scoped `original` source preference (reusing the existing `sourcePreference` state — no new state machine). The playback URL then never passes through null: the reviewer stays on the original source across the `processing → ready` flip until they explicitly switch quality or original playback fails.
- Fresh loads of already-ready videos are unchanged: they still wait for the 720p session (no original flash).
- Explicit quality switching and the existing original-failure → 720p recovery path are unchanged.
- Playback session + original URL state are now scoped by video id so they can't leak across version navigation.
- If the background 720p session fetch fails while original playback continues, a non-interrupting **Retry 720p** banner is shown.

The preference transition lives in a small pure helper (`selectDashboardPlaybackPreferenceAfterOriginalLoad`) next to the URL selector so the regression is pinned by unit tests.

## Testing

- `bun test src/lib/dashboardPlaybackSource.test.ts` — 8 pass, 0 fail, including the regression sequence: processing-on-original → ready-with-no-session → ready-with-session never returns null and never auto-switches.
- `tsc --noEmit`, `eslint`, `prettier --check` on changed files — clean.
- Not verified end-to-end in a browser (no local Convex env in this checkout); worth a manual check of: upload → play original mid-processing → wait for finalize → playback continues uninterrupted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core dashboard video playback and source-selection timing; behavior is well covered by unit tests but end-to-end encoding transitions weren't verified in-browser.
> 
> **Overview**
> Fixes reviewers getting kicked out of the player when a video flips from **processing** to **ready** while they're watching the **Original** upload.
> 
> The active URL was briefly going **original → null → 720p** because the default preference stayed on `mux720` once Mux was ready, but the 720p session wasn't loaded yet—so `VideoPlayer` unmounted and restarted at 0:00. When the original URL is fetched during a processing session, the page now commits a video-scoped **`original`** preference via `selectDashboardPlaybackPreferenceAfterOriginalLoad`, with `sawProcessingVideoIdRef` so a status flip mid-request doesn't drop that lock.
> 
> Playback session and original URL state are keyed by **`resolvedVideoId`** so version switches don't reuse stale URLs/posters. If 720p session load fails while Original keeps playing, a non-blocking **Retry 720p** banner is shown. Unit tests cover the processing → ready sequence and preference rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89f09fab560c2800727f40b235839078d84b718a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix player restart when 720p transform finalizes mid-review
> - Ties 720p and Original playback state to the current `videoId` in [`VideoPage`](https://github.com/pingdotgg/lawn/pull/66/files#diff-833e2f5b1e2fafc1cc96eaad146f828e4462dfc59201a1f837cf780c7d11a442) to prevent cross-video state leakage when a transform completes during review.
> - Adds `selectDashboardPlaybackPreferenceAfterOriginalLoad` in [`dashboardPlaybackSource.ts`](https://github.com/pingdotgg/lawn/pull/66/files#diff-09fefe0d4e1f71845666f33082e755b63c1efc5402ab4b694bc56abf1c645401): locks playback to `'original'` only when the page started while the video was processing and an Original URL exists, leaving any existing preference unchanged.
> - Tracks whether the page observed a `'processing'` status via `sawProcessingVideoIdRef` to inform the preference decision without re-triggering on unrelated state changes.
> - Shows a 'Retry 720p' button when the 720p session fails to load while Original playback continues, or when switching away from Original due to issues.
> - Behavioral Change: pages that open while a video is still processing will now stay on the Original source even after Mux becomes ready, rather than switching to 720p.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89f09fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed video playback state to reliably match the currently selected video, avoiding stale sessions/URLs.
  * Improved switching logic between Original and Mux playback, including correct preference handling after Original loads.
  * Added an explicit **Retry 720p** action when 720p fails (outside automatic/manual retry conditions).
  * Updated the video poster to reflect the active playback session.

* **Tests**
  * Expanded automated coverage for playback source selection, fallback behavior, loading states, and preference preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->